### PR TITLE
Add Logger, @MainActor isolation, and document dev loop

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -119,17 +119,26 @@ to get the complete adversary list.
 
 ---
 
-## Testing
+## Development Loop
 
-Tests use **Swift Testing** (`import Testing`), not XCTest.
+The primary iteration cycle is running tests from the terminal:
 
 ```bash
-# Run unit tests from CLI (adjust scheme/destination as needed)
 xcodebuild test \
   -scheme Encounter \
   -destination 'platform=macOS' \
   -resultBundlePath TestResults.xcresult
 ```
+
+Run this after every meaningful change. All test output — including `print()` calls and
+`Logger` messages routed to stderr — is visible directly in the terminal. Prefer this
+over the interactive Xcode debugger for CLI-driven iteration.
+
+---
+
+## Testing
+
+Tests use **Swift Testing** (`import Testing`), not XCTest.
 
 Test coverage priorities:
 1. `Adversary` JSON decoding (both threshold formats, all field variants)

--- a/Encounter/Models/Compendium.swift
+++ b/Encounter/Models/Compendium.swift
@@ -15,6 +15,7 @@
 
 import Foundation
 import Observation
+import OSLog
 
 // MARK: - CompendiumError
 
@@ -61,8 +62,11 @@ nonisolated public enum CompendiumError: Error, LocalizedError {
 /// Call ``addAdversary(_:)`` / ``addEnvironment(_:)`` to merge homebrew
 /// entries at runtime. Homebrew entries with the same `id` as an SRD entry
 /// replace the SRD version.
+@MainActor
 @Observable
 public final class Compendium {
+
+    private let logger = Logger(subsystem: "gwillish.Encounter", category: "Compendium")
 
     // MARK: Published State
 
@@ -131,9 +135,13 @@ public final class Compendium {
     /// Throws a ``CompendiumError`` if a resource is missing or malformed.
     /// The error is also stored in ``loadError`` for SwiftUI observation.
     public func load() async throws {
-        guard !isLoading else { return }
+        guard !isLoading else {
+            logger.debug("load() called while already loading — skipped")
+            return
+        }
         isLoading = true
         loadError = nil
+        logger.info("Compendium load started")
 
         defer { isLoading = false }
 
@@ -146,12 +154,15 @@ public final class Compendium {
 
             srdAdversariesByID  = Dictionary(uniqueKeysWithValues: loadedAdversaries.map  { ($0.id, $0) })
             srdEnvironmentsByID = Dictionary(uniqueKeysWithValues: loadedEnvironments.map { ($0.id, $0) })
+            logger.info("Compendium loaded \(loadedAdversaries.count) adversaries, \(loadedEnvironments.count) environments")
         } catch let error as CompendiumError {
             loadError = error
+            logger.error("Compendium load failed: \(error.localizedDescription)")
             throw error
         } catch {
             let wrapped = CompendiumError.decodingFailed("unknown", error)
             loadError = wrapped
+            logger.error("Compendium load failed (unexpected): \(error)")
             throw wrapped
         }
     }

--- a/Encounter/Models/EncounterSession.swift
+++ b/Encounter/Models/EncounterSession.swift
@@ -17,6 +17,7 @@
 
 import Foundation
 import Observation
+import OSLog
 
 // MARK: - AdversarySlot
 
@@ -128,10 +129,13 @@ nonisolated public struct EnvironmentSlot: Identifiable, Sendable, Equatable {
 /// session.add(adversary: bandits.ironguard)   // second copy
 /// session.add(environment: terrain.forestEdge)
 /// ```
+@MainActor
 @Observable
 public final class EncounterSession: Identifiable, Hashable {
     public nonisolated static func == (lhs: EncounterSession, rhs: EncounterSession) -> Bool { lhs.id == rhs.id }
     public nonisolated func hash(into hasher: inout Hasher) { hasher.combine(id) }
+
+    private let logger = Logger(subsystem: "gwillish.Encounter", category: "EncounterSession")
 
     // MARK: Identity
     public let id: UUID
@@ -229,25 +233,38 @@ public final class EncounterSession: Identifiable, Hashable {
 
     /// Apply damage to an adversary slot, clamping HP to 0.
     public func applyDamage(_ amount: Int, to slotID: UUID) {
-        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else { return }
+        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
+            logger.warning("applyDamage: slot \(slotID) not found")
+            return
+        }
         adversarySlots[index].currentHP = max(0, adversarySlots[index].currentHP - amount)
         if adversarySlots[index].currentHP == 0 {
             adversarySlots[index].isDefeated = true
+            logger.info("Slot \(slotID) defeated")
+        } else {
+            logger.debug("Slot \(slotID) took \(amount) damage, HP now \(self.adversarySlots[index].currentHP)")
         }
     }
 
     /// Apply stress to an adversary slot, clamping to the slot's snapshotted maximum.
     public func applyStress(_ amount: Int, to slotID: UUID) {
-        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else { return }
+        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
+            logger.warning("applyStress: slot \(slotID) not found")
+            return
+        }
         adversarySlots[index].currentStress = min(
             adversarySlots[index].maxStress,
             adversarySlots[index].currentStress + amount
         )
+        logger.debug("Slot \(slotID) stress now \(self.adversarySlots[index].currentStress)/\(self.adversarySlots[index].maxStress)")
     }
 
     /// Heal an adversary slot, clamping HP to the slot's snapshotted maximum.
     public func heal(_ amount: Int, slotID: UUID) {
-        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else { return }
+        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
+            logger.warning("heal: slot \(slotID) not found")
+            return
+        }
         adversarySlots[index].currentHP = min(
             adversarySlots[index].maxHP,
             adversarySlots[index].currentHP + amount
@@ -255,6 +272,7 @@ public final class EncounterSession: Identifiable, Hashable {
         if adversarySlots[index].currentHP > 0 {
             adversarySlots[index].isDefeated = false
         }
+        logger.debug("Slot \(slotID) healed \(amount), HP now \(self.adversarySlots[index].currentHP)/\(self.adversarySlots[index].maxHP)")
     }
 
     // MARK: - Adversary Condition Management
@@ -367,6 +385,7 @@ public final class EncounterSession: Identifiable, Hashable {
         // Defeated adversaries are removed from the turn order for the new round.
         let defeatedIDs = Set(adversarySlots.filter(\.isDefeated).map(\.id))
         turnOrder = turnOrder.filter { !defeatedIDs.contains($0) }
+        logger.info("Advanced to round \(self.currentRound), \(self.turnOrder.count) slots in order")
     }
 
     /// Turn order filtered to non-defeated participants.


### PR DESCRIPTION
## Summary

- Adds `OSLog` logging to `Compendium` and `EncounterSession` for load events, damage/stress/heal mutations, and turn advancement
- Explicitly marks both `@Observable` classes as `@MainActor` for clear actor isolation
- Updates `CLAUDE.md` with a dedicated **Development Loop** section documenting the `xcodebuild test` command and rationale for CLI-driven iteration

## Test plan

- [x] All existing unit and UI tests pass on macOS (`** TEST SUCCEEDED **`)
- [ ] Verify `Logger` output appears in Console.app during a live run