### PR TITLE
Add ADR structure and 25 historical decision records

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,6 +1,6 @@
 # Encounter — Claude Code Context
 
-Daggerheart encounter prep and run app for iOS and macOS, targeting game masters who need to set up and track encounters at the table.
+Daggerheart encounter prep and run app for iOS and macOS, primarily for game masters who need to set up and track encounters at the table.
 Built with SwiftUI, targeting Xcode 26.3 / Swift 6.
 
 ---
@@ -21,10 +21,12 @@ Encounter/
 │   ├── ContentView.swift       # Root view (stub)
 │   └── EncounterApp.swift      # App entry point
 ├── EncounterTests/             # Swift Testing unit tests
-│   └── EncounterTests.swift    # Model tests (Adversary decoding, EncounterSession mutations)
 ├── EncounterUITests/           # XCUITest UI tests
 ├── docs/
-│   └── data-schema.md          # Daggerheart JSON schema reference + source links
+│   ├── data-schema.md          # Daggerheart JSON schema reference + source links
+│   └── decisions/              # Architecture Decision Records (ADRs)
+│       └── README.md           # ADR format, lifecycle, and superseded process
+├── README.md                   # Project overview
 └── CLAUDE.md                   # This file
 ```
 
@@ -161,6 +163,48 @@ Test coverage priorities:
 
 ---
 
+## Architecture Decision Records
+
+Significant architectural, data-format, and UX decisions are recorded as ADRs in
+`docs/decisions/`. See `docs/decisions/README.md` for the full format and process.
+
+### When to write an ADR
+
+Write one when choosing between meaningfully different approaches, establishing a
+project-wide convention, making a UX decision that constrains future work, or
+deciding explicitly *not* to do something. Do not write one for routine
+implementation details. At the end of any planning session, propose ADRs for
+what was decided and let the user confirm which to write.
+
+### ADR statuses
+
+| Status | Meaning |
+|---|---|
+| **Proposed** | Under active exploration; not yet settled |
+| **Accepted** | Decided and currently in effect |
+| **Rejected** | Explored but not implemented; findings recorded to prevent re-exploring the same dead end |
+| **Deprecated** | No longer applies; no direct replacement |
+| **Superseded by ADR-NNNN** | A later decision replaced this one |
+
+### Superseded / Mistake Process
+
+**Never edit or delete an existing ADR.** If a decision was wrong or needs to change:
+
+1. Write a **new ADR** with the next available number. Open its Context section
+   with _"This supersedes [ADR-NNNN](NNNN-title.md)."_ Explain what changed and why.
+2. Update the **original ADR's status line only** to:
+   `Superseded by [ADR-NNNN](NNNN-title.md)`
+3. Leave the original content completely intact below the status line.
+
+### Branch explorations
+
+A `Proposed` ADR on a feature branch documents an approach under exploration.
+If the branch is discarded but the findings matter, cherry-pick just the ADR
+file to `main` with status `Rejected` before deleting the branch. If nothing
+was learned worth preserving, don't bring the ADR to `main`.
+
+---
+
 ## Git
 
 - **Never commit on behalf of the user.** Do not create commits unless explicitly asked.
@@ -184,32 +228,10 @@ Test coverage priorities:
 
 ## Known Gaps / Next Steps
 
-Full gap detail: `.claude/memory/project_data_model_gaps.md`
-
-### High priority — blocking architecture
-
-- [x] **GAP-1** `EncounterDefinition` type — `EncounterDefinition.swift` added; `EncounterSession.start(from:using:)` factory method bridges the two.
-- [x] **GAP-2** `PlayerSlot` type — `PlayerSlot.swift` added; participates in turn order; full HP/stress/armor/condition tracking in `EncounterSession`.
-- [x] **GAP-3** Difficulty budget model — `DifficultyBudget.swift` added; pure Battle Points namespace per SRD.
-- [x] **GAP-4** `EncounterDefinition` `Codable` — resolved with GAP-1; `PlayerConfig` also fully Codable.
-
-### Medium priority
-
-- [x] **GAP-5** Homebrew distinction — `Compendium` now has separate `srdAdversariesByID` / `homebrewAdversariesByID` dicts; `homebrewAdversaries` / `homebrewEnvironments` arrays for filtering; `removeHomebrewAdversary(id:)` / `removeHomebrewEnvironment(id:)` for deletion.
-- [x] **GAP-6** Condition tags — `Condition.swift` added; `Set<Condition>` on both `AdversarySlot` and `PlayerSlot`.
-
-### Low priority
-
-- [x] **GAP-7** `createdAt`/`modifiedAt` — included in `EncounterDefinition`.
-- [x] **GAP-8** `Compendium.load()` — now `async throws`; decodes on a background task.
-- [x] **GAP-9** `AdversarySlot` stat snapshot — `maxHP` and `maxStress` snapshotted at slot creation; `applyStress` and `heal` no longer need a `Compendium` parameter.
-
-### Pre-existing
-
-- [ ] `ContentView.swift` is a stub — needs compendium browser + encounter runner UI
-- [ ] `adversaries.json` / `environments.json` are sample data — replace with full SRD export
+- [ ] `adversaries.json` / `environments.json` are stub data — replace with full SRD export and move to writable content directory (see ADRs on content architecture)
 - [ ] No dice rolling logic — `damage` strings are stored raw (e.g. `"1d12+2 phy"`)
 - [ ] Horde adversary rules (shared HP pool, modified attack) not yet implemented
+- [ ] Adversary creation UI and difficulty meter — deferred to a dedicated design session
 - [ ] No iCloud sync or Handoff between iOS and macOS
 
 ### Future (out of scope for v1)

--- a/README.md
+++ b/README.md
@@ -1,0 +1,25 @@
+# Encounter
+
+Daggerheart encounter prep and run app for iOS and macOS, primarily for game masters
+who need to set up and track encounters at the table.
+
+Built with SwiftUI, targeting iOS 26, macOS 26, and visionOS 26.
+
+## Documentation
+
+- `CLAUDE.md` — full technical context, conventions, and build instructions for
+  development with Claude Code
+- `docs/data-schema.md` — Daggerheart JSON schema reference and source links
+- `docs/decisions/` — Architecture Decision Records (ADRs): the history of
+  significant architectural, data-format, and UX choices made during development
+
+## Architecture Decision Records
+
+Significant decisions are recorded as ADRs in `docs/decisions/`. Each record
+captures why a decision was needed, what was decided, what alternatives were
+considered, and what consequences follow.
+
+When a decision turns out to be wrong or needs to change, a new ADR is written
+that supersedes the original. The original is never edited or deleted — the
+reasoning history is preserved. See `docs/decisions/README.md` for the full
+process.

--- a/docs/decisions/0001-swiftui-only-no-uikit.md
+++ b/docs/decisions/0001-swiftui-only-no-uikit.md
@@ -1,0 +1,34 @@
+# ADR-0001: SwiftUI only — no UIKit
+
+**Status:** Accepted
+**Date:** 2026-03-14
+
+## Context
+
+The app targets iOS, macOS, and visionOS from a single codebase. Choosing between
+SwiftUI and UIKit (or a hybrid) affects how much platform-specific code is needed
+and how maintainable the codebase is over time.
+
+## Decision
+
+Use SwiftUI exclusively. No UIKit imports anywhere in the app target. Platform
+differences are handled with `#if os(iOS)` / `#if os(macOS)` conditional compilation
+inside SwiftUI views.
+
+## Options Considered
+
+- **SwiftUI only (chosen):** Single declarative UI layer, works across all three
+  target platforms, no bridging overhead.
+- **UIKit + SwiftUI hybrid:** More escape hatches for complex custom controls, but
+  requires `UIViewRepresentable` bridging, complicates the visionOS story, and
+  splits the mental model.
+- **UIKit only:** Maximum control, but visionOS support is painful and the tooling
+  investment is not justified for this app's UI complexity.
+
+## Consequences
+
+- Views are `internal`; all UI stays in the SwiftUI layer.
+- Platform-specific adaptations (navigation style, sheet sizing) use
+  `#if os(iOS)` / `#if os(macOS)` guards inside SwiftUI view bodies.
+- Any future requirement for a UIKit-only control must be wrapped in a
+  `UIViewRepresentable` and justified as an exception, not a pattern.

