### PR TITLE
Simplify live encounter runner (Step 4 cleanup)

### DIFF
--- a/Encounter/Models/Condition.swift
+++ b/Encounter/Models/Condition.swift
@@ -33,6 +33,10 @@ nonisolated public enum Condition: Hashable, Sendable, Codable {
     /// A feature-imposed condition with a custom name.
     case custom(String)
 
+    /// The three standard SRD conditions available for toggle in encounter UI.
+    /// `.custom` is omitted because it requires a name parameter.
+    public static let standardConditions: [Condition] = [.hidden, .restrained, .vulnerable]
+
     /// Human-readable display name for UI rendering.
     public var displayName: String {
         switch self {

--- a/Encounter/Views/AdversaryRunnerCard.swift
+++ b/Encounter/Views/AdversaryRunnerCard.swift
@@ -20,15 +20,16 @@ struct AdversaryRunnerCard: View {
     let compendium: Compendium
     let onCollapse: () -> Void
 
-    private var adversary: Adversary? {
-        compendium.adversary(id: slot.adversaryID)
-    }
-
     private var displayName: String {
-        slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
+        let adversary = compendium.adversary(id: slot.adversaryID)
+        return slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
     }
 
     var body: some View {
+        let adversary = compendium.adversary(id: slot.adversaryID)
+        let major = adversary.map { "\($0.thresholdMajor)" } ?? "—"
+        let severe = adversary.map { "\($0.thresholdSevere)" } ?? "—"
+
         VStack(alignment: .leading, spacing: 12) {
 
             // Header
@@ -60,21 +61,9 @@ struct AdversaryRunnerCard: View {
 
             // Damage threshold buttons
             HStack(spacing: 8) {
-                thresholdButton(
-                    "Minor",
-                    subtitle: "< \(adversary.map { "\($0.thresholdMajor)" } ?? "—")",
-                    marks: 1
-                )
-                thresholdButton(
-                    "Major",
-                    subtitle: "≥ \(adversary.map { "\($0.thresholdMajor)" } ?? "—")",
-                    marks: 2
-                )
-                thresholdButton(
-                    "Severe",
-                    subtitle: "≥ \(adversary.map { "\($0.thresholdSevere)" } ?? "—")",
-                    marks: 3
-                )
+                thresholdButton("Minor",  subtitle: "< \(major)",  marks: 1)
+                thresholdButton("Major",  subtitle: "≥ \(major)",  marks: 2)
+                thresholdButton("Severe", subtitle: "≥ \(severe)", marks: 3)
             }
 
             // Stress
@@ -121,7 +110,7 @@ struct AdversaryRunnerCard: View {
                 .font(.caption)
                 .foregroundStyle(.secondary)
             HStack(spacing: 6) {
-                ForEach([Condition.hidden, .restrained, .vulnerable], id: \.displayName) { condition in
+                ForEach(Condition.standardConditions, id: \.displayName) { condition in
                     let active = slot.conditions.contains(condition)
                     Button(condition.displayName) {
                         if active {

--- a/Encounter/Views/AdversaryRunnerRow.swift
+++ b/Encounter/Views/AdversaryRunnerRow.swift
@@ -13,15 +13,14 @@ struct AdversaryRunnerRow: View {
     let slot: AdversarySlot
     let compendium: Compendium
 
-    private var adversary: Adversary? {
-        compendium.adversary(id: slot.adversaryID)
-    }
-
     private var displayName: String {
-        slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
+        let adversary = compendium.adversary(id: slot.adversaryID)
+        return slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
     }
 
     var body: some View {
+        let adversary = compendium.adversary(id: slot.adversaryID)
+
         VStack(alignment: .leading, spacing: 6) {
             HStack(spacing: 6) {
                 Text(displayName)

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -116,7 +116,7 @@ struct EncounterBuilderView: View {
             }
         }
         .navigationDestination(item: $runSession) { session in
-            EncounterRunnerView(session: session, definition: draft)
+            EncounterRunnerView(session: session)
         }
     }
 

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -15,18 +15,15 @@ import SwiftUI
 
 struct EncounterRunnerView: View {
     let session: EncounterSession
-    let definition: EncounterDefinition
 
     @Environment(Compendium.self) private var compendium
     @State private var expandedSlotID: UUID?
 
     // MARK: - Sorted slots (computed, non-mutating)
-    // Active adversaries preserve original insertion order.
+    // Active adversaries preserve original insertion order (stable sort).
     // Defeated adversaries accumulate at the bottom in defeat order.
     private var sortedAdversarySlots: [AdversarySlot] {
-        let active   = session.adversarySlots.filter { !$0.isDefeated }
-        let defeated = session.adversarySlots.filter {  $0.isDefeated }
-        return active + defeated
+        session.adversarySlots.sorted { !$0.isDefeated && $1.isDefeated }
     }
 
     var body: some View {
@@ -81,7 +78,7 @@ struct EncounterRunnerView: View {
     )
     let session = EncounterSession.start(from: definition, using: compendium)
     return NavigationStack {
-        EncounterRunnerView(session: session, definition: definition)
+        EncounterRunnerView(session: session)
     }
     .environment(compendium)
 }


### PR DESCRIPTION
## Summary

- Extract `Condition.standardConditions` static constant; removes hardcoded array literal from `AdversaryRunnerCard.conditionsSection`
- Bind `compendium.adversary(id:)` once per render in `AdversaryRunnerCard` and `AdversaryRunnerRow` instead of recomputing via a computed property on every access
- Replace double-filter in `EncounterRunnerView.sortedAdversarySlots` with a single stable sort pass
- Remove unused `definition` parameter from `EncounterRunnerView`

## Test plan

- [x] Build succeeds (confirmed clean)
- [ ] Runner screen renders adversary list with active/defeated ordering intact
- [ ] Condition toggles still appear and work for Hidden / Restrained / Vulnerable
- [ ] HP threshold labels still show correct values on adversary cards