### PR TITLE
Split test plans: UnitTests (default) and AllTests for UI validation

### DIFF
--- a/AllTests.xctestplan
+++ b/AllTests.xctestplan
@@ -1,0 +1,38 @@
+{
+  "configurations" : [
+    {
+      "id" : "3F1A2B4C-1234-5678-ABCD-000000000002",
+      "name" : "All Tests",
+      "options" : {
+
+      }
+    }
+  ],
+  "defaultOptions" : {
+    "performanceAntipatternCheckerEnabled" : true,
+    "targetForVariableExpansion" : {
+      "containerPath" : "container:Encounter.xcodeproj",
+      "identifier" : "1A8F7B992F660D3800548E3A",
+      "name" : "Encounter"
+    }
+  },
+  "testTargets" : [
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Encounter.xcodeproj",
+        "identifier" : "1A8F7BA62F660D3900548E3A",
+        "name" : "EncounterTests"
+      }
+    },
+    {
+      "parallelizable" : true,
+      "target" : {
+        "containerPath" : "container:Encounter.xcodeproj",
+        "identifier" : "1A8F7BB02F660D3900548E3A",
+        "name" : "EncounterUITests"
+      }
+    }
+  ],
+  "version" : 1
+}

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -121,7 +121,7 @@ to get the complete adversary list.
 
 ## Development Loop
 
-The primary iteration cycle is running tests from the terminal:
+The primary iteration cycle is running unit tests from the terminal:
 
 ```bash
 xcodebuild test \
@@ -130,9 +130,22 @@ xcodebuild test \
   -resultBundlePath TestResults.xcresult
 ```
 
-Run this after every meaningful change. All test output — including `print()` calls and
-`Logger` messages routed to stderr — is visible directly in the terminal. Prefer this
-over the interactive Xcode debugger for CLI-driven iteration.
+This uses the `UnitTests` test plan (the scheme default) — UI tests are excluded so no
+unlock prompt appears. Run this after every meaningful change.
+
+To include UI tests (e.g. before a PR or release):
+
+```bash
+xcodebuild test \
+  -scheme Encounter \
+  -destination 'platform=macOS' \
+  -testPlan AllTests \
+  -resultBundlePath TestResults.xcresult
+```
+
+All test output — including `print()` calls and `Logger` messages routed to stderr — is
+visible directly in the terminal. Prefer this over the interactive Xcode debugger for
+CLI-driven iteration.
 
 ---
 

--- a/Encounter.xcodeproj/xcshareddata/xcschemes/Encounter.xcscheme
+++ b/Encounter.xcodeproj/xcshareddata/xcschemes/Encounter.xcscheme
@@ -30,8 +30,11 @@
       shouldUseLaunchSchemeArgsEnv = "YES">
       <TestPlans>
          <TestPlanReference
-            reference = "container:Encounter.xctestplan"
+            reference = "container:UnitTests.xctestplan"
             default = "YES">
+         </TestPlanReference>
+         <TestPlanReference
+            reference = "container:AllTests.xctestplan">
          </TestPlanReference>
       </TestPlans>
       <Testables>

--- a/UnitTests.xctestplan
+++ b/UnitTests.xctestplan
@@ -1,8 +1,8 @@
 {
   "configurations" : [
     {
-      "id" : "85A8E511-ECFA-4462-86AB-719C348A9161",
-      "name" : "Test Scheme Action",
+      "id" : "3F1A2B4C-1234-5678-ABCD-000000000001",
+      "name" : "Unit Tests",
       "options" : {
 
       }
@@ -23,17 +23,6 @@
         "containerPath" : "container:Encounter.xcodeproj",
         "identifier" : "1A8F7BA62F660D3900548E3A",
         "name" : "EncounterTests"
-      }
-    },
-    {
-      "enabled" : false,
-      "selectedTests" : [
-        "EncounterUITestsLaunchTests\/testLaunch()"
-      ],
-      "target" : {
-        "containerPath" : "container:Encounter.xcodeproj",
-        "identifier" : "1A8F7BB02F660D3900548E3A",
-        "name" : "EncounterUITests"
       }
     }
   ],


### PR DESCRIPTION
## Summary

- Adds `UnitTests.xctestplan` — `EncounterTests` only; set as the scheme default so the bare `xcodebuild test` command never triggers UI tests or an unlock prompt
- Adds `AllTests.xctestplan` — both `EncounterTests` and `EncounterUITests` for pre-PR / release validation
- Removes the old `Encounter.xctestplan` which had `EncounterUITests` marked `enabled: false` but still ran `testLaunch()` via `selectedTests`, causing the unlock prompt
- Updates `CLAUDE.md` Development Loop section to document both commands

## Test plan

- [x] `xcodebuild test -scheme Encounter -destination 'platform=macOS'` runs unit tests only — no UI tests, no unlock prompt (**TEST SUCCEEDED**)
- [x] `xcodebuild test -scheme Encounter -destination 'platform=macOS' -testPlan AllTests` runs all tests including UI (**TEST SUCCEEDED**)