--- a/docs/decisions/0002-swift6-compiler-settings.md
+++ b/docs/decisions/0002-swift6-compiler-settings.md
@@ -1,0 +1,44 @@
+# ADR-0002: Swift 6 compiler settings and default actor isolation
+
+**Status:** Accepted
+**Date:** 2026-03-14
+
+## Context
+
+Swift 6 introduced strict concurrency checking. The project needed a concurrency
+posture that prevents data races by default without requiring explicit annotations
+on every type.
+
+## Decision
+
+Enable the following build settings:
+
+| Flag | Value |
+|---|---|
+| `SWIFT_DEFAULT_ACTOR_ISOLATION` | `MainActor` |
+| `SWIFT_APPROACHABLE_CONCURRENCY` | `YES` |
+| `SWIFT_UPCOMING_FEATURE_MEMBER_IMPORT_VISIBILITY` | `YES` (SE-0409) |
+
+All non-isolated code defaults to `@MainActor`. All `@Observable` classes are
+explicitly annotated `@MainActor` to make the isolation intent visible rather than
+inferred (see ADR-0004). `nonisolated` is only used where specifically required
+(e.g., `Hashable` conformances, background-safe helper functions).
+
+## Options Considered
+
+- **Default MainActor isolation (chosen):** Safe by default; model types are either
+  Sendable value types or explicitly `@MainActor` classes. Reduces annotation noise.
+- **No default isolation:** Every type requires explicit actor annotation or
+  `nonisolated`. More verbose, more opportunity for omission.
+- **Strict Swift 6 without approachable concurrency:** Maximum safety but more
+  migration friction for early-stage development.
+
+## Consequences
+
+- Model types must be either Sendable value types (structs/enums — preferred for
+  catalog data) or explicitly `@MainActor @Observable` classes.
+- `nonisolated` is a deliberate exception that requires justification.
+- `Hashable` conformances on `@MainActor` types use `nonisolated` for `==` and
+  `hash(into:)` since equality and hashing must not require actor context.
+- Future Swift Package extraction of model types must account for these isolation
+  requirements.

--- a/docs/decisions/0003-catalog-runtime-model-split.md
+++ b/docs/decisions/0003-catalog-runtime-model-split.md
@@ -1,0 +1,47 @@
+# ADR-0003: Catalog vs. runtime model split
+
+**Status:** Accepted
+**Date:** 2026-03-15
+
+## Context
+
+Daggerheart data has two fundamentally different lifecycle concerns: static
+reference data (adversary and environment definitions from the SRD) and mutable
+in-session state (current HP, conditions, turn tracking). Conflating these makes
+mutations harder to reason about and complicates future persistence decisions.
+
+## Decision
+
+Split the data layer into two distinct concerns:
+
+**Catalog models** (`Adversary`, `DaggerheartEnvironment`) — immutable value types
+loaded from JSON. These are static SRD/homebrew definitions that do not change
+during a session.
+
+**Runtime models** (`EncounterSession`, `AdversarySlot`, `EnvironmentSlot`,
+`PlayerSlot`) — mutable state for a live encounter being run at the table.
+
+`Compendium` bridges the two: it loads catalog data and provides lookups so the
+session can resolve `adversaryID` slugs to full `Adversary` structs when needed.
+`EncounterDefinition` is the saved representation of encounter prep that is
+converted to a live `EncounterSession` at play time via
+`EncounterSession.start(from:using:)`.
+
+## Options Considered
+
+- **Single unified model (rejected):** One `Adversary` type carries both static
+  fields and mutable HP/stress state. Simple initially but creates mutation hazards
+  when the same catalog entry is used across multiple session slots.
+- **Catalog/runtime split (chosen):** Clean separation of concerns. Catalog data
+  can be shared safely across sessions. Runtime state is owned by the session and
+  isolated to it.
+
+## Consequences
+
+- `AdversarySlot` and `PlayerSlot` snapshot the catalog stats they need (`maxHP`,
+  `maxStress`) at creation time so the session remains self-contained even if the
+  source catalog entry is later edited or removed (homebrew orphan safety —
+  see ADR-0011).
+- `EncounterSession` is the single mutable owner of all runtime state.
+- `Compendium` is a read-only lookup service during a running session.
+- "Reset encounter" means clearing the session while keeping the definition.

--- a/docs/decisions/0004-observable-mainactor-isolation.md
+++ b/docs/decisions/0004-observable-mainactor-isolation.md
@@ -1,0 +1,47 @@
+# ADR-0004: Explicit @MainActor on @Observable classes
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+With `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` (ADR-0002), `@Observable` classes
+are implicitly `@MainActor`. However, relying on the implicit behavior makes actor
+isolation invisible — it's a build-flag detail rather than something expressed in
+the code itself. This becomes a problem when reading code in isolation, in PRs, or
+if the build flag ever changes.
+
+## Decision
+
+Explicitly annotate all `@Observable` classes with `@MainActor`:
+
+```swift
+@MainActor
+@Observable
+public final class Compendium { ... }
+
+@MainActor
+@Observable
+public final class EncounterSession: Identifiable, Hashable { ... }
+```
+
+The `OSLog` `Logger` instances inside these classes are declared `private let` (not
+`nonisolated`) since they are only accessed from the main actor context.
+
+## Options Considered
+
+- **Rely on implicit isolation (rejected):** Works today under the current build
+  flags, but the isolation intent is invisible. Any consumer of the type in a
+  different module or build configuration would see unexpected behavior.
+- **Explicit @MainActor annotation (chosen):** The type's isolation contract is
+  self-documenting. Future Swift Package extraction, code review, and agent
+  sessions all see the intent without needing to know the build settings.
+
+## Consequences
+
+- `Compendium` and `EncounterSession` are always `@MainActor`. All mutations and
+  reads must occur on the main actor.
+- Background work (JSON decoding in `Compendium.load()`) is dispatched to a
+  detached task and results are published back to the main actor.
+- `nonisolated` conformances (`Hashable`, `Equatable`, `Sendable`) on these types
+  are explicitly marked and must not capture actor-isolated state.

--- a/docs/decisions/0005-swift-testing-not-xctest.md
+++ b/docs/decisions/0005-swift-testing-not-xctest.md
@@ -1,0 +1,33 @@
+# ADR-0005: Swift Testing framework, not XCTest
+
+**Status:** Accepted
+**Date:** 2026-03-15
+
+## Context
+
+Apple ships two test frameworks: the legacy XCTest and the modern Swift Testing
+(`import Testing`). New projects can choose either or use both.
+
+## Decision
+
+Use Swift Testing exclusively (`import Testing`). No XCTest in `EncounterTests`.
+`EncounterUITests` continues to use XCUITest (which has no Swift Testing
+equivalent for UI automation).
+
+## Options Considered
+
+- **Swift Testing only (chosen):** Modern, native Swift syntax (`#expect`,
+  `@Test`, `@Suite`), better error messages, parameterized tests, integrates
+  with Xcode and `xcodebuild` natively.
+- **XCTest only:** Familiar but verbose. `setUp`/`tearDown` lifecycle is
+  heavier than Swift Testing's structured approach.
+- **Both:** Unnecessary complexity for a new project.
+
+## Consequences
+
+- All unit tests in `EncounterTests` use `import Testing`.
+- `EncounterUITests` remains XCUITest — this is correct and not an exception.
+- The two test suites are separated by the `UnitTests` / `AllTests` test plan
+  split (see ADR-0006).
+- CI and development commands must use `xcodebuild test` (which handles both
+  frameworks), not `swift test` (which does not run XCUITest).

