### PR TITLE
Add Compendium Browser — adversary and environment reference UI (Step 2)

### DIFF
--- a/Encounter/Models/Adversary.swift
+++ b/Encounter/Models/Adversary.swift
@@ -71,7 +71,7 @@ nonisolated public enum FeatureType: String, Codable, CaseIterable, Sendable {
 // MARK: - AdversaryFeature
 
 /// A single named feature (action, reaction, or passive) on an adversary or environment.
-nonisolated public struct AdversaryFeature: Codable, Identifiable, Sendable, Equatable {
+nonisolated public struct AdversaryFeature: Codable, Identifiable, Sendable, Equatable, Hashable {
     // `id` uses name because feature names are unique within a given adversary.
     public var id: String { name }
 
@@ -108,7 +108,7 @@ nonisolated public struct AdversaryFeature: Codable, Identifiable, Sendable, Equ
 /// into `thresholdMajor` and `thresholdSevere` integers. Both the combined
 /// string key and pre-split `threshold_major` / `threshold_severe` keys
 /// are accepted.
-nonisolated public struct Adversary: Codable, Identifiable, Sendable, Equatable {
+nonisolated public struct Adversary: Codable, Identifiable, Sendable, Equatable, Hashable {
 
     // MARK: Identity
     /// URL-safe slug, e.g. `"acid-burrower"`. Used as stable ID for cross-referencing.

--- a/Encounter/Models/DaggerheartEnvironment.swift
+++ b/Encounter/Models/DaggerheartEnvironment.swift
@@ -22,7 +22,7 @@ import Foundation
 /// Environments share the same feature schema as adversaries but represent
 /// location hazards, terrain, or interactive elements rather than combatants.
 /// They participate in encounters but are not tracked as HP pools.
-nonisolated public struct DaggerheartEnvironment: Codable, Identifiable, Sendable, Equatable {
+nonisolated public struct DaggerheartEnvironment: Codable, Identifiable, Sendable, Equatable, Hashable {
 
     // MARK: Identity
     /// URL-safe slug, e.g. `"collapsing-cavern"`.

--- a/Encounter/Views/AdversaryDetailView.swift
+++ b/Encounter/Views/AdversaryDetailView.swift
@@ -1,0 +1,161 @@
+//
+//  AdversaryDetailView.swift
+//  Encounter
+//
+//  Full stat card for a single adversary.
+//  When onSelect is provided (e.g. called from EncounterBuilderView),
+//  an "Add to Encounter" toolbar button is shown.
+//
+
+import SwiftUI
+
+struct AdversaryDetailView: View {
+    let adversary: Adversary
+    let onSelect: ((Adversary) -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+
+    init(adversary: Adversary, onSelect: ((Adversary) -> Void)? = nil) {
+        self.adversary = adversary
+        self.onSelect = onSelect
+    }
+
+    var body: some View {
+        List {
+            // Identity
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack(spacing: 6) {
+                        typeBadge
+                        Text("Tier \(adversary.tier)")
+                            .font(.caption)
+                            .foregroundStyle(.secondary)
+                        if adversary.source != "SRD" {
+                            Text(adversary.source)
+                                .font(.caption2)
+                                .foregroundStyle(.white)
+                                .padding(.horizontal, 5)
+                                .padding(.vertical, 2)
+                                .background(.blue)
+                                .clipShape(.capsule)
+                        }
+                    }
+                    Text(adversary.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            // Combat Stats
+            Section("Combat Stats") {
+                LabeledContent("Difficulty", value: adversary.difficulty, format: .number)
+                LabeledContent("Hit Points", value: adversary.hp, format: .number)
+                LabeledContent("Stress", value: adversary.stress, format: .number)
+                LabeledContent("Major Threshold", value: adversary.thresholdMajor, format: .number)
+                LabeledContent("Severe Threshold", value: adversary.thresholdSevere, format: .number)
+            }
+
+            // Standard Attack
+            Section("Standard Attack") {
+                LabeledContent("Attack") {
+                    Text("\(adversary.attackName) \(adversary.attackModifier)")
+                }
+                LabeledContent("Range", value: adversary.attackRange.rawValue)
+                LabeledContent("Damage", value: adversary.damage)
+            }
+
+            // Experience
+            if let experience = adversary.experience {
+                Section("Experience") {
+                    Text(experience)
+                        .font(.subheadline)
+                }
+            }
+
+            // Features grouped: passives → actions → reactions
+            featureSections(adversary.features)
+
+            // Motives & Tactics
+            if let motives = adversary.motivesAndTactics {
+                Section("Motives & Tactics") {
+                    Text(motives)
+                        .font(.subheadline)
+                }
+            }
+        }
+        .navigationTitle(adversary.name)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        #endif
+        .toolbar {
+            if let onSelect {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Add to Encounter") {
+                        onSelect(adversary)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    private var typeBadge: some View {
+        Text(adversary.type.rawValue)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.secondary.opacity(0.15))
+            .clipShape(.capsule)
+    }
+
+    @ViewBuilder
+    private func featureSections(_ features: [AdversaryFeature]) -> some View {
+        let passives  = features.filter { $0.featType == .passive }
+        let actions   = features.filter { $0.featType == .action }
+        let reactions = features.filter { $0.featType == .reaction }
+
+        if !passives.isEmpty {
+            Section("Passives") {
+                ForEach(passives) { AdversaryFeatureRow(feature: $0) }
+            }
+        }
+        if !actions.isEmpty {
+            Section("Actions") {
+                ForEach(actions) { AdversaryFeatureRow(feature: $0) }
+            }
+        }
+        if !reactions.isEmpty {
+            Section("Reactions") {
+                ForEach(reactions) { AdversaryFeatureRow(feature: $0) }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        AdversaryDetailView(adversary: Adversary(
+            id: "goblin",
+            name: "Goblin",
+            tier: 1,
+            type: .minion,
+            description: "Small, cunning, and cowardly alone but dangerous in numbers.",
+            motivesAndTactics: "Goblins mob weak targets and flee from strong ones.",
+            difficulty: 10,
+            thresholdMajor: 5,
+            thresholdSevere: 10,
+            hp: 3,
+            stress: 2,
+            attackModifier: "+2",
+            attackName: "Rusty Blade",
+            attackRange: .veryClose,
+            damage: "1d4 phy",
+            features: [
+                AdversaryFeature(name: "Pack Tactics", text: "Deal +1 damage for each ally adjacent to the target.", featType: .passive),
+                AdversaryFeature(name: "Sneak Attack", text: "Once per round, deal +1d6 damage when hidden.", featType: .action),
+            ]
+        ))
+    }
+}

--- a/Encounter/Views/AdversaryFeatureRow.swift
+++ b/Encounter/Views/AdversaryFeatureRow.swift
@@ -1,0 +1,43 @@
+//
+//  AdversaryFeatureRow.swift
+//  Encounter
+//
+//  A single adversary or environment feature row: name, type badge, description text.
+//  Used in both AdversaryDetailView and EnvironmentDetailView.
+//
+
+import SwiftUI
+
+struct AdversaryFeatureRow: View {
+    let feature: AdversaryFeature
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 4) {
+            HStack(spacing: 6) {
+                Text(feature.name)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(feature.featType.rawValue.capitalized)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+                    .padding(.horizontal, 5)
+                    .padding(.vertical, 2)
+                    .background(.secondary.opacity(0.15))
+                    .clipShape(.capsule)
+            }
+            Text(feature.text)
+                .font(.footnote)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+#Preview {
+    AdversaryFeatureRow(feature: AdversaryFeature(
+        name: "Pack Tactics",
+        text: "Deal +1 damage for each ally adjacent to the target.",
+        featType: .passive
+    ))
+    .padding()
+}

--- a/Encounter/Views/AdversaryListView.swift
+++ b/Encounter/Views/AdversaryListView.swift
@@ -1,0 +1,52 @@
+//
+//  AdversaryListView.swift
+//  Encounter
+//
+//  Filtered list of adversaries. Navigation destinations are registered
+//  on the parent CompendiumBrowserView so they persist across tab switches.
+//
+
+import SwiftUI
+
+struct AdversaryListView: View {
+    let adversaries: [Adversary]
+
+    var body: some View {
+        if adversaries.isEmpty {
+            ContentUnavailableView(
+                "No Adversaries",
+                systemImage: "magnifyingglass",
+                description: Text("Try a different search or filter.")
+            )
+        } else {
+            List(adversaries) { adversary in
+                NavigationLink(value: adversary) {
+                    AdversaryRow(adversary: adversary)
+                }
+            }
+        }
+    }
+}
+
+#Preview("With results") {
+    NavigationStack {
+        AdversaryListView(adversaries: [
+            Adversary(id: "goblin", name: "Goblin", tier: 1, type: .minion,
+                      description: "Small and cunning.", difficulty: 10,
+                      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+                      attackModifier: "+2", attackName: "Rusty Blade",
+                      attackRange: .veryClose, damage: "1d4 phy"),
+            Adversary(id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
+                      description: "Massive and relentless.", difficulty: 14,
+                      thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+                      attackModifier: "+5", attackName: "Great Axe",
+                      attackRange: .veryClose, damage: "2d10+4 phy"),
+        ])
+    }
+}
+
+#Preview("Empty") {
+    NavigationStack {
+        AdversaryListView(adversaries: [])
+    }
+}

--- a/Encounter/Views/AdversaryRow.swift
+++ b/Encounter/Views/AdversaryRow.swift
@@ -1,0 +1,54 @@
+//
+//  AdversaryRow.swift
+//  Encounter
+//
+//  A single row in the adversary list: name, type/tier/difficulty, homebrew badge.
+//
+
+import SwiftUI
+
+struct AdversaryRow: View {
+    let adversary: Adversary
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(adversary.name)
+                    .font(.body)
+                if adversary.source != "SRD" {
+                    Text(adversary.source)
+                        .font(.caption2)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(.blue)
+                        .clipShape(.capsule)
+                }
+            }
+            Text("\(adversary.type.rawValue) · Tier \(adversary.tier) · DC \(adversary.difficulty)")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+#Preview {
+    AdversaryRow(adversary: Adversary(
+        id: "goblin",
+        name: "Goblin",
+        tier: 1,
+        type: .minion,
+        description: "Small and cunning.",
+        difficulty: 10,
+        thresholdMajor: 5,
+        thresholdSevere: 10,
+        hp: 3,
+        stress: 2,
+        attackModifier: "+2",
+        attackName: "Rusty Blade",
+        attackRange: .veryClose,
+        damage: "1d4 phy"
+    ))
+    .padding()
+}

--- a/Encounter/Views/BrowserTab.swift
+++ b/Encounter/Views/BrowserTab.swift
@@ -1,0 +1,11 @@
+//
+//  BrowserTab.swift
+//  Encounter
+//
+//  Tab selection for the CompendiumBrowserView.
+//
+
+enum BrowserTab: String, CaseIterable {
+    case adversaries  = "Adversaries"
+    case environments = "Environments"
+}

--- a/Encounter/Views/CompendiumBrowserView.swift
+++ b/Encounter/Views/CompendiumBrowserView.swift
@@ -1,0 +1,157 @@
+//
+//  CompendiumBrowserView.swift
+//  Encounter
+//
+//  Root screen for browsing the adversary and environment compendium.
+//
+//  The optional onSelect / onSelectEnvironment closures establish the
+//  Step 3 seam: when non-nil (called from EncounterBuilderView),
+//  detail views show an "Add to Encounter" button that calls the closure
+//  and dismisses the sheet.
+//
+
+import SwiftUI
+
+struct CompendiumBrowserView: View {
+    @Environment(Compendium.self) private var compendium
+    @Environment(\.dismiss) private var dismiss
+
+    let onSelect: ((Adversary) -> Void)?
+    let onSelectEnvironment: ((DaggerheartEnvironment) -> Void)?
+
+    @State private var activeTab = BrowserTab.adversaries
+    @State private var searchText = ""
+    @State private var selectedType: AdversaryType?
+
+    init(
+        onSelect: ((Adversary) -> Void)? = nil,
+        onSelectEnvironment: ((DaggerheartEnvironment) -> Void)? = nil
+    ) {
+        self.onSelect = onSelect
+        self.onSelectEnvironment = onSelectEnvironment
+    }
+
+    var filteredAdversaries: [Adversary] {
+        let base = selectedType.map { t in compendium.adversaries.filter { $0.type == t } }
+            ?? compendium.adversaries
+        guard !searchText.isEmpty else { return base }
+        return base.filter {
+            $0.name.localizedStandardContains(searchText) ||
+            $0.description.localizedStandardContains(searchText)
+        }
+    }
+
+    var filteredEnvironments: [DaggerheartEnvironment] {
+        guard !searchText.isEmpty else { return compendium.environments }
+        return compendium.environments.filter {
+            $0.name.localizedStandardContains(searchText) ||
+            $0.description.localizedStandardContains(searchText)
+        }
+    }
+
+    var body: some View {
+        Group {
+            switch activeTab {
+            case .adversaries:
+                AdversaryListView(adversaries: filteredAdversaries)
+            case .environments:
+                EnvironmentListView(environments: filteredEnvironments)
+            }
+        }
+        .navigationTitle("Compendium")
+        .navigationDestination(for: Adversary.self) { adversary in
+            AdversaryDetailView(adversary: adversary, onSelect: onSelect)
+        }
+        .navigationDestination(for: DaggerheartEnvironment.self) { environment in
+            EnvironmentDetailView(environment: environment, onSelect: onSelectEnvironment)
+        }
+        .searchable(text: $searchText, prompt: "Search \(activeTab.rawValue.lowercased())")
+        .onChange(of: activeTab) { selectedType = nil }
+        .toolbar { toolbarContent }
+    }
+
+    @ToolbarContentBuilder
+    private var toolbarContent: some ToolbarContent {
+        // Done button when shown as a sheet from the builder
+        if onSelect != nil || onSelectEnvironment != nil {
+            ToolbarItem(placement: .cancellationAction) {
+                Button("Done") { dismiss() }
+            }
+        }
+
+        // Tab switcher
+        ToolbarItem(placement: .principal) {
+            Picker("Category", selection: $activeTab) {
+                ForEach(BrowserTab.allCases, id: \.self) { tab in
+                    Text(tab.rawValue).tag(tab)
+                }
+            }
+            .pickerStyle(.segmented)
+            .frame(maxWidth: 240)
+        }
+
+        // Type filter — adversaries tab only
+        ToolbarItem(placement: .primaryAction) {
+            if activeTab == .adversaries {
+                Menu {
+                    Button("All Types") { selectedType = nil }
+                    Divider()
+                    ForEach(AdversaryType.allCases, id: \.self) { type in
+                        Button(type.rawValue) { selectedType = type }
+                    }
+                } label: {
+                    Label(
+                        selectedType?.rawValue ?? "Filter",
+                        systemImage: selectedType != nil
+                            ? "line.3.horizontal.decrease.circle.fill"
+                            : "line.3.horizontal.decrease.circle"
+                    )
+                }
+            }
+        }
+    }
+}
+
+#Preview("Standalone") {
+    let compendium = Compendium()
+    compendium.addAdversary(Adversary(
+        id: "goblin", name: "Goblin", tier: 1, type: .minion,
+        description: "Small and cunning.", difficulty: 10,
+        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+        attackModifier: "+2", attackName: "Rusty Blade",
+        attackRange: .veryClose, damage: "1d4 phy"
+    ))
+    compendium.addAdversary(Adversary(
+        id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
+        description: "Massive and relentless.", difficulty: 14,
+        thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+        attackModifier: "+5", attackName: "Great Axe",
+        attackRange: .veryClose, damage: "2d10+4 phy"
+    ))
+    compendium.addEnvironment(DaggerheartEnvironment(
+        id: "collapsing-cavern", name: "Collapsing Cavern",
+        description: "The ceiling threatens to fall with every heavy blow."
+    ))
+    return NavigationStack {
+        CompendiumBrowserView()
+    }
+    .environment(compendium)
+}
+
+#Preview("From Builder (with selection)") {
+    let compendium = Compendium()
+    compendium.addAdversary(Adversary(
+        id: "goblin", name: "Goblin", tier: 1, type: .minion,
+        description: "Small and cunning.", difficulty: 10,
+        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+        attackModifier: "+2", attackName: "Rusty Blade",
+        attackRange: .veryClose, damage: "1d4 phy"
+    ))
+    return NavigationStack {
+        CompendiumBrowserView(
+            onSelect: { adversary in print("Selected: \(adversary.name)") },
+            onSelectEnvironment: { env in print("Selected: \(env.name)") }
+        )
+    }
+    .environment(compendium)
+}

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -5,11 +5,17 @@
 //  Stub destination shown when a library row is tapped.
 //  Full builder (adversary/environment/player configuration) is Step 3.
 //
+//  The compendium browser sheet is wired now (Step 2 seam).
+//  onSelect and onSelectEnvironment closures will be filled in during Step 3.
+//
 
 import SwiftUI
 
 struct EncounterBuilderView: View {
     let definition: EncounterDefinition
+
+    @Environment(Compendium.self) private var compendium
+    @State private var showCompendium = false
 
     var body: some View {
         ContentUnavailableView {
@@ -23,6 +29,28 @@ struct EncounterBuilderView: View {
                 Button("Run Encounter") {}
                     .disabled(true)
             }
+            ToolbarItem(placement: .primaryAction) {
+                Button("Browse Compendium", systemImage: "books.vertical") {
+                    showCompendium = true
+                }
+            }
+        }
+        .sheet(isPresented: $showCompendium) {
+            NavigationStack {
+                CompendiumBrowserView(
+                    onSelect: { adversary in
+                        // Step 3: add adversary.id to definition and save via store
+                        _ = adversary
+                        showCompendium = false
+                    },
+                    onSelectEnvironment: { environment in
+                        // Step 3: add environment.id to definition and save via store
+                        _ = environment
+                        showCompendium = false
+                    }
+                )
+            }
+            .environment(compendium)
         }
     }
 }
@@ -33,4 +61,5 @@ struct EncounterBuilderView: View {
             definition: EncounterDefinition(name: "Goblin Ambush")
         )
     }
+    .environment(Compendium())
 }

--- a/Encounter/Views/EnvironmentDetailView.swift
+++ b/Encounter/Views/EnvironmentDetailView.swift
@@ -1,0 +1,97 @@
+//
+//  EnvironmentDetailView.swift
+//  Encounter
+//
+//  Full detail card for a single environment.
+//  When onSelect is provided, an "Add to Encounter" toolbar button is shown.
+//
+
+import SwiftUI
+
+struct EnvironmentDetailView: View {
+    let environment: DaggerheartEnvironment
+    let onSelect: ((DaggerheartEnvironment) -> Void)?
+
+    @Environment(\.dismiss) private var dismiss
+
+    init(environment: DaggerheartEnvironment, onSelect: ((DaggerheartEnvironment) -> Void)? = nil) {
+        self.environment = environment
+        self.onSelect = onSelect
+    }
+
+    var body: some View {
+        List {
+            // Identity
+            Section {
+                VStack(alignment: .leading, spacing: 6) {
+                    if environment.source != "SRD" {
+                        Text(environment.source)
+                            .font(.caption2)
+                            .foregroundStyle(.white)
+                            .padding(.horizontal, 5)
+                            .padding(.vertical, 2)
+                            .background(.blue)
+                            .clipShape(.capsule)
+                    }
+                    Text(environment.description)
+                        .font(.subheadline)
+                        .foregroundStyle(.secondary)
+                }
+                .padding(.vertical, 4)
+            }
+
+            // Features grouped: passives → actions → reactions
+            featureSections(environment.features)
+        }
+        .navigationTitle(environment.name)
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.large)
+        #endif
+        .toolbar {
+            if let onSelect {
+                ToolbarItem(placement: .primaryAction) {
+                    Button("Add to Encounter") {
+                        onSelect(environment)
+                        dismiss()
+                    }
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func featureSections(_ features: [AdversaryFeature]) -> some View {
+        let passives  = features.filter { $0.featType == .passive }
+        let actions   = features.filter { $0.featType == .action }
+        let reactions = features.filter { $0.featType == .reaction }
+
+        if !passives.isEmpty {
+            Section("Passives") {
+                ForEach(passives) { AdversaryFeatureRow(feature: $0) }
+            }
+        }
+        if !actions.isEmpty {
+            Section("Actions") {
+                ForEach(actions) { AdversaryFeatureRow(feature: $0) }
+            }
+        }
+        if !reactions.isEmpty {
+            Section("Reactions") {
+                ForEach(reactions) { AdversaryFeatureRow(feature: $0) }
+            }
+        }
+    }
+}
+
+#Preview {
+    NavigationStack {
+        EnvironmentDetailView(environment: DaggerheartEnvironment(
+            id: "collapsing-cavern",
+            name: "Collapsing Cavern",
+            description: "The ceiling threatens to fall with every heavy blow. Whenever a Severe hit is dealt, roll 1d6 — on a 1–3, a section collapses.",
+            features: [
+                AdversaryFeature(name: "Cave-In", text: "When a Severe hit is dealt, roll 1d6. On 1–3, creatures in the area make an Agility roll against DC 14 or take 2d8 physical damage.", featType: .reaction),
+            ]
+        ))
+    }
+}

--- a/Encounter/Views/EnvironmentListView.swift
+++ b/Encounter/Views/EnvironmentListView.swift
@@ -1,0 +1,46 @@
+//
+//  EnvironmentListView.swift
+//  Encounter
+//
+//  Filtered list of environments. Navigation destinations are registered
+//  on the parent CompendiumBrowserView so they persist across tab switches.
+//
+
+import SwiftUI
+
+struct EnvironmentListView: View {
+    let environments: [DaggerheartEnvironment]
+
+    var body: some View {
+        if environments.isEmpty {
+            ContentUnavailableView(
+                "No Environments",
+                systemImage: "magnifyingglass",
+                description: Text("Try a different search term.")
+            )
+        } else {
+            List(environments) { environment in
+                NavigationLink(value: environment) {
+                    EnvironmentRow(environment: environment)
+                }
+            }
+        }
+    }
+}
+
+#Preview("With results") {
+    NavigationStack {
+        EnvironmentListView(environments: [
+            DaggerheartEnvironment(id: "collapsing-cavern", name: "Collapsing Cavern",
+                description: "The ceiling threatens to fall with every heavy blow."),
+            DaggerheartEnvironment(id: "burning-bridge", name: "Burning Bridge",
+                description: "The planks crumble underfoot as flames spread."),
+        ])
+    }
+}
+
+#Preview("Empty") {
+    NavigationStack {
+        EnvironmentListView(environments: [])
+    }
+}

--- a/Encounter/Views/EnvironmentRow.swift
+++ b/Encounter/Views/EnvironmentRow.swift
@@ -1,0 +1,44 @@
+//
+//  EnvironmentRow.swift
+//  Encounter
+//
+//  A single row in the environment list: name, description preview, homebrew badge.
+//
+
+import SwiftUI
+
+struct EnvironmentRow: View {
+    let environment: DaggerheartEnvironment
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 2) {
+            HStack {
+                Text(environment.name)
+                    .font(.body)
+                if environment.source != "SRD" {
+                    Text(environment.source)
+                        .font(.caption2)
+                        .foregroundStyle(.white)
+                        .padding(.horizontal, 5)
+                        .padding(.vertical, 2)
+                        .background(.blue)
+                        .clipShape(.capsule)
+                }
+            }
+            Text(environment.description)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(1)
+        }
+        .padding(.vertical, 2)
+    }
+}
+
+#Preview {
+    EnvironmentRow(environment: DaggerheartEnvironment(
+        id: "collapsing-cavern",
+        name: "Collapsing Cavern",
+        description: "The ceiling threatens to fall with every heavy blow."
+    ))
+    .padding()
+}


### PR DESCRIPTION
## Summary

- Adds a full compendium browser with separate adversary and environment tabs, search, and adversary type filtering
- Stat cards show all fields (difficulty, thresholds, HP/stress, attack, features grouped by type) via `LabeledContent`
- Optional `onSelect`/`onSelectEnvironment` closures wire the Step 3 seam: when called from `EncounterBuilderView`, detail views show an "Add to Encounter" button
- `EncounterBuilderView` gains a Browse Compendium toolbar button that presents the browser in a sheet (stub closures dismiss for now)
- `Hashable` added to `Adversary`, `AdversaryFeature`, `DaggerheartEnvironment` (required for `NavigationLink(value:)`)

## Test plan

- [ ] Build succeeds on macOS and iOS simulator (signing disabled for CI)
- [ ] Compendium browser opens from library sidebar (standalone) and from builder sheet
- [ ] Search filters both adversaries and environments using `localizedStandardContains`
- [ ] Type filter menu filters adversaries; resets when switching tabs
- [ ] Tapping a row navigates to the detail view; back navigation works
- [ ] Detail view shows all stats, features grouped (Passives / Actions / Reactions)
- [ ] "Add to Encounter" button absent in standalone mode; present when opened from builder
- [ ] "Done" button dismisses the sheet when opened from builder
- [ ] Homebrew badge (`source != "SRD"`) visible on row and detail when applicable