### PR TITLE
Add live encounter runner (Step 4)

### DIFF
--- a/Encounter/EncounterApp.swift
+++ b/Encounter/EncounterApp.swift
@@ -11,12 +11,14 @@ import SwiftUI
 struct EncounterApp: App {
     @State private var compendium = Compendium()
     @State private var store = EncounterStore(directory: EncounterStore.localDirectory)
+    @State private var sessionRegistry = SessionRegistry()
 
     var body: some Scene {
         WindowGroup {
             ContentView()
                 .environment(compendium)
                 .environment(store)
+                .environment(sessionRegistry)
                 .task {
                     let dir = await EncounterStore.defaultDirectory()
                     store.relocate(to: dir)

--- a/Encounter/Models/EncounterSession.swift
+++ b/Encounter/Models/EncounterSession.swift
@@ -129,7 +129,9 @@ nonisolated public struct EnvironmentSlot: Identifiable, Sendable, Equatable {
 /// session.add(environment: terrain.forestEdge)
 /// ```
 @Observable
-public final class EncounterSession: Identifiable {
+public final class EncounterSession: Identifiable, Hashable {
+    public nonisolated static func == (lhs: EncounterSession, rhs: EncounterSession) -> Bool { lhs.id == rhs.id }
+    public nonisolated func hash(into hasher: inout Hasher) { hasher.combine(id) }
 
     // MARK: Identity
     public let id: UUID
@@ -310,6 +312,15 @@ public final class EncounterSession: Identifiable {
         guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
         guard playerSlots[index].currentArmorSlots > 0 else { return }
         playerSlots[index].currentArmorSlots -= 1
+    }
+
+    /// Restore one Armor Slot on a player (undo a mark, or recover via a rest ability).
+    public func restorePlayerArmorSlot(_ slotID: UUID) {
+        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+        playerSlots[index].currentArmorSlots = min(
+            playerSlots[index].armorSlots,
+            playerSlots[index].currentArmorSlots + 1
+        )
     }
 
     // MARK: - Player Condition Management

--- a/Encounter/Models/SessionRegistry.swift
+++ b/Encounter/Models/SessionRegistry.swift
@@ -1,0 +1,52 @@
+//
+//  SessionRegistry.swift
+//  Encounter
+//
+//  In-memory registry of live EncounterSessions, keyed by EncounterDefinition.ID.
+//  Injected into the SwiftUI environment at app launch alongside Compendium
+//  and EncounterStore.
+//
+//  Sessions are retained for the lifetime of the app process.
+//  Cross-launch persistence is a future enhancement.
+//
+
+import Foundation
+import Observation
+
+/// In-memory registry of live ``EncounterSession`` objects, keyed by definition ID.
+///
+/// Inject once at app launch:
+/// ```swift
+/// @State private var sessionRegistry = SessionRegistry()
+///
+/// ContentView()
+///     .environment(sessionRegistry)
+/// ```
+///
+/// Retrieve or create a session via ``session(for:definition:compendium:)``.
+/// The same session is returned on every call for a given definition ID until
+/// ``clearSession(for:)`` is called.
+@Observable
+public final class SessionRegistry {
+    public private(set) var sessions: [UUID: EncounterSession] = [:]
+
+    public init() {}
+
+    /// Return the existing session for `definitionID`, or create and store a new one.
+    public func session(
+        for definitionID: UUID,
+        definition: EncounterDefinition,
+        compendium: Compendium
+    ) -> EncounterSession {
+        if let existing = sessions[definitionID] { return existing }
+        let newSession = EncounterSession.start(from: definition, using: compendium)
+        sessions[definitionID] = newSession
+        return newSession
+    }
+
+    /// Remove the stored session so the next call to ``session(for:definition:compendium:)``
+    /// starts a fresh session.
+    public func clearSession(for definitionID: UUID) {
+        sessions.removeValue(forKey: definitionID)
+    }
+}

--- a/Encounter/Views/AdversaryRunnerCard.swift
+++ b/Encounter/Views/AdversaryRunnerCard.swift
@@ -1,0 +1,192 @@
+//
+//  AdversaryRunnerCard.swift
+//  Encounter
+//
+//  Expanded inline adversary card in the live encounter runner.
+//  Shows threshold damage buttons, stress control, condition toggles,
+//  and a compact stat reference.
+//
+//  Damage marks per Daggerheart SRD:
+//    Minor hit (below Major threshold): mark 1 HP
+//    Major hit (at/above Major threshold): mark 2 HP
+//    Severe hit (at/above Severe threshold): mark 3 HP
+//
+
+import SwiftUI
+
+struct AdversaryRunnerCard: View {
+    let slot: AdversarySlot
+    let session: EncounterSession
+    let compendium: Compendium
+    let onCollapse: () -> Void
+
+    private var adversary: Adversary? {
+        compendium.adversary(id: slot.adversaryID)
+    }
+
+    private var displayName: String {
+        slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+
+            // Header
+            HStack {
+                Text(displayName)
+                    .font(.headline)
+                Spacer()
+                Button("Collapse", systemImage: "chevron.up", action: onCollapse)
+                .labelStyle(.iconOnly)
+                .buttonStyle(.borderless)
+            }
+
+            // HP pip track
+            HStack(spacing: 4) {
+                Text("HP")
+                    .font(.caption)
+                    .foregroundStyle(.secondary)
+                PipTrack(current: slot.currentHP, maximum: slot.maxHP)
+                if slot.isDefeated {
+                    Text("Defeated")
+                        .font(.caption)
+                        .foregroundStyle(.red)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.red.opacity(0.12))
+                        .clipShape(.capsule)
+                }
+            }
+
+            // Damage threshold buttons
+            HStack(spacing: 8) {
+                thresholdButton(
+                    "Minor",
+                    subtitle: "< \(adversary.map { "\($0.thresholdMajor)" } ?? "—")",
+                    marks: 1
+                )
+                thresholdButton(
+                    "Major",
+                    subtitle: "≥ \(adversary.map { "\($0.thresholdMajor)" } ?? "—")",
+                    marks: 2
+                )
+                thresholdButton(
+                    "Severe",
+                    subtitle: "≥ \(adversary.map { "\($0.thresholdSevere)" } ?? "—")",
+                    marks: 3
+                )
+            }
+
+            // Stress
+            Button("+1 Stress (\(slot.currentStress)/\(slot.maxStress))") {
+                session.applyStress(1, to: slot.id)
+            }
+            .buttonStyle(.bordered)
+            .disabled(slot.currentStress >= slot.maxStress || slot.isDefeated)
+
+            // Condition toggles
+            conditionsSection
+
+            // Stat reference
+            if let adversary {
+                statReferenceSection(adversary)
+            }
+        }
+        .padding(.vertical, 8)
+    }
+
+    @ViewBuilder
+    private func thresholdButton(_ label: String, subtitle: String, marks: Int) -> some View {
+        Button {
+            session.applyDamage(marks, to: slot.id)
+        } label: {
+            VStack(spacing: 2) {
+                Text(label)
+                    .font(.subheadline)
+                    .fontWeight(.semibold)
+                Text(subtitle)
+                    .font(.caption2)
+                    .foregroundStyle(.secondary)
+            }
+            .frame(maxWidth: .infinity)
+        }
+        .buttonStyle(.bordered)
+        .disabled(slot.isDefeated)
+    }
+
+    @ViewBuilder
+    private var conditionsSection: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text("Conditions")
+                .font(.caption)
+                .foregroundStyle(.secondary)
+            HStack(spacing: 6) {
+                ForEach([Condition.hidden, .restrained, .vulnerable], id: \.displayName) { condition in
+                    let active = slot.conditions.contains(condition)
+                    Button(condition.displayName) {
+                        if active {
+                            session.removeCondition(condition, from: slot.id)
+                        } else {
+                            session.applyCondition(condition, to: slot.id)
+                        }
+                    }
+                    .font(.caption)
+                    .buttonStyle(.bordered)
+                    .tint(active ? .orange : nil)
+                }
+            }
+        }
+    }
+
+    @ViewBuilder
+    private func statReferenceSection(_ adversary: Adversary) -> some View {
+        Divider()
+        VStack(alignment: .leading, spacing: 4) {
+            LabeledContent("Difficulty", value: "\(adversary.difficulty)")
+                .font(.caption)
+            LabeledContent("Thresholds") {
+                Text("\(adversary.thresholdMajor) / \(adversary.thresholdSevere)")
+            }
+            .font(.caption)
+            LabeledContent("Attack") {
+                Text("\(adversary.attackName) \(adversary.attackModifier) · \(adversary.attackRange.rawValue)")
+            }
+            .font(.caption)
+            LabeledContent("Damage", value: adversary.damage)
+                .font(.caption)
+        }
+        if !adversary.features.isEmpty {
+            Divider()
+            ForEach(adversary.features) { feature in
+                AdversaryFeatureRow(feature: feature)
+            }
+        }
+    }
+}
+
+#Preview {
+    let compendium = Compendium()
+    compendium.addAdversary(Adversary(
+        id: "goblin", name: "Goblin", tier: 1, type: .minion,
+        description: "Small and cunning.", difficulty: 10,
+        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+        attackModifier: "+2", attackName: "Rusty Blade",
+        attackRange: .veryClose, damage: "1d4 phy",
+        features: [AdversaryFeature(name: "Sneak", text: "Can hide as a free action.", featType: .passive)]
+    ))
+    let session = EncounterSession(name: "Test")
+    if let goblin = compendium.adversary(id: "goblin") {
+        session.add(adversary: goblin)
+    }
+    return List {
+        if let slot = session.adversarySlots.first {
+            AdversaryRunnerCard(
+                slot: slot,
+                session: session,
+                compendium: compendium,
+                onCollapse: {}
+            )
+        }
+    }
+    .environment(compendium)
+}

--- a/Encounter/Views/AdversaryRunnerRow.swift
+++ b/Encounter/Views/AdversaryRunnerRow.swift
@@ -1,0 +1,80 @@
+//
+//  AdversaryRunnerRow.swift
+//  Encounter
+//
+//  Collapsed adversary row shown in the live encounter runner.
+//  Displays name, type/tier badge, HP pip track, and stress pip track.
+//  Tapping expands to AdversaryRunnerCard (managed by AdversaryRunnerSection).
+//
+
+import SwiftUI
+
+struct AdversaryRunnerRow: View {
+    let slot: AdversarySlot
+    let compendium: Compendium
+
+    private var adversary: Adversary? {
+        compendium.adversary(id: slot.adversaryID)
+    }
+
+    private var displayName: String {
+        slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
+    }
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack(spacing: 6) {
+                Text(displayName)
+                    .font(.body)
+                    .fontWeight(.medium)
+                Spacer()
+                if let adversary {
+                    Text("\(adversary.type.rawValue) · T\(adversary.tier)")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                        .padding(.horizontal, 6)
+                        .padding(.vertical, 2)
+                        .background(.secondary.opacity(0.15))
+                        .clipShape(.capsule)
+                }
+            }
+            HStack(spacing: 16) {
+                HStack(spacing: 4) {
+                    Text("HP")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    PipTrack(current: slot.currentHP, maximum: slot.maxHP)
+                }
+                HStack(spacing: 4) {
+                    Text("St")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    PipTrack(current: slot.currentStress, maximum: slot.maxStress)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+}
+
+#Preview {
+    let compendium = Compendium()
+    compendium.addAdversary(Adversary(
+        id: "goblin", name: "Goblin", tier: 1, type: .minion,
+        description: "Small and cunning.", difficulty: 10,
+        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+        attackModifier: "+2", attackName: "Rusty Blade",
+        attackRange: .veryClose, damage: "1d4 phy"
+    ))
+    return List {
+        AdversaryRunnerRow(
+            slot: AdversarySlot(adversaryID: "goblin", maxHP: 3, maxStress: 2, currentHP: 2),
+            compendium: compendium
+        )
+        AdversaryRunnerRow(
+            slot: AdversarySlot(adversaryID: "goblin", maxHP: 3, maxStress: 2, currentHP: 0, isDefeated: true),
+            compendium: compendium
+        )
+        .opacity(0.4)
+    }
+}

--- a/Encounter/Views/AdversaryRunnerSection.swift
+++ b/Encounter/Views/AdversaryRunnerSection.swift
@@ -1,0 +1,41 @@
+//
+//  AdversaryRunnerSection.swift
+//  Encounter
+//
+//  ForEach over the sorted adversary slots in EncounterRunnerView.
+//  Drives the accordion via the expandedSlotID binding — only one
+//  card can be open at a time by design (single UUID stored).
+//
+
+import SwiftUI
+
+struct AdversaryRunnerSection: View {
+    let slots: [AdversarySlot]
+    @Binding var expandedSlotID: UUID?
+    let session: EncounterSession
+    let compendium: Compendium
+
+    var body: some View {
+        ForEach(slots) { slot in
+            if expandedSlotID == slot.id {
+                AdversaryRunnerCard(
+                    slot: slot,
+                    session: session,
+                    compendium: compendium,
+                    onCollapse: { expandedSlotID = nil }
+                )
+                .opacity(slot.isDefeated ? 0.4 : 1.0)
+                .listRowSeparator(.hidden)
+            } else {
+                Button {
+                    expandedSlotID = slot.id
+                } label: {
+                    AdversaryRunnerRow(slot: slot, compendium: compendium)
+                        .opacity(slot.isDefeated ? 0.4 : 1.0)
+                        .contentShape(Rectangle())
+                }
+                .buttonStyle(.plain)
+            }
+        }
+    }
+}

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -6,8 +6,8 @@
 //  Manages a local draft copy of the EncounterDefinition and auto-saves
 //  after every mutation via EncounterStore.
 //
-//  Step 4 seam: Run Encounter button is present but disabled until
-//  EncounterRunnerView is implemented.
+//  Step 4: Run Encounter button creates or resumes a session via SessionRegistry
+//  and pushes EncounterRunnerView.
 //
 
 import SwiftUI
@@ -18,12 +18,14 @@ struct EncounterBuilderView: View {
     @State private var draft: EncounterDefinition
     @Environment(EncounterStore.self) private var store
     @Environment(Compendium.self) private var compendium
+    @Environment(SessionRegistry.self) private var sessionRegistry
 
     @State private var showCompendium = false
     @State private var showAddPlayer = false
     @State private var notesExpanded = false
     @State private var manualAdjustments: Set<DifficultyBudget.Adjustment> = []
     @State private var saveError: String?
+    @State private var runSession: EncounterSession?
 
     init(definition: EncounterDefinition) {
         self.definition = definition
@@ -113,6 +115,9 @@ struct EncounterBuilderView: View {
                 addPlayer(config)
             }
         }
+        .navigationDestination(item: $runSession) { session in
+            EncounterRunnerView(session: session, definition: draft)
+        }
     }
 
     // MARK: - Toolbar
@@ -120,8 +125,14 @@ struct EncounterBuilderView: View {
     @ToolbarContentBuilder
     private var toolbarContent: some ToolbarContent {
         ToolbarItem(placement: .primaryAction) {
-            Button("Run Encounter") {}
-                .disabled(true)
+            Button("Run Encounter") {
+                runSession = sessionRegistry.session(
+                    for: draft.id,
+                    definition: draft,
+                    compendium: compendium
+                )
+            }
+            .disabled(draft.adversaryIDs.isEmpty)
         }
         ToolbarItem(placement: .primaryAction) {
             Button("Browse Compendium", systemImage: "books.vertical") {
@@ -196,6 +207,7 @@ struct EncounterBuilderView: View {
     }
     .environment(store)
     .environment(compendium)
+    .environment(SessionRegistry())
 }
 
 /// Preview wrapper that creates a definition in the store before showing the builder.

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -1,0 +1,87 @@
+//
+//  EncounterRunnerView.swift
+//  Encounter
+//
+//  Live encounter running screen. Pushed from EncounterBuilderView
+//  when the GM taps "Run Encounter".
+//
+//  Layout:
+//   - Nav bar: "<name> · R<round>" + FearTrackerButton (trailing)
+//   - Scrollable adversary list (active first, defeated greyed at bottom)
+//   - PlayerStrip pinned to bottom via .safeAreaInset
+//
+
+import SwiftUI
+
+struct EncounterRunnerView: View {
+    let session: EncounterSession
+    let definition: EncounterDefinition
+
+    @Environment(Compendium.self) private var compendium
+    @State private var expandedSlotID: UUID?
+
+    // MARK: - Sorted slots (computed, non-mutating)
+    // Active adversaries preserve original insertion order.
+    // Defeated adversaries accumulate at the bottom in defeat order.
+    private var sortedAdversarySlots: [AdversarySlot] {
+        let active   = session.adversarySlots.filter { !$0.isDefeated }
+        let defeated = session.adversarySlots.filter {  $0.isDefeated }
+        return active + defeated
+    }
+
+    var body: some View {
+        List {
+            AdversaryRunnerSection(
+                slots: sortedAdversarySlots,
+                expandedSlotID: $expandedSlotID,
+                session: session,
+                compendium: compendium
+            )
+        }
+        .navigationTitle("\(session.name) · R\(session.currentRound)")
+        #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+        #endif
+        .toolbar {
+            ToolbarItem(placement: .primaryAction) {
+                FearTrackerButton(session: session)
+            }
+        }
+        .safeAreaInset(edge: .bottom) {
+            PlayerStrip(session: session)
+        }
+    }
+}
+
+#Preview {
+    let compendium = Compendium()
+    compendium.addAdversary(Adversary(
+        id: "goblin", name: "Goblin", tier: 1, type: .minion,
+        description: "Small and cunning.", difficulty: 10,
+        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+        attackModifier: "+2", attackName: "Rusty Blade",
+        attackRange: .veryClose, damage: "1d4 phy"
+    ))
+    compendium.addAdversary(Adversary(
+        id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
+        description: "Massive and relentless.", difficulty: 14,
+        thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+        attackModifier: "+5", attackName: "Great Axe",
+        attackRange: .veryClose, damage: "2d10+4 phy"
+    ))
+    let definition = EncounterDefinition(
+        name: "Goblin Ambush",
+        adversaryIDs: ["goblin", "goblin", "orc"],
+        playerConfigs: [
+            PlayerConfig(name: "Aric", maxHP: 6, maxStress: 6, evasion: 12,
+                         thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
+            PlayerConfig(name: "Lira", maxHP: 5, maxStress: 7, evasion: 14,
+                         thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
+        ]
+    )
+    let session = EncounterSession.start(from: definition, using: compendium)
+    return NavigationStack {
+        EncounterRunnerView(session: session, definition: definition)
+    }
+    .environment(compendium)
+}

--- a/Encounter/Views/FearTrackerButton.swift
+++ b/Encounter/Views/FearTrackerButton.swift
@@ -1,0 +1,65 @@
+//
+//  FearTrackerButton.swift
+//  Encounter
+//
+//  Toolbar button showing the current Fear pool (flame icon + count).
+//  Tapping opens a compact popover with +1 / −1 / −2 / −3 controls.
+//
+
+import SwiftUI
+
+struct FearTrackerButton: View {
+    let session: EncounterSession
+    @State private var showPopover = false
+
+    var body: some View {
+        Button {
+            showPopover.toggle()
+        } label: {
+            Label("\(session.fearPool)", systemImage: "flame.fill")
+                .monospacedDigit()
+        }
+        .tint(.orange)
+        .popover(isPresented: $showPopover) {
+            VStack(spacing: 12) {
+                Text("Fear")
+                    .font(.headline)
+                Text("\(session.fearPool)")
+                    .font(.largeTitle)
+                    .fontWeight(.bold)
+                    .monospacedDigit()
+                    .foregroundStyle(.orange)
+                HStack(spacing: 8) {
+                    Button("+1") { session.incrementFear(by: 1) }
+                        .buttonStyle(.bordered)
+                    Button("−1") { session.spendFear(1) }
+                        .buttonStyle(.bordered)
+                        .disabled(session.fearPool < 1)
+                    Button("−2") { session.spendFear(2) }
+                        .buttonStyle(.bordered)
+                        .disabled(session.fearPool < 2)
+                    Button("−3") { session.spendFear(3) }
+                        .buttonStyle(.bordered)
+                        .disabled(session.fearPool < 3)
+                }
+            }
+            .padding()
+            .frame(minWidth: 180)
+            .presentationCompactAdaptation(.popover)
+        }
+    }
+}
+
+#Preview {
+    let compendium = Compendium()
+    let session = EncounterSession(name: "Test", fearPool: 3)
+    return NavigationStack {
+        Text("Runner")
+            .toolbar {
+                ToolbarItem(placement: .primaryAction) {
+                    FearTrackerButton(session: session)
+                }
+            }
+    }
+    .environment(compendium)
+}

--- a/Encounter/Views/PipTrack.swift
+++ b/Encounter/Views/PipTrack.swift
@@ -1,0 +1,58 @@
+//
+//  PipTrack.swift
+//  Encounter
+//
+//  Compact pip-dot visualizer for HP and Stress values.
+//  Renders filled/empty circle symbols up to a threshold of 10;
+//  falls back to "N/M" text for larger values.
+//
+//  Color gradient (HP): neutral → orange → red as current decreases.
+//  Stress uses neutral color (filling stress is not inherently dangerous).
+//
+
+import SwiftUI
+
+struct PipTrack: View {
+    let current: Int
+    let maximum: Int
+
+    private let pipThreshold = 10
+
+    var body: some View {
+        if maximum > pipThreshold {
+            Text("\(current)/\(maximum)")
+                .font(.caption)
+                .monospacedDigit()
+                .foregroundStyle(current == 0 ? .red : .primary)
+        } else {
+            HStack(spacing: 3) {
+                ForEach(0 ..< max(maximum, 0), id: \.self) { i in
+                    Image(systemName: i < current ? "circle.fill" : "circle")
+                        .font(.system(size: 8))
+                        .foregroundStyle(i < current ? pipColor : .secondary.opacity(0.4))
+                        .accessibilityHidden(true)
+                }
+            }
+            .accessibilityLabel(Text("\(current) of \(maximum)"))
+        }
+    }
+
+    private var pipColor: Color {
+        guard maximum > 0 else { return .primary }
+        let ratio = Double(current) / Double(maximum)
+        if ratio > 0.66 { return .primary }
+        if ratio > 0.33 { return .orange }
+        return .red
+    }
+}
+
+#Preview {
+    VStack(alignment: .leading, spacing: 8) {
+        PipTrack(current: 5, maximum: 5)
+        PipTrack(current: 3, maximum: 5)
+        PipTrack(current: 1, maximum: 5)
+        PipTrack(current: 0, maximum: 5)
+        PipTrack(current: 8, maximum: 12)   // text fallback
+    }
+    .padding()
+}

--- a/Encounter/Views/PlayerEditPopover.swift
+++ b/Encounter/Views/PlayerEditPopover.swift
@@ -1,0 +1,94 @@
+//
+//  PlayerEditPopover.swift
+//  Encounter
+//
+//  Popover presenting stepper-style controls for a player's HP, Stress,
+//  and Armor Slots during a live encounter.
+//
+
+import SwiftUI
+
+struct PlayerEditPopover: View {
+    let player: PlayerSlot
+    let session: EncounterSession
+
+    var body: some View {
+        VStack(alignment: .leading, spacing: 16) {
+            Text(player.name)
+                .font(.headline)
+
+            statRow(
+                label: "HP",
+                current: player.currentHP,
+                maximum: player.maxHP,
+                onDecrement: { session.applyPlayerDamage(1, to: player.id) },
+                onIncrement: { session.healPlayer(1, slotID: player.id) }
+            )
+
+            statRow(
+                label: "Stress",
+                current: player.currentStress,
+                maximum: player.maxStress,
+                onDecrement: { session.clearPlayerStress(1, slotID: player.id) },
+                onIncrement: { session.applyPlayerStress(1, to: player.id) }
+            )
+
+            if player.armorSlots > 0 {
+                statRow(
+                    label: "Armor",
+                    current: player.currentArmorSlots,
+                    maximum: player.armorSlots,
+                    onDecrement: { session.markPlayerArmorSlot(player.id) },
+                    onIncrement: { session.restorePlayerArmorSlot(player.id) }
+                )
+            }
+        }
+        .padding()
+        .frame(minWidth: 220)
+    }
+
+    @ViewBuilder
+    private func statRow(
+        label: String,
+        current: Int,
+        maximum: Int,
+        onDecrement: @escaping () -> Void,
+        onIncrement: @escaping () -> Void
+    ) -> some View {
+        HStack {
+            Text(label)
+                .font(.subheadline)
+                .frame(minWidth: 60, alignment: .leading)
+            Spacer()
+            Button("Decrease \(label)", systemImage: "minus.circle", action: onDecrement)
+                .labelStyle(.iconOnly)
+                .font(.title3)
+                .buttonStyle(.borderless)
+                .disabled(current <= 0)
+
+            Text("\(current) / \(maximum)")
+                .font(.body)
+                .monospacedDigit()
+                .frame(minWidth: 64, alignment: .center)
+
+            Button("Increase \(label)", systemImage: "plus.circle", action: onIncrement)
+                .labelStyle(.iconOnly)
+                .font(.title3)
+                .buttonStyle(.borderless)
+                .disabled(current >= maximum)
+        }
+    }
+}
+
+#Preview {
+    let session = EncounterSession(name: "Test")
+    session.addPlayer(PlayerSlot(
+        name: "Aric Stonehammer",
+        maxHP: 6, maxStress: 6, evasion: 12,
+        thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3
+    ))
+    return PlayerEditPopover(
+        player: session.playerSlots[0],
+        session: session
+    )
+}

--- a/Encounter/Views/PlayerStrip.swift
+++ b/Encounter/Views/PlayerStrip.swift
@@ -1,0 +1,45 @@
+//
+//  PlayerStrip.swift
+//  Encounter
+//
+//  Always-visible panel pinned to the bottom of EncounterRunnerView
+//  via .safeAreaInset(edge: .bottom). Shows all player slots.
+//
+
+import SwiftUI
+
+struct PlayerStrip: View {
+    let session: EncounterSession
+
+    var body: some View {
+        VStack(spacing: 0) {
+            Divider()
+            VStack(spacing: 4) {
+                ForEach(session.playerSlots) { player in
+                    PlayerStripRow(player: player, session: session)
+                }
+            }
+            .padding(.horizontal)
+            .padding(.vertical, 6)
+            .background(.regularMaterial)
+        }
+    }
+}
+
+#Preview {
+    let session = EncounterSession(
+        name: "Goblin Ambush",
+        playerSlots: [
+            PlayerSlot(name: "Aric Stonehammer",
+                       maxHP: 6, maxStress: 6, evasion: 12,
+                       thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
+            PlayerSlot(name: "Lira Dawnwhisper",
+                       maxHP: 5, currentHP: 3, maxStress: 7, currentStress: 2,
+                       evasion: 14, thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
+        ]
+    )
+    VStack {
+        Spacer()
+        PlayerStrip(session: session)
+    }
+}

--- a/Encounter/Views/PlayerStripRow.swift
+++ b/Encounter/Views/PlayerStripRow.swift
@@ -1,0 +1,83 @@
+//
+//  PlayerStripRow.swift
+//  Encounter
+//
+//  Compact player row inside the always-visible PlayerStrip.
+//  Shows name, HP pip track, stress pip track, and armor slot count.
+//  Tapping opens PlayerEditPopover for HP/Stress/Armor stepper controls.
+//
+
+import SwiftUI
+
+struct PlayerStripRow: View {
+    let player: PlayerSlot
+    let session: EncounterSession
+    @State private var showPopover = false
+
+    var body: some View {
+        Button {
+            showPopover = true
+        } label: {
+            HStack(spacing: 8) {
+                Text(player.name)
+                    .font(.caption)
+                    .fontWeight(.medium)
+                    .frame(minWidth: 60, alignment: .leading)
+                    .lineLimit(1)
+                    .truncationMode(.tail)
+
+                Spacer()
+
+                HStack(spacing: 4) {
+                    Text("HP")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    PipTrack(current: player.currentHP, maximum: player.maxHP)
+                }
+
+                HStack(spacing: 4) {
+                    Text("St")
+                        .font(.caption2)
+                        .foregroundStyle(.secondary)
+                    PipTrack(current: player.currentStress, maximum: player.maxStress)
+                }
+
+                if player.armorSlots > 0 {
+                    HStack(spacing: 4) {
+                        Text("Arm")
+                            .font(.caption2)
+                            .foregroundStyle(.secondary)
+                        Text("\(player.currentArmorSlots)/\(player.armorSlots)")
+                            .font(.caption)
+                            .monospacedDigit()
+                    }
+                }
+            }
+            .foregroundStyle(.primary)
+        }
+        .buttonStyle(.plain)
+        .popover(isPresented: $showPopover) {
+            PlayerEditPopover(player: player, session: session)
+                .presentationCompactAdaptation(.popover)
+        }
+    }
+}
+
+#Preview {
+    let session = EncounterSession(
+        name: "Test",
+        playerSlots: [
+            PlayerSlot(name: "Aric Stonehammer",
+                       maxHP: 6, maxStress: 6, evasion: 12,
+                       thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
+            PlayerSlot(name: "Lira Dawnwhisper",
+                       maxHP: 5, currentHP: 3, maxStress: 7, currentStress: 2,
+                       evasion: 14, thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
+        ]
+    )
+    List {
+        ForEach(session.playerSlots) { player in
+            PlayerStripRow(player: player, session: session)
+        }
+    }
+}


### PR DESCRIPTION
## Summary

- Wires **Run Encounter** in `EncounterBuilderView` to push `EncounterRunnerView`, with in-memory session resume via `SessionRegistry`
- **Adversary panel**: accordion list (one slot expanded at a time); collapsed rows show pip HP/stress tracks; expanded card shows threshold-damage buttons (Minor/Major/Severe → 1/2/3 HP), +Stress, and condition toggles (Hidden/Restrained/Vulnerable)
- **Player strip**: always-visible panel pinned to `.safeAreaInset(edge: .bottom)` with per-player HP/stress pips; tap opens a popover with stepper buttons for HP, Stress, and Armor Slots
- **Fear tracker**: toolbar button with popover showing pool total and +1/−1/−2/−3 spend buttons

## New files
| File | Purpose |
|---|---|
| `SessionRegistry.swift` | @Observable in-memory session registry keyed by definition ID |
| `PipTrack.swift` | Reusable HP/stress pip visualizer (text fallback above 10) |
| `FearTrackerButton.swift` | Toolbar button with Fear pool popover |
| `AdversaryRunnerRow/Card/Section.swift` | Accordion adversary list |
| `PlayerEditPopover.swift` | HP/Stress/Armor stepper popover |
| `PlayerStripRow/PlayerStrip.swift` | Always-visible player panel |

## Model changes
- `EncounterSession`: `Hashable` conformance (`nonisolated` `==` and `hash(into:)`) for `navigationDestination(item:)`
- `EncounterSession`: `restorePlayerArmorSlot` added (inverse of `markPlayerArmorSlot`)

## Review fixes (3-round swiftui-pro + concurrency-pro + code-review-pro)
- Accessibility labels on pip tracks and stepper buttons
- `nonisolated` on `Hashable` methods (required under `SWIFT_DEFAULT_ACTOR_ISOLATION=MainActor`)
- `private(set)` on `SessionRegistry.sessions` to enforce creation via `session(for:)` only
- Accordion tap dead-branch simplified to direct assignment
- Force-unwraps removed from previews

## Test plan
- [ ] Build and run on iOS simulator — tap Run Encounter from builder, session opens
- [ ] Tap an adversary row to expand; tap again (or tap another) to collapse
- [ ] Apply Minor/Major/Severe damage; verify HP pip track updates and slot greys out at 0
- [ ] Toggle conditions on an adversary
- [ ] Tap a player row → popover opens; adjust HP, Stress, Armor Slots
- [ ] Tap Fear button in toolbar → popover opens; increment and spend fear
- [ ] Navigate back to builder and tap Run Encounter again — same session resumes (HP preserved)
- [ ] Build and run on macOS simulator — same interactions work

🤖 Generated with [Claude Code](https://claude.com/claude-code)