--- a/docs/decisions/0006-unit-and-all-tests-plans.md
+++ b/docs/decisions/0006-unit-and-all-tests-plans.md
@@ -1,0 +1,52 @@
+# ADR-0006: UnitTests and AllTests test plans
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+The project has both unit tests (`EncounterTests`) and UI tests
+(`EncounterUITests`). On macOS, UI tests require unlocking the screen and
+interact with a live running app. Running UI tests on every save during
+development interrupts the iteration loop.
+
+The original `Encounter.xctestplan` had `EncounterUITests` marked
+`enabled: false` but still listed a `selectedTests` entry
+(`EncounterUITestsLaunchTests/testLaunch()`), which caused the launch test
+to still run and trigger the unlock prompt.
+
+## Decision
+
+Replace the single `Encounter.xctestplan` with two named plans:
+
+- **`UnitTests.xctestplan`** — `EncounterTests` only. No UI tests. Set as the
+  scheme default so bare `xcodebuild test` never triggers the unlock prompt.
+- **`AllTests.xctestplan`** — both `EncounterTests` and `EncounterUITests`.
+  Used before PRs and for release validation.
+
+```bash
+# Development iteration (default):
+xcodebuild test -scheme Encounter -destination 'platform=macOS' \
+  -resultBundlePath TestResults.xcresult
+
+# Pre-PR / release validation:
+xcodebuild test -scheme Encounter -destination 'platform=macOS' \
+  -testPlan AllTests -resultBundlePath TestResults.xcresult
+```
+
+## Options Considered
+
+- **`-skip-testing:EncounterUITests` flag (rejected):** Works but must be
+  remembered on every invocation. Easy to forget; not enforced for collaborators.
+- **Second scheme (rejected):** Schemes are fiddly to manage in `.xcodeproj`;
+  test plans are the modern mechanism for this.
+- **Two named test plans (chosen):** Intent is in the repo, Xcode's UI shows
+  the plans, CI can select the right plan by name.
+
+## Consequences
+
+- The old `Encounter.xctestplan` is deleted.
+- The bare `xcodebuild test` command (as documented in `CLAUDE.md`) runs unit
+  tests only with no unlock prompt.
+- UI test coverage is not skipped — it is deliberately separated into an
+  explicit workflow step.

--- a/docs/decisions/0007-encounter-store-flat-json-files.md
+++ b/docs/decisions/0007-encounter-store-flat-json-files.md
@@ -1,0 +1,51 @@
+# ADR-0007: EncounterStore — flat directory of JSON files
+
+**Status:** Accepted
+**Date:** 2026-03-15
+
+## Context
+
+`EncounterDefinition` is the saved representation of encounter prep. It needs
+to persist across app launches and, eventually, sync between devices. A
+persistence strategy is needed.
+
+## Decision
+
+Each `EncounterDefinition` is stored as an individual JSON file named
+`<UUID>.encounter.json` in a flat directory managed by `EncounterStore`.
+
+The directory resolves at startup:
+1. Check for iCloud ubiquity container availability (async).
+2. If available: `<ubiquityContainer>/Documents/Encounters/`
+3. If not: `<applicationSupport>/Encounters/`
+
+`EncounterStore` exposes `create`, `save`, `delete`, and `duplicate` operations.
+All mutating operations update both the in-memory `definitions` array and the
+on-disk file atomically. Definitions are kept sorted by `modifiedAt` descending.
+
+## Options Considered
+
+- **Single JSON file with all encounters (rejected):** Simple reads but full
+  rewrite on every save. Grows unbounded. Concurrent writes (future) would
+  require locking.
+- **SQLite / Core Data (rejected):** Heavy for what is structured JSON. Adds
+  framework dependency. Harder to inspect/debug.
+- **Flat JSON files per encounter (chosen):** Each file is self-contained,
+  independently writable, and human-readable. iCloud Drive syncs individual
+  files. No schema migrations needed for adding fields (Codable
+  `decodeIfPresent` handles missing keys).
+- **CloudKit records (rejected for v1):** More powerful but requires a
+  CloudKit container, authentication, and conflict resolution logic.
+  The ubiquity container approach gives file sync for free with no backend.
+
+## Consequences
+
+- File naming: `<UUID>.encounter.json`. The `.encounter` infix is the
+  discriminator — `EncounterStore.load()` ignores files without it.
+- `JSONEncoder` and `JSONDecoder` are created per-call (Swift 6 Sendability;
+  encoders are not safely retained across actor boundaries).
+- Dates are stored as ISO8601 Zulu strings (see ADR-0013).
+- iCloud entitlements must be added before App Store submission. During
+  development they may be disabled; the store falls back to
+  `applicationSupport` gracefully.
+- See ADR-0008 for the iCloud strategy.

--- a/docs/decisions/0008-icloud-ubiquity-not-cloudkit.md
+++ b/docs/decisions/0008-icloud-ubiquity-not-cloudkit.md
@@ -1,0 +1,43 @@
+# ADR-0008: iCloud sync via ubiquity container, not CloudKit
+
+**Status:** Accepted
+**Date:** 2026-03-15
+
+## Context
+
+Encounter definitions should sync between a GM's iPhone and Mac. Apple provides
+two sync mechanisms: iCloud Drive (ubiquity containers) and CloudKit (record API).
+
+## Decision
+
+Use iCloud Drive via `FileManager.default.url(forUbiquityContainerIdentifier:)`.
+Encounter files are stored in the ubiquity container's `Documents/Encounters/`
+directory. When iCloud is unavailable the store falls back to
+`applicationSupport` with no change to the consumer API.
+
+The directory is resolved asynchronously at startup. `EncounterStore` exposes
+a `relocate(to:)` method so the app can switch from local to iCloud storage
+after the async check completes.
+
+## Options Considered
+
+- **iCloud Drive / ubiquity container (chosen):** Files sync automatically
+  with no backend implementation. GMs can access encounter files in the Files
+  app. Human-readable JSON is inspectable and shareable outside the app.
+- **CloudKit record API (rejected for v1):** More flexible conflict resolution
+  and real-time sync, but requires a CloudKit container setup, schema definition,
+  authentication handling, and record-level conflict logic. Significant backend
+  work not justified for v1.
+- **No sync (rejected):** GM would need to manually transfer files between
+  devices. Unacceptable for a table tool.
+
+## Consequences
+
+- iCloud Documents entitlement (`com.apple.developer.ubiquity-container-identifiers`)
+  must be present in the provisioning profile for sync to work.
+- During local development without a signing identity, the store falls back to
+  `applicationSupport` — see ADR-0007.
+- CloudKit can be substituted later without changing the consumer API since
+  `EncounterStore` abstracts the directory location.
+- File conflicts (two devices editing the same encounter simultaneously) are
+  handled by iCloud's last-write-wins semantics. No merge UI needed for v1.

--- a/docs/decisions/0009-session-registry-in-memory.md
+++ b/docs/decisions/0009-session-registry-in-memory.md
@@ -1,0 +1,42 @@
+# ADR-0009: SessionRegistry — in-memory session cache
+
+**Status:** Accepted
+**Date:** 2026-03-17
+
+## Context
+
+When a GM taps "Run Encounter" from the builder, a live `EncounterSession` is
+created. If the GM navigates back to the builder and taps "Run Encounter" again,
+should they get a fresh session (losing all HP/condition progress) or resume the
+existing one?
+
+## Decision
+
+Introduce `SessionRegistry` — an `@Observable` class injected into the SwiftUI
+environment at app launch that caches live `EncounterSession` objects keyed by
+`EncounterDefinition.ID`.
+
+`session(for:definition:compendium:)` returns an existing session if one is
+cached, or creates and caches a new one. `clearSession(for:)` removes a cached
+session (explicit "start over" action).
+
+Sessions are **in-memory only**. They are lost when the app is killed.
+
+## Options Considered
+
+- **Create new session on every navigation (rejected):** Simple but loses all
+  progress. Unacceptable when a GM leaves the runner to reference a rule and
+  returns.
+- **Persist sessions to disk (deferred):** Encoding `EncounterSession` as JSON
+  would survive app restarts. Deferred because the session state graph is
+  complex and the v1 priority is correct in-session behavior.
+- **In-memory cache (chosen):** Solves the navigation-away-and-back problem
+  with minimal complexity. Acceptable limitation that kill-and-relaunch resets
+  the session.
+
+## Consequences
+
+- `EncounterSession` must conform to `Hashable` (using only `id`) so it can be
+  used as a `NavigationStack` destination value.
+- Session state is lost on app termination. GMs need to be aware of this.
+- Cross-launch session persistence is a future enhancement (noted in Known Gaps).

