### PR TITLE
Add EncounterStore: file-based iCloud/local persistence for encounters

### DIFF
--- a/Encounter/EncounterApp.swift
+++ b/Encounter/EncounterApp.swift
@@ -21,11 +21,12 @@ struct EncounterApp: App {
                     let dir = await EncounterStore.defaultDirectory()
                     store.relocate(to: dir)
                     // Both loads are independent — run concurrently.
-                    // Errors are stored in compendium.loadError / store.loadError
-                    // for views to observe; try? here is intentional.
+                    // Errors surface via compendium.loadError / store.loadError
+                    // for views to observe; the thrown error from compendium.load()
+                    // is intentionally not propagated here.
                     async let compendiumLoad: Void = compendium.load()
                     async let storeLoad: Void = store.load()
-                    try? await compendiumLoad
+                    do { try await compendiumLoad } catch {}
                     await storeLoad
                 }
         }

--- a/Encounter/Models/EncounterStore.swift
+++ b/Encounter/Models/EncounterStore.swift
@@ -56,8 +56,8 @@ public enum EncounterStoreError: Error, LocalizedError {
 ///         ContentView()
 ///             .environment(store)
 ///             .task {
-///                 async let dir = EncounterStore.defaultDirectory()
-///                 store.relocate(to: await dir)
+///                 let dir = await EncounterStore.defaultDirectory()
+///                 store.relocate(to: dir)
 ///                 await store.load()
 ///             }
 ///     }
@@ -122,7 +122,10 @@ public final class EncounterStore {
 
     /// Reads all `.encounter.json` files from `directory`.
     ///
-    /// Concurrent calls while a load is in progress are ignored.
+    /// If a load is already in progress, this call returns immediately without
+    /// waiting for the existing load to complete and without triggering a second
+    /// load. Callers that need fresh data should await the first load before calling again.
+    ///
     /// Corrupt or unreadable individual files are skipped silently.
     /// Valid definitions are published via ``definitions``, sorted by
     /// `modifiedAt` descending. Directory-level errors are stored in ``loadError``.
@@ -213,6 +216,10 @@ public final class EncounterStore {
     /// The copy is inserted with `createdAt = modifiedAt = .now`, so it sorts
     /// to the top of ``definitions``.
     ///
+    /// - Note: All content fields of ``EncounterDefinition`` must be listed
+    ///   explicitly here. When adding new fields to `EncounterDefinition`,
+    ///   update this method to include them.
+    ///
     /// - Throws: ``EncounterStoreError/notFound(_:)`` if the source ID is unknown.
     public func duplicate(id: UUID) async throws {
         guard let original = definitions.first(where: { $0.id == id }) else {
@@ -245,6 +252,10 @@ public final class EncounterStore {
                     at: url.deletingLastPathComponent(),
                     withIntermediateDirectories: true
                 )
+                // JSONEncoder is allocated per-call because JSONEncoder is not
+                // Sendable in Swift 6 and cannot be safely shared across
+                // Task.detached boundaries. For GM-scale encounter lists this
+                // allocation cost is negligible.
                 let data = try JSONEncoder().encode(definition)
                 try data.write(to: url, options: .atomic)
             }.value
@@ -253,6 +264,8 @@ public final class EncounterStore {
         }
     }
 
+    // Appends then re-sorts the full array. O(n log n), appropriate for
+    // GM-scale encounter lists (tens to low hundreds of items).
     private func insertSorted(_ definition: EncounterDefinition) {
         definitions.append(definition)
         definitions.sort { $0.modifiedAt > $1.modifiedAt }

--- a/EncounterTests/EncounterTests.swift
+++ b/EncounterTests/EncounterTests.swift
@@ -1328,16 +1328,11 @@ struct DifficultyBudgetTests {
     // MARK: load
 
     @Test func loadReconstitutesFromFiles() async throws {
-        let dir = FileManager.default.temporaryDirectory
-            .appending(path: UUID().uuidString)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-
+        let store = try makeStore()
         let def = EncounterDefinition(name: "From File")
-        let data = try JSONEncoder().encode(def)
-        let fileURL = dir.appending(path: "\(def.id.uuidString).encounter.json")
-        try data.write(to: fileURL)
-
-        let store = EncounterStore(directory: dir)
+        try JSONEncoder().encode(def).write(
+            to: store.directory.appending(path: "\(def.id.uuidString).encounter.json")
+        )
         await store.load()
         #expect(store.definitions.count == 1)
         #expect(store.definitions[0].name == "From File")
@@ -1345,33 +1340,21 @@ struct DifficultyBudgetTests {
     }
 
     @Test func loadIgnoresNonEncounterFiles() async throws {
-        let dir = FileManager.default.temporaryDirectory
-            .appending(path: UUID().uuidString)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-
-        // Write a non-encounter file that should be skipped
-        try Data("noise".utf8).write(to: dir.appending(path: "readme.txt"))
-
-        let store = EncounterStore(directory: dir)
+        let store = try makeStore()
+        try Data("noise".utf8).write(to: store.directory.appending(path: "readme.txt"))
         await store.load()
         #expect(store.definitions.isEmpty)
     }
 
     @Test func loadIgnoresCorruptFiles() async throws {
-        let dir = FileManager.default.temporaryDirectory
-            .appending(path: UUID().uuidString)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
-
-        // Write a valid encounter file alongside a corrupt one
+        let store = try makeStore()
         let def = EncounterDefinition(name: "Good Encounter")
         try JSONEncoder().encode(def).write(
-            to: dir.appending(path: "\(def.id.uuidString).encounter.json")
+            to: store.directory.appending(path: "\(def.id.uuidString).encounter.json")
         )
         try Data("not valid json".utf8).write(
-            to: dir.appending(path: "corrupt.encounter.json")
+            to: store.directory.appending(path: "corrupt.encounter.json")
         )
-
-        let store = EncounterStore(directory: dir)
         await store.load()
         #expect(store.definitions.count == 1)
         #expect(store.definitions[0].name == "Good Encounter")
@@ -1404,15 +1387,48 @@ struct DifficultyBudgetTests {
         try encoder.encode(latest).write(
             to: store.directory.appending(path: "\(latest.id.uuidString).encounter.json")
         )
-        alpha.gmNotes = "touched last" // bump modifiedAt to now
+        alpha.gmNotes = "touched last" // bump modifiedAt via save() stamp
         try await store.save(alpha)
 
         await store.load()
+
+        // Verify specific order: alpha (just saved = most recent),
+        // Gamma (now-10s), Beta (now-60s)
+        #expect(store.definitions.count == 3)
+        #expect(store.definitions[0].name == "Alpha")
+        #expect(store.definitions[0].gmNotes == "touched last")
+        #expect(store.definitions[1].name == "Gamma")
+        #expect(store.definitions[2].name == "Beta")
 
         let dates = store.definitions.map(\.modifiedAt)
         for i in 0..<(dates.count - 1) {
             #expect(dates[i] >= dates[i + 1], "definitions[\(i)] should be >= definitions[\(i+1)]")
         }
+    }
+}
+
+// MARK: - EncounterStoreError
+
+struct EncounterStoreErrorTests {
+
+    @Test func notFoundDescription() {
+        let id = UUID()
+        let error = EncounterStoreError.notFound(id)
+        #expect(error.errorDescription == "No encounter definition found with ID \(id).")
+    }
+
+    @Test func saveFailedDescription() {
+        let id = UUID()
+        let underlying = CocoaError(.fileWriteNoPermission)
+        let error = EncounterStoreError.saveFailed(id, underlying)
+        #expect(error.errorDescription?.hasPrefix("Failed to save encounter \(id):") == true)
+    }
+
+    @Test func deleteFailedDescription() {
+        let id = UUID()
+        let underlying = CocoaError(.fileNoSuchFile)
+        let error = EncounterStoreError.deleteFailed(id, underlying)
+        #expect(error.errorDescription?.hasPrefix("Failed to delete encounter \(id):") == true)
     }
 }
 


### PR DESCRIPTION
## Summary

- Adds `EncounterStore`, an `@Observable` persistence layer that stores each `EncounterDefinition` as a `<UUID>.encounter.json` file
- Uses the iCloud ubiquity container when available (iCloud Drive syncs automatically); falls back to local Application Support — no Core Data or CloudKit record API required
- Wires `EncounterStore` into `EncounterApp` alongside `Compendium`, injected via SwiftUI environment
- 15 new `EncounterStoreTests` covering full CRUD, disk round-trips, sort order, error paths, and corrupt-file resilience

## Test plan

- [x] `EncounterStoreTests` — 15 tests, all passing on macOS
- [x] All prior unit tests still green
- [ ] iOS simulator run before merge