--- a/docs/decisions/0010-difficulty-budget-pure-namespace.md
+++ b/docs/decisions/0010-difficulty-budget-pure-namespace.md
@@ -1,0 +1,45 @@
+# ADR-0010: DifficultyBudget as a pure static namespace
+
+**Status:** Accepted
+**Date:** 2026-03-15
+
+## Context
+
+The SRD defines a Battle Points (BP) system for sizing encounters. This logic
+needs to live somewhere in the app. The question is whether it belongs as methods
+on a model type, a service object, or a standalone namespace.
+
+## Decision
+
+`DifficultyBudget` is a `public enum` with no cases — a pure static namespace.
+All functions are `static`. It holds no state and takes no dependencies.
+
+Key functions:
+- `cost(for adversaryType:)` — BP cost per adversary type
+- `baseBudget(playerCount:)` — formula: `(3 × playerCount) + 2`
+- `totalCost(for adversaryTypes:)` — sum of costs for a roster
+- `rating(adversaryTypes:playerCount:budgetAdjustment:)` — returns a `Rating`
+  struct with remaining BP and suggested adjustments
+
+Adjustments are expressed as an `Adjustment` enum with associated point values.
+Auto-detected adjustments (`multipleSolos`, `noBigThreats`) are separated from
+GM-discretionary toggles (`easierFight`, `harderFight`, `boostedDamage`,
+`lowerTierAdversary`).
+
+## Options Considered
+
+- **Methods on `EncounterDefinition` (rejected):** Adds budget logic to a type
+  whose purpose is serializable prep state. Harder to test in isolation.
+- **Methods on `Compendium` (rejected):** Budget calculation has no dependency on
+  catalog data. Wrong abstraction.
+- **Pure static namespace (chosen):** No state, no dependencies, fully testable
+  as pure functions. Can be called from any context including tests without
+  setting up an environment.
+
+## Consequences
+
+- `DifficultyBudget` functions can be called directly in tests without mocking.
+- The `DifficultyAssessorView` calls these functions directly, passing the
+  adversary type array from the current builder state.
+- Difficulty meter and adversary creation validation (future) will call the same
+  functions — no duplication needed.

--- a/docs/decisions/0011-adversary-slot-stat-snapshot.md
+++ b/docs/decisions/0011-adversary-slot-stat-snapshot.md
@@ -1,0 +1,49 @@
+# ADR-0011: AdversarySlot snapshots maxHP and maxStress at creation
+
+**Status:** Accepted
+**Date:** 2026-03-15
+
+## Context
+
+When a GM adds an adversary to a session, the slot needs to clamp HP and stress
+to the adversary's maximum values. The question is whether to look up those
+maximums from the `Compendium` at mutation time, or snapshot them when the slot
+is created.
+
+Early implementations of `applyStress` and `heal` required a `Compendium`
+parameter so they could look up the catalog maximum on each call.
+
+## Decision
+
+`AdversarySlot` snapshots `maxHP` and `maxStress` from the catalog `Adversary`
+at slot creation time. These are stored as `let` properties. Mutation methods
+(`applyStress`, `heal`) use the snapshot values — no `Compendium` parameter.
+
+```swift
+public let maxHP: Int
+public let maxStress: Int
+```
+
+The factory `AdversarySlot.from(_:customName:)` reads these from the `Adversary`
+struct at the moment the slot is added to the session.
+
+## Options Considered
+
+- **Look up from Compendium at mutation time (rejected):** Required passing
+  `Compendium` as a parameter to every mutation method. Complicates call sites.
+  Silently produces wrong results if a homebrew adversary is removed mid-session
+  (orphan returns `nil`, lookup falls back to `Int.max`).
+- **Snapshot at creation (chosen):** Slot is self-contained. Mutations are
+  simple and testable without a Compendium. Correct behavior is preserved even
+  if the source adversary is edited or deleted after the session starts.
+
+## Consequences
+
+- HP and stress clamping works correctly even for orphaned homebrew slots.
+- `AdversarySlot` can be mutated without injecting `Compendium` into every
+  call site.
+- If a GM edits an adversary's max HP mid-session, existing slots retain the
+  original value. This is intentional — sessions are snapshots of the build
+  state at start time.
+- `PlayerSlot` follows the same pattern: `maxHP`, `maxStress`, and `armorSlots`
+  are all snapshotted from `PlayerConfig` at session creation.

--- a/docs/decisions/0012-oslog-structured-logging.md
+++ b/docs/decisions/0012-oslog-structured-logging.md
@@ -1,0 +1,45 @@
+# ADR-0012: OSLog structured logging in service types
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+CLI-driven development (`xcodebuild test`) needs visibility into app behavior
+without an interactive debugger. `print()` works but produces unstructured output
+with no subsystem or category tagging. `os.Logger` provides structured output
+visible in both Console.app and terminal stderr.
+
+## Decision
+
+Add `os.Logger` instances to `Compendium` and `EncounterSession` using the app's
+bundle ID as the subsystem:
+
+```swift
+private let logger = Logger(subsystem: "gwillish.Encounter", category: "Compendium")
+private let logger = Logger(subsystem: "gwillish.Encounter", category: "EncounterSession")
+```
+
+Log levels used:
+- `.info` — load start/completion, slot defeated, round advanced
+- `.debug` — per-mutation stat changes (HP after damage, stress after apply)
+- `.warning` — slot ID not found in mutation methods
+- `.error` — load failures with error description
+
+## Options Considered
+
+- **`print()` statements (rejected):** No subsystem/category. No log level
+  filtering. Clutters output indiscriminately.
+- **Third-party logging framework (rejected):** Unnecessary dependency for
+  structured logging that the OS already provides.
+- **OSLog (chosen):** Zero overhead when not observed. Integrates with Console.app
+  for live device debugging. All output visible in `xcodebuild test` terminal via
+  stderr, which is the primary dev loop.
+
+## Consequences
+
+- Logger instances are `private let` on `@MainActor` classes — not `nonisolated`.
+- All test output including logger messages is visible in the terminal during
+  `xcodebuild test` runs (routed to stderr).
+- Future service types (`ContentStore`, `EncounterStore`) should follow the same
+  pattern with their own category names.

--- a/docs/decisions/0013-iso8601-zulu-date-storage.md
+++ b/docs/decisions/0013-iso8601-zulu-date-storage.md
@@ -1,0 +1,40 @@
+# ADR-0013: Store all dates as ISO8601 Zulu
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+`EncounterDefinition` stores `createdAt` and `modifiedAt` timestamps. Future
+types (content source metadata, session records) will also need timestamps. When
+files are shared between GMs in different time zones, synced via iCloud, or read
+after a daylight-saving transition, locally-zoned timestamps produce ambiguous
+or incorrect values.
+
+## Decision
+
+All dates stored in JSON or on disk are written in ISO8601 format with the UTC
+(Zulu) offset: `2026-03-21T15:04:00Z`. Never store local-time dates.
+
+Use `JSONEncoder.DateEncodingStrategy.iso8601` and
+`JSONDecoder.DateDecodingStrategy.iso8601` on all coders. These use UTC by
+default. When displaying dates in the UI, convert to the user's local time zone
+via `Date` formatting — but never store local time.
+
+## Options Considered
+
+- **Local time zone (rejected):** Correct for single-device use but produces
+  wrong sort order and ambiguous display when files cross time zones or DST
+  boundaries.
+- **Unix timestamp / `timeIntervalSinceReferenceDate` (rejected):** Unambiguous
+  but not human-readable in raw JSON, which matters for a transparent file format.
+- **ISO8601 Zulu (chosen):** Unambiguous, human-readable, universally parseable,
+  and the standard for interchange formats.
+
+## Consequences
+
+- All `Date` properties in `Codable` types encode/decode as ISO8601 Zulu strings.
+- In tests, construct dates from UTC references (not local `Date()` without a
+  fixed zone) to avoid flaky assertions.
+- Applies to: `EncounterDefinition.createdAt`/`modifiedAt`, future
+  `ContentSource.lastFetched`, and any other timestamps added to the project.

--- a/docs/decisions/0014-adversary-source-field.md
+++ b/docs/decisions/0014-adversary-source-field.md
@@ -1,0 +1,57 @@
+# ADR-0014: Adversary identity — slug ID with source field
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+Adversaries from the SRD, from downloaded community packs, and from user-created
+homebrew all need to coexist in the `Compendium`. The question is how to identify
+them uniquely and how to handle cases where a homebrew entry intentionally replaces
+an SRD entry with the same conceptual identity.
+
+Three options were considered:
+
+- **A:** Keep bare slug `id`, add a `source: String` field
+- **B:** Composite key `(source, id)` — no implicit shadowing
+- **C:** Keep bare slug, add explicit `overrides: String?` field
+
+## Decision
+
+**Option A:** The `id` field remains a bare slug string (e.g., `"ironguard-bandit"`)
+for upstream JSON compatibility with the seansbox/daggerheart-srd format. A
+`source: String` field is added to every `Adversary` to identify its origin.
+
+Well-known source values:
+- `"srd"` — bundled SRD content (default when decoding JSON without this field)
+- `"homebrew"` — user-created adversaries
+- A URL slug or UUID string for downloaded content packs
+
+`Compendium` maintains separate `srdAdversariesByID` and
+`homebrewAdversariesByID` dictionaries. The merged `adversariesByID` computed
+property applies homebrew entries over SRD entries when IDs collide. When a
+collision occurs it is treated as an **explicit override** and surfaced to the GM
+(warning on creation, visible badge or label in the UI).
+
+## Options Considered
+
+- **Option A — source field (chosen):** Backward-compatible with upstream JSON
+  (decoded as optional with default `"srd"`). Enables source-based filtering.
+  Override semantics are implicit (same slug) but surfaced explicitly in the UI.
+- **Option B — composite key (rejected):** More precise but breaks compatibility
+  with existing JSON format and all encounter definitions that store adversary IDs.
+  Adds lookup complexity everywhere.
+- **Option C — `overrides` field (deferred):** Useful when GMs create modified
+  versions of SRD creatures, but most valuable in the adversary creation flow.
+  Can be added later without breaking existing data.
+
+## Consequences
+
+- `source` decodes as optional with default `"srd"` — all existing JSON is
+  compatible without modification.
+- When a non-SRD adversary shares an `id` with an SRD entry, the compendium
+  treats it as an override and can expose `overriddenSRDEntries` for UI warnings.
+- Compendium filtering by source is architecturally supported; the UI can expose
+  it without data model changes.
+- The `overrides` field from Option C remains available as a future addition for
+  the adversary creation flow.

--- a/docs/decisions/0015-writable-content-directory.md
+++ b/docs/decisions/0015-writable-content-directory.md
@@ -1,0 +1,59 @@
+# ADR-0015: Writable directory for all persistent content
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+The app bundles SRD JSON in its resources, but bundle resources are read-only at
+runtime. GMs need to download SRD updates (to get corrections or new content
+without waiting for an App Store release) and add community content packs. These
+all require a writable storage location.
+
+## Decision
+
+All persistent content data lives in a writable app-specific directory under
+`Application Support/Encounter/`:
+
+```
+Application Support/Encounter/
+├── srd/
+│   ├── adversaries.json       ← SRD content (seeded from bundle on first launch)
+│   └── environments.json
+├── sources/
+│   ├── <uuid>.meta.json       ← source metadata: name, url, lastFetched, contentHash
+│   ├── <uuid>-adversaries.json
+│   └── <uuid>-environments.json
+└── homebrew/
+    ├── adversaries.json       ← user-created adversaries (future)
+    └── environments.json
+```
+
+**First launch:** Bundle JSON is copied into `srd/`. Subsequent launches read
+from the writable directory only. The bundle serves as the installation-time seed
+and read-only fallback.
+
+**Load priority** (highest wins on ID collision):
+homebrew → sources → srd/ → bundled fallback
+
+## Options Considered
+
+- **Read from bundle always, write overrides alongside (rejected):** Requires
+  complex merge logic to reconcile bundle vs. override files. Bundle updates via
+  App Store would conflict with downloaded overrides.
+- **On-demand resources (rejected):** Adds App Store submission complexity.
+  Designed for large asset bundles, not frequently updated JSON text files.
+- **Writable directory (chosen):** Simple mental model. GM has full control.
+  Offline-capable. SRD errors can be corrected by URL download without waiting
+  for an App Store update cycle.
+
+## Consequences
+
+- A new `ContentStore` service owns the writable directory and the source
+  registry. `Compendium` remains the in-memory merged view and lookup service.
+- `EncounterStore` (encounter definitions) uses a separate path
+  (`Documents/Encounters/`) — not mixed with content data.
+- Dates in source metadata (`lastFetched`) are stored as ISO8601 Zulu
+  (see ADR-0013).
+- See ADR-0016 for the `.dhpack` file format used to import content packs.
+- See ADR-0017 for the URL fetch and CDN strategy.

--- a/docs/decisions/0016-dhpack-uti-file-type.md
+++ b/docs/decisions/0016-dhpack-uti-file-type.md
@@ -1,0 +1,71 @@
+# ADR-0016: .dhpack custom file type with public.json UTI conformance
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+Community adversary packs need to be transferable between GMs via AirDrop,
+Messages, email, and the Files app. This requires registering a custom file type
+with the OS so the system knows Encounter is the handler.
+
+## Decision
+
+Register a custom file type with extension `.dhpack` and UTI
+`gwillish.Encounter.dhpack`. A `.dhpack` file is a JSON file in the
+seansbox/daggerheart-srd format — just renamed. It can contain adversaries,
+environments, or both.
+
+**UTI conformance chain:**
+```
+gwillish.Encounter.dhpack → public.json → public.text → public.data → public.item
+```
+
+Conforming to `public.json` (not just `public.data`) means the system recognizes
+the file as JSON content — text editors can open it, Quick Look can preview it,
+and JSON-aware apps understand it.
+
+**Swift declaration:**
+```swift
+extension UTType {
+    static let dhpack = UTType(exportedAs: "gwillish.Encounter.dhpack",
+                               conformingTo: .json)
+}
+```
+
+`static let` (not `var`) is correct for an exported type — the value is stable
+for the app's lifetime since the app declares it in `Info.plist`. Computed
+properties are appropriate for *imported* types (owned by other apps) where the
+system registration can change at runtime.
+
+**Info.plist keys required:**
+- `UTExportedTypeDeclarations` — declares ownership of the type
+- `CFBundleDocumentTypes` — registers the app as a handler
+
+**Import handling:** `onOpenURL` + `.fileImporter` in `EncounterApp`, not
+`DocumentGroup`. The app is not document-centric; files are imported into the
+content source registry rather than being the primary unit of work.
+
+**Export:** `ShareLink` with `FileRepresentation(contentType: .dhpack)` via the
+`Transferable` protocol.
+
+## Options Considered
+
+- **Conform to `public.data` only (rejected):** Works for basic file handling
+  but misses Quick Look integration and JSON-aware app compatibility.
+- **Conform to `public.json` (chosen):** Better system integration, no downside.
+- **Plain `.json` extension (rejected):** No app-specific type registration.
+  System cannot distinguish a `.dhpack` from any other JSON file; AirDrop won't
+  offer Encounter as the handler.
+- **`DocumentGroup` for import (rejected):** Forces a document lifecycle that
+  conflicts with the content-source-registry architecture.
+
+## Consequences
+
+- iOS and macOS share the same UTI since they share the bundle ID
+  `gwillish.Encounter`. No cross-platform conflict.
+- `.dhpack` files airdropped or emailed to a device with Encounter installed
+  open directly in the app.
+- Content validation (checking the JSON is a valid adversary pack) happens in
+  the `DataRepresentation` import handler using `JSONDecoder` + schema checks,
+  throwing `LocalizedError` for user-facing error messages.

--- a/docs/decisions/0017-jsdelivr-version-pinned-urls.md
+++ b/docs/decisions/0017-jsdelivr-version-pinned-urls.md
@@ -1,0 +1,70 @@
+# ADR-0017: jsDelivr CDN with version-pinned URLs for SRD content
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+SRD JSON content (and community packs) needs a reliable hosting URL that GMs can
+register as a source. The obvious starting point is GitHub, but raw GitHub URLs
+have significant limitations in production use.
+
+## Decision
+
+Use **jsDelivr** as the CDN layer over GitHub content:
+
+```
+https://cdn.jsdelivr.net/gh/{owner}/{repo}@{tag}/{path}
+```
+
+Example:
+```
+https://cdn.jsdelivr.net/gh/seansbox/daggerheart-srd@v1.2.0/adversaries.json
+```
+
+Always use **version-pinned URLs** (a git tag or commit hash). Never use `@main`
+or `@latest`.
+
+### Why version-pinned
+
+jsDelivr permanently caches all served files in S3 storage. Cache purges exist
+but are documented as frequently unreliable. Version-pinned URLs make this
+behavior a feature: each version's URL is stable and cached forever. When SRD
+content updates, a new tag is published and the URL changes. GMs explicitly
+choose when to update a source — their cached content never changes unexpectedly.
+
+### Why jsDelivr over raw.githubusercontent.com
+
+- `raw.githubusercontent.com` ignores authentication headers entirely. Rate
+  limits are IP-based and opaque (~5,000 req/hr unauthenticated, but GitHub
+  discourages production use of raw URLs.
+- jsDelivr provides global CDN distribution (Cloudflare + Fastly), better
+  uptime, and documented (if imperfect) cache management.
+
+### Privacy note
+
+All requests through jsDelivr are visible to jsDelivr, Cloudflare, and Fastly
+(IP address and user agent logged; no cookies). For community game content this
+is acceptable. The app should note in its settings that source refreshes make
+network requests.
+
+## Options Considered
+
+- **raw.githubusercontent.com (rejected):** GitHub discourages production use.
+  Auth headers ignored. Rate limits opaque. No CDN.
+- **GitHub REST API (rejected):** Proper auth and rate-limit headers, but returns
+  base64-encoded content, requires parsing, and is rate-limited at 60 req/hr
+  unauthenticated (5,000 with token). Unnecessary complexity for infrequent pulls.
+- **GitHub Pages / Cloudflare Pages (alternative):** More control over caching
+  and invalidation. Valid if a source author wants full control. The app should
+  accept any valid HTTPS URL, not require jsDelivr specifically.
+- **jsDelivr (chosen as recommended default):** Reliable, no auth required,
+  global CDN, version-pinned URLs make permanent caching a feature.
+
+## Consequences
+
+- Source URLs registered in the app should prefer tagged/commit-hash URLs.
+- The UI should warn if a user registers an `@latest` or `@main` URL.
+- The app accepts any valid HTTPS JSON URL — jsDelivr is the recommended
+  pattern for GitHub-hosted content, not a hard requirement.
+- See ADR-0018 for the user-initiated fetch strategy.

--- a/docs/decisions/0018-user-initiated-content-refresh.md
+++ b/docs/decisions/0018-user-initiated-content-refresh.md
@@ -1,0 +1,43 @@
+# ADR-0018: User-initiated content refresh — no background fetch
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+Content source packs (SRD updates, community adversary packs) need to be
+refreshed when new versions are available. iOS provides background fetch
+mechanisms, but automatic updates carry significant risks for a table tool.
+
+## Decision
+
+Content source updates are **user-initiated only**. There is no automatic
+background fetch. GMs explicitly tap "Refresh" on a source to check for and
+download updates.
+
+Sources are cached locally on first download. The cached content is what the
+app uses — a GM's adversary list never changes unexpectedly during a session.
+
+`URLSession` with a background configuration is used for the actual download so
+the transfer continues reliably if the app is backgrounded during a large pull.
+
+## Options Considered
+
+- **Background fetch (rejected):** System-scheduled, ~30-second window, fires
+  at unpredictable times. Content could change between when a GM reviews an
+  encounter before the game and when they sit down to run it. Unacceptable for
+  a table tool.
+- **Automatic refresh at launch (rejected):** Same problem — a GM who opens the
+  app at the table could see their adversary list change as sources pull.
+- **User-initiated refresh (chosen):** GM is in full control of when content
+  updates. No surprises during a session. Explicit refresh also makes the
+  network request transparent, which is appropriate given jsDelivr's IP logging
+  (see ADR-0017).
+
+## Consequences
+
+- The `ContentStore` source list shows each source's `lastFetched` date so GMs
+  know how stale their cache is.
+- Refreshing a source during an active session has no effect on the running
+  `EncounterSession` — the session's adversary slots are snapshots (see ADR-0011).
+- Dates are stored as ISO8601 Zulu (see ADR-0013).

--- a/docs/decisions/0019-macos-split-view-ios-stack.md
+++ b/docs/decisions/0019-macos-split-view-ios-stack.md
@@ -1,0 +1,43 @@
+# ADR-0019: macOS NavigationSplitView, iOS NavigationStack
+
+**Status:** Accepted
+**Date:** 2026-03-17
+
+## Context
+
+The app targets both iPhone and Mac. The initial implementation used
+`NavigationStack` on all platforms (push-based navigation). On macOS this
+produced a narrow column experience that didn't make good use of the wider
+screen, and the detail pane showed blank when no encounter was selected.
+
+## Decision
+
+`ContentView` owns a `selection: EncounterDefinition.ID?` state variable and
+renders the appropriate navigation container per platform:
+
+- **macOS:** `NavigationSplitView` with library list in the sidebar and encounter
+  builder in the detail column. `EncounterLibraryList` uses plain tappable rows
+  (no `NavigationLink`) that update the selection binding.
+- **iOS:** `NavigationStack` with push-based navigation. `EncounterLibraryList`
+  uses `NavigationLink` + `.navigationDestination` for standard push behavior.
+
+A `ProgressView` is shown in the library while `store.isLoading` is true,
+eliminating the blank-state flash on first load.
+
+## Options Considered
+
+- **NavigationStack on all platforms (rejected):** Works on iOS but wastes Mac
+  screen real estate. The builder and runner feel cramped in a single column.
+- **NavigationSplitView on all platforms (rejected):** Awkward on iPhone — the
+  sidebar/detail model doesn't translate well to a small screen.
+- **Platform-adaptive split (chosen):** Each platform gets the navigation
+  pattern its users expect. Code is conditionally compiled with `#if os(macOS)`.
+
+## Consequences
+
+- `ContentView` is the single owner of `selection` state on macOS; detail pane
+  visibility is driven by this binding.
+- iOS and macOS share the same model layer and most view components; only the
+  navigation container and library list interaction differ.
+- The runner (`EncounterRunnerView`) is presented via `navigationDestination`
+  on iOS and as a detail column or sheet on macOS.

--- a/docs/decisions/0020-naming-access-control-conventions.md
+++ b/docs/decisions/0020-naming-access-control-conventions.md
@@ -1,0 +1,50 @@
+# ADR-0020: Naming, access control, and domain language conventions
+
+**Status:** Accepted
+**Date:** 2026-03-15
+
+## Context
+
+A consistent set of naming and access control conventions prevents drift across
+a growing codebase and makes the code easier to read alongside the Daggerheart
+SRD, which uses specific game terminology.
+
+## Decision
+
+**File naming:** One primary type per file; filename matches the type name.
+Exception: `EncounterSession.swift` contains `AdversarySlot`, `EnvironmentSlot`,
+and `PlayerSlot` as closely related supporting types.
+
+**Access control:**
+- `public` on all model types and their properties. This anticipates potential
+  future extraction as a Swift Package.
+- Views are `internal` (default). View types are not intended for external use.
+
+**No force-unwrap:** Model and view code uses `guard let` or optional chaining.
+Force-unwrap is never acceptable in non-test code.
+
+**Domain language:** Use Daggerheart game terms as-is in code. Do not rename to
+generic equivalents:
+- `hp` not `health` or `hitPoints`
+- `stress` not `exhaustion`
+- `fear` / `hope` not `resource` or `currency`
+- `difficulty` / `thresholds` not `armorClass` / `damageResistance`
+- `evasion` not `defense`
+
+## Options Considered
+
+- **Generic naming (rejected):** `health`, `defense`, etc. are more familiar to
+  developers from other game contexts, but create a translation layer between the
+  SRD and the code. A GM reading the code alongside the rulebook should see the
+  same terms in both places.
+- **Daggerheart terms (chosen):** Zero translation overhead. The SRD is the
+  source of truth; the code speaks the same language.
+
+## Consequences
+
+- `internal` access on views means the view layer is not a public API boundary.
+  This is correct — views are implementation details.
+- `public` model types allow tests in `EncounterTests` to access all properties
+  directly without `@testable import`.
+- Any deviation from these conventions (force-unwrap, UIKit import, generic
+  naming) should be flagged in code review as a convention violation.

--- a/docs/decisions/0021-daggerheart-spotlight-not-initiative.md
+++ b/docs/decisions/0021-daggerheart-spotlight-not-initiative.md
@@ -1,0 +1,46 @@
+# ADR-0021: Daggerheart uses spotlight, not initiative order
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+Many tabletop RPGs (D&D 5e, Pathfinder) use an initiative track: a numbered
+sequence that determines exactly whose turn comes next. The original Encounter app
+architecture included `turnOrder: [UUID]` and `advanceTurn()` on `EncounterSession`,
+modelled on this assumption.
+
+Daggerheart uses a different model entirely.
+
+## Decision
+
+Daggerheart uses a **spotlight** model, not initiative order:
+
+- The GM spends Fear to take an adversary action. This is a GM resource decision,
+  not a fixed sequence.
+- After an adversary acts, the spotlight passes to the **players as a group** —
+  any player can act, not a specific one.
+- Players pass the spotlight back to the GM (or the GM spends Fear to interrupt).
+- There is no numbered turn order. "Whose turn is it?" is always: GM or players.
+
+The runner UI should reflect this binary spotlight (GM side / Player side), not
+a sequential initiative track.
+
+## Options Considered
+
+- **Traditional turn order UI (rejected):** Misrepresents the game mechanics.
+  Would confuse GMs familiar with Daggerheart and require tracking data the game
+  doesn't use.
+- **GM/Player spotlight toggle (correct model):** The runner needs to communicate
+  whether it is currently the GM's action opportunity or the players'.
+
+## Consequences
+
+- `turnOrder: [UUID]` and `advanceTurn()` on `EncounterSession` reflect an
+  incorrect assumption about the game. These should be reconsidered or removed
+  when the runner UI is next revisited.
+- The runner does not need a "Next Turn" button cycling through individual combatants.
+- Fear pool management (ADR-0023) is the GM's primary action economy mechanism
+  and should be prominently surfaced in the runner.
+- The `currentRound` counter remains valid — rounds are a real concept in
+  Daggerheart even without fixed turn order.

--- a/docs/decisions/0022-encounter-runner-ux.md
+++ b/docs/decisions/0022-encounter-runner-ux.md
@@ -1,0 +1,57 @@
+# ADR-0022: Encounter runner UX — accordion cards, player strip, fear tracker
+
+**Status:** Accepted
+**Date:** 2026-03-17
+
+## Context
+
+The live encounter runner needs to surface a lot of information (multiple
+adversaries with HP/stress/conditions, all players, the Fear pool) while keeping
+the GM's hands free for the table. The layout must prioritize the most common
+mid-combat actions.
+
+## Decision
+
+**Adversary cards — accordion expansion:**
+Only one adversary card is expanded at a time. The collapsed state shows the
+adversary name and a HP pip track. Expanding reveals damage threshold buttons
+(Minor / Major / Severe → 1/2/3 HP removed), a +Stress button, condition toggles
+(Hidden, Restrained, Vulnerable), and a stat reference section. Defeated adversaries
+sort to the bottom at 40% opacity — still visible for reference, not in the way.
+
+Damage is applied via threshold buttons rather than a numeric entry field.
+The GM picks the threshold based on the roll result; the app applies the correct
+mark count. Numeric damage input is deferred to a future iteration.
+
+**Player strip — always visible:**
+Pinned to the bottom of the screen via `.safeAreaInset(edge: .bottom)`. Shows all
+players simultaneously — name, HP pips, stress pips, armor slots remaining. Tapping
+a player row opens a popover with stepper controls for HP, Stress, and Armor.
+
+The strip is always visible regardless of which adversary card is open. GMs need
+to update player state at any moment, not only when a player's "turn" is active
+(Daggerheart has no individual player turns — see ADR-0021).
+
+**Fear tracker — nav bar popover:**
+A persistent flame icon + count in the trailing navigation bar position. Tapping
+opens a compact popover with one-tap spend amounts (+1, −1, −2, −3 Fear). Always
+accessible at zero scroll cost.
+
+## Options Considered
+
+- **Inline +/− controls per player in the strip (rejected):** Too narrow for
+  three stats (HP, Stress, Armor). A popover accommodates all three without
+  crowding.
+- **Dedicated Fear screen (rejected):** Full screen for a single counter is
+  wasteful. A popover from the persistent nav bar button is sufficient.
+- **All adversary cards expanded simultaneously (rejected):** Too much information
+  at once. The accordion keeps focus on the active adversary.
+
+## Consequences
+
+- `PipTrack` is a reusable component used for HP, Stress, and Armor pips
+  throughout the runner. Falls back to a text counter above 10 pips.
+- The accordion state (which card is expanded) is local view state, not session
+  state — it resets if the GM navigates away.
+- The player popover stepper pattern should be consistent for any future
+  player-tracking additions (conditions, Hope, etc.).

--- a/docs/decisions/0023-difficulty-budget-color-thresholds.md
+++ b/docs/decisions/0023-difficulty-budget-color-thresholds.md
@@ -1,0 +1,56 @@
+# ADR-0023: Difficulty budget color thresholds and adjustment model
+
+**Status:** Accepted
+**Date:** 2026-03-16
+
+## Context
+
+The SRD's Battle Points system provides a numerical budget for sizing encounters.
+The `DifficultyAssessorView` needs to communicate how the current roster sits
+relative to that budget in a way that is immediately readable at a glance.
+
+## Decision
+
+**Color thresholds** (remaining BP after cost vs. budget):
+
+| Remaining BP | Color | Label |
+|---|---|---|
+| ≥ 4 | Teal | Too Easy |
+| 1–3 | Green | Well Matched |
+| 0 | Green | Exactly on Budget |
+| −1 to −3 | Amber | Challenging |
+| −4 to −6 | Red | Dangerous |
+| ≤ −7 | Pulsing red | Likely TPK |
+
+**Adjustment model:**
+
+Auto-detected (read-only labels, based on roster composition):
+- `multipleSolos` (2+ Solo types) → −2 BP (SRD rule)
+- `noBigThreats` (no Bruiser/Horde/Leader/Solo) → +2 BP (SRD rule)
+
+GM-discretionary toggles (4 options the GM enables manually):
+- `easierFight` → −1 BP
+- `harderFight` → +2 BP
+- `boostedDamage` → −2 BP
+- `lowerTierAdversary` → +1 BP
+
+The assessor is always visible at the bottom of the builder via `.safeAreaInset`.
+
+## Options Considered
+
+- **Binary safe/unsafe indicator (rejected):** Too coarse. GMs often intentionally
+  build challenging or easy encounters. A gradient gives nuance.
+- **Numeric only, no color (rejected):** Numbers alone require the GM to know the
+  thresholds mentally. Color communicates the assessment at a glance.
+- **Pulsing animation at all danger levels (rejected):** Alarm fatigue. Reserve
+  animation for the most severe case (likely TPK) only.
+
+## Consequences
+
+- Small overspend (−1 to −3) is amber, not red — intentional challenge design
+  should not feel like an error.
+- Large overspend (≤ −7) uses animation to flag genuine danger without the GM
+  having to read numbers.
+- The difficulty meter and assessor design are deferred to the adversary creation
+  session (see ADR-0025) for refinement. Current thresholds may be adjusted
+  based on playtesting feedback.

--- a/docs/decisions/0024-srd-json-format-seansbox.md
+++ b/docs/decisions/0024-srd-json-format-seansbox.md
@@ -1,0 +1,48 @@
+# ADR-0024: SRD JSON data format — seansbox/daggerheart-srd
+
+**Status:** Accepted
+**Date:** 2026-03-15
+
+## Context
+
+Daggerheart SRD content needs to be represented in a structured, machine-readable
+format. Multiple community projects have produced JSON exports of the SRD, but
+they use different schemas.
+
+## Decision
+
+Use the **seansbox/daggerheart-srd** JSON format as the canonical data format for
+adversaries and environments. This is the format used by the bundled
+`adversaries.json` and `environments.json`, and all downloaded content packs
+(`.dhpack` files) use this format.
+
+The decoder handles two threshold formats produced by different SRD export
+versions:
+- Combined string: `"thresholds": "8/15"`
+- Pre-split keys: `"threshold_major": 8, "threshold_severe": 15`
+
+The decoder also normalizes adversary type variants (e.g., `"Horde (N/HP)"` →
+`.horde`) and handles `"None"` threshold values for adversary types that have no
+damage thresholds (e.g., Minions).
+
+## Options Considered
+
+- **daggersearch/daggerheart-data format (rejected for adversaries):** This repo
+  focuses on player content (classes, ancestries, items). It does not include
+  adversaries and uses a different schema.
+- **Custom schema (rejected):** Designing and maintaining a proprietary schema
+  would fragment the community tooling ecosystem. Using the community-standard
+  format means GMs can author content with existing tools.
+- **seansbox format (chosen):** Widest community adoption. The most complete
+  adversary dataset available. Existing community tooling targets this format.
+
+## Consequences
+
+- All content packs (`.dhpack` files) must conform to the seansbox schema.
+  The `Adversary` and `DaggerheartEnvironment` decoders validate on import.
+- The `source` field (ADR-0014) is an extension to this format — it decodes
+  as optional with a default of `"srd"` to maintain backward compatibility.
+- Future schema additions (e.g., an `overrides` field for homebrew) should
+  follow the same optional-with-default pattern.
+- `SRDDecodeTests` verify that all bundled adversaries and environments decode
+  without error after any decoder changes.

--- a/docs/decisions/0025-adversary-creator-difficulty-meter-deferred.md
+++ b/docs/decisions/0025-adversary-creator-difficulty-meter-deferred.md
@@ -1,0 +1,54 @@
+# ADR-0025: Adversary creator and difficulty meter — deferred to dedicated session
+
+**Status:** Accepted
+**Date:** 2026-03-21
+
+## Context
+
+GMs need to create custom adversaries for their campaigns. The adversary creation
+flow requires power-level validation (does this adversary's stats fit the expected
+range for its tier and type?) and a visual difficulty meter that integrates
+validation feedback. These features are design-intensive and closely coupled.
+
+## Decision
+
+Both features are deferred to a single dedicated design-and-build session. They
+are not in scope for the current iteration.
+
+Draft design notes (to be refined in that session):
+
+**Adversary creation flow (proposed):**
+1. Identity step — name, type, tier; selecting these surfaces an "expected stat
+   ranges" reference panel pulled from SRD adversaries of the same type/tier
+2. Stats step — HP, Stress, Difficulty, Thresholds, Attack modifier; inline range
+   indicators per field (colored bar or label: within range / above average /
+   outlier); soft guidance only, not blocking
+3. Attack & Features step — attack name, range, damage string; feature list
+   (add action/reaction/passive with name and text)
+4. Review — full stat card preview as it appears in Compendium; summary of any
+   out-of-range stats
+
+**Difficulty meter (proposed):**
+- Horizontal gradient bar (green → yellow → orange → red) with a fill that moves
+  based on total BP vs. budget
+- Collapsed meter always visible at bottom of builder; tap to expand full
+  breakdown showing per-adversary BP cost
+- Integrated with adversary creation to validate new adversaries against
+  tier expectations
+
+**Power validation options (to decide in that session):**
+- Inline range bars next to numeric fields (preferred)
+- Summary warnings at review step
+- "Similar adversaries" reference panel (2–3 SRD adversaries of the same type/tier)
+
+**Open question:** Where do created adversaries live — auto to a "My Adversaries"
+source, or prompt the GM to select a source?
+
+## Consequences
+
+- No adversary creation UI is built until the dedicated session.
+- `DifficultyBudget` pure functions (ADR-0010) are already in place; the meter
+  visual layer builds on top of them.
+- The current `DifficultyAssessorView` color threshold design (ADR-0023) may
+  be revised during the dedicated session based on how the meter and creator
+  interact.

--- a/docs/decisions/README.md
+++ b/docs/decisions/README.md
@@ -1,0 +1,96 @@
+# Architecture Decision Records
+
+This directory contains Architecture Decision Records (ADRs) for the Encounter
+project. Each file captures one significant decision: the context that made it
+necessary, what was decided, the alternatives considered, and the consequences.
+
+## File naming
+
+```
+NNNN-short-title.md
+```
+
+Numbers are zero-padded to four digits and assigned sequentially. The title is a
+short lowercase slug describing the decision.
+
+## Statuses
+
+| Status | Meaning |
+|---|---|
+| **Proposed** | Under active exploration; not yet settled |
+| **Accepted** | Decided and currently in effect |
+| **Rejected** | Explored but not implemented; findings recorded to prevent re-exploring the same dead end |
+| **Deprecated** | No longer applies; no direct replacement |
+| **Superseded by [ADR-NNNN](NNNN-title.md)** | A later decision replaced this one |
+
+## Branch explorations
+
+An ADR on a feature branch may start as `Proposed` while the approach is being
+explored. When the branch concludes:
+
+- **Branch merges:** update the ADR status to `Accepted` (or `Rejected` if the
+  exploration ruled something out).
+- **Branch is discarded, findings matter:** cherry-pick just the ADR file to
+  `main` with status `Rejected` and a brief findings section before deleting the
+  branch. The dead end is now documented so no one re-explores it.
+- **Branch is discarded, nothing worth preserving:** don't bring the ADR to
+  `main`. Small or fast explorations don't need a permanent record.
+
+## Template
+
+```markdown
+# ADR-NNNN: Title
+
+**Status:** Accepted
+**Date:** YYYY-MM-DD
+
+## Context
+
+Why this decision was needed. What problem or constraint prompted it.
+
+## Decision
+
+What was decided, stated plainly.
+
+## Options Considered
+
+- **Option A (chosen):** description — chosen because ...
+- **Option B:** description — rejected because ...
+
+## Consequences
+
+What this decision means going forward. Trade-offs accepted. Things that become
+easier or harder as a result.
+```
+
+## Superseded / Mistake Process
+
+**Never edit or delete an existing ADR.** If a decision was wrong, incomplete,
+or needs to change direction:
+
+1. Write a **new ADR** with the next available number. Open its Context section
+   with: _"This supersedes [ADR-NNNN](NNNN-title.md)."_ Explain what changed,
+   why the original decision was wrong or no longer applies, and what the new
+   direction is.
+
+2. Update the **original ADR's status line only** to:
+   `Superseded by [ADR-NNNN](NNNN-title.md)`
+
+3. Leave the original ADR's content completely intact below the status line.
+
+The result is a navigable chain: reading the original shows the first reasoning;
+the status line points to the correction; reading the new ADR explains why the
+change was made. Future agents and developers can follow the full arc of any
+decision without guesswork.
+
+## When to write an ADR
+
+Write one when:
+
+- Choosing between meaningfully different architectural approaches
+- Establishing a project-wide convention (naming, data formats, date handling)
+- Making a UX or product decision that constrains future work
+- Deciding explicitly *not* to do something that might otherwise seem obvious
+
+Do not write one for routine implementation details that can be changed without
+downstream impact.


### PR DESCRIPTION
## Summary

- Adds `README.md` at the project root with project overview and ADR reference
- Adds `docs/decisions/README.md` defining the ADR format, lifecycle statuses (Proposed / Accepted / Rejected / Deprecated / Superseded), and the branch exploration workflow
- Adds `docs/decisions/` with 25 historical ADRs reconstructed from git history, PR descriptions, commit messages, and session memory
- Updates `CLAUDE.md`: ADR section with status table, superseded process, branch workflow convention; trimmed all resolved `[x]` gap items; updated project tree

## ADRs included (0001–0025)

Covers: SwiftUI-only, Swift 6 compiler settings, catalog/runtime split, @MainActor isolation, Swift Testing, test plans, EncounterStore persistence, iCloud strategy, SessionRegistry, DifficultyBudget, AdversarySlot snapshots, OSLog, ISO8601 Zulu dates, adversary source field, writable content directory, .dhpack UTI, jsDelivr CDN, user-initiated refresh, macOS split-view nav, naming conventions, Daggerheart spotlight model, encounter runner UX, difficulty budget thresholds, SRD JSON format, and deferred adversary creator.

## Test plan

- [x] `xcodebuild test` passes (no code changes — documentation only)