### PR TITLE
Add DocC catalog, .dhpack articles, and JSON Schema

### DIFF
--- a/Encounter/Encounter.docc/Articles/AuthoringAPack.md
+++ b/Encounter/Encounter.docc/Articles/AuthoringAPack.md
@@ -1,0 +1,131 @@
+# Authoring a Content Pack
+
+Create your own adversaries and environments for Encounter.
+
+## Overview
+
+A `.dhpack` file is plain JSON — you can create one in any text editor, export one from
+within the app, or generate one programmatically. This article walks through all three
+paths.
+
+For the complete field-by-field reference, see <doc:DHPackFormat>.
+
+## Path 1: Write it in a text editor
+
+This is the most direct approach and works on any platform.
+
+### 1. Create a new JSON file
+
+Open any text editor (TextEdit, VS Code, BBEdit, Zed — anything that can save plain
+text) and start with the pack wrapper:
+
+```json
+{
+  "adversaries": [],
+  "environments": []
+}
+```
+
+### 2. Add adversaries
+
+Fill in the `adversaries` array. Every adversary needs at minimum: `name`, `tier`,
+`type`, `description`, `difficulty`, a threshold (via `thresholds` or the split keys),
+`hp`, `stress`, `atk`, `attack`, `range`, and `damage`.
+
+```json
+{
+  "adversaries": [
+    {
+      "name": "Ashwalker",
+      "tier": 1,
+      "type": "Standard",
+      "description": "Hollow-eyed wanderers from the Ashen Wastes, drawn to heat and sound.",
+      "motives_and_tactics": "Slowly encircles prey; attacks when it outnumbers a target.",
+      "difficulty": 11,
+      "thresholds": "5/12",
+      "hp": 5,
+      "stress": 3,
+      "atk": "+2",
+      "attack": "Cinder Claws",
+      "range": "Melee",
+      "damage": "1d8+1 phy",
+      "feature": [
+        {
+          "name": "Ash Cloud - Reaction",
+          "text": "When the Ashwalker takes a Major hit, it releases a cloud of ash. All creatures within Very Close range must make a Difficulty 11 Agility roll or be Blinded until the end of their next turn.",
+          "feat_type": "reaction"
+        }
+      ]
+    }
+  ]
+}
+```
+
+### 3. Validate your JSON
+
+Before saving as `.dhpack`, confirm the JSON is well-formed:
+
+```bash
+# Built-in on macOS and Linux:
+python3 -m json.tool my-pack.json
+```
+
+A clean file prints the formatted JSON. An error prints the line number and problem.
+
+If you use VS Code, add a `$schema` field to enable inline validation and
+autocomplete:
+
+```json
+{
+  "$schema": "https://gwillish.github.io/encounter/schemas/dhpack.schema.json",
+  "adversaries": [ ... ]
+}
+```
+
+### 4. Save as .dhpack
+
+Rename or save the file with a `.dhpack` extension, e.g. `ashen-wastes.dhpack`.
+
+> On macOS, if the Finder warns you about changing the extension, click **Use .dhpack**.
+
+### 5. Test the import
+
+Send the file to a device with Encounter installed (AirDrop is the fastest) and open
+it. If the import succeeds, your adversaries appear in the Compendium. If an error
+banner appears, check the JSON for missing required fields.
+
+## Path 2: Export from within the app (coming in a future release)
+
+Encounter will support building and exporting packs directly from homebrew adversaries
+you've created in the app — tracked in [issue #21](https://github.com/gwillish/encounter/issues/21).
+
+Once available, the flow will look something like this:
+
+1. Add adversaries to the Compendium using the in-app creator.
+2. Select the adversaries you want to export (multi-select or select all homebrew).
+3. Tap **Export Pack** and name the file.
+4. The system share sheet appears — AirDrop it, save to Files, or share however you like.
+
+This is the lowest-friction path for GMs who don't want to hand-edit JSON.
+
+## Path 3: Generate programmatically
+
+If you're building a tool or converting content from another system, construct the
+JSON structure using any language that can serialize JSON and write the output with a
+`.dhpack` extension.
+
+The field names are stable (see <doc:DHPackFormat>), and the format accepts numeric
+strings for `tier`, `difficulty`, `hp`, and `stress` — so loose-typed sources can
+be passed through without coercing every field.
+
+## Tips
+
+- **Keep IDs URL-safe.** Slugs like `"ashwalker"` or `"iron-golem"` work; spaces or
+  special characters don't. If you omit `id`, the app derives one from the name.
+- **Give your pack a source field.** Setting `"source": "My Pack Name"` on each
+  entry makes it easy to filter by source in the Compendium browser.
+- **Minions have no thresholds.** Use `"thresholds": "None"` for minion-type
+  adversaries that take a single hit rather than tracking Major/Severe thresholds.
+- **Feature types are inferred.** If you name a feature `"Bite - Action"`, you can
+  omit `feat_type` and the app will infer it correctly. Including `feat_type` explicitly
+  is cleaner for machine-generated packs.

--- a/Encounter/Encounter.docc/Articles/DHPackFormat.md
+++ b/Encounter/Encounter.docc/Articles/DHPackFormat.md
@@ -1,0 +1,253 @@
+# The .dhpack Format
+
+Complete reference for the Encounter content pack file format.
+
+## Overview
+
+A `.dhpack` file is a plain JSON file with a custom extension. The extension tells
+iOS and macOS to route the file to Encounter on open, which imports the content into
+the app's compendium. Any text editor can create or inspect one.
+
+The format is based on the [seansbox/daggerheart-srd](https://github.com/seansbox/daggerheart-srd)
+community JSON schema — the closest thing to a community standard for Daggerheart JSON data.
+
+## Top-level structure
+
+A `.dhpack` accepts two JSON structures:
+
+**Pack wrapper (recommended)** — supports adversaries, environments, or both:
+
+```json
+{
+  "adversaries": [ ... ],
+  "environments": [ ... ]
+}
+```
+
+**Bare adversary array** — direct seansbox export format, adversaries only:
+
+```json
+[ ... ]
+```
+
+Use the pack wrapper for new packs. The bare array format exists for compatibility with
+direct exports from seansbox/daggerheart-srd tooling.
+
+## Adversary object
+
+Each adversary in the array must conform to this schema.
+
+```json
+{
+  "id": "iron-golem",
+  "name": "Iron Golem",
+  "source": "My Homebrew Pack",
+  "tier": 2,
+  "type": "Bruiser",
+  "description": "A hulking construct of hammered iron, animated by an ancient binding rune.",
+  "motives_and_tactics": "Relentless; ignores difficult terrain. Focuses on the nearest PC.",
+  "difficulty": 14,
+  "thresholds": "10/18",
+  "hp": 12,
+  "stress": 4,
+  "atk": "+4",
+  "attack": "Iron Fist",
+  "range": "Very Close",
+  "damage": "1d12+4 phy",
+  "experience": "Construct Lore +2",
+  "feature": [
+    {
+      "name": "Runic Shell - Passive",
+      "text": "The first time the Iron Golem would take a Major hit each scene, reduce the damage to a Minor hit instead.",
+      "feat_type": "passive"
+    }
+  ]
+}
+```
+
+### Adversary fields
+
+| Field | Required | Type | Notes |
+|---|---|---|---|
+| `id` | Recommended | String | URL-safe slug, e.g. `"iron-golem"`. Auto-derived from `name` if absent. |
+| `name` | Yes | String | Display name |
+| `source` | No | String | Pack name, author, or `"homebrew"`. Stored lowercase. |
+| `tier` | Yes | Integer or string | `1`–`4`, matching PC level tiers |
+| `type` | Yes | String | See **Adversary types** below |
+| `description` | Yes | String | One-line appearance or demeanor |
+| `motives_and_tactics` | No | String | GM-facing guidance on running this adversary |
+| `difficulty` | Yes | Integer or string | DC for all player rolls against this adversary |
+| `thresholds` | Either | String | Combined `"major/severe"` format, e.g. `"8/15"`. Minions with no thresholds use `"None"`. |
+| `threshold_major` | Either | Integer | Pre-split alternative to `thresholds` |
+| `threshold_severe` | Either | Integer | Pre-split alternative to `thresholds` |
+| `hp` | Yes | Integer or string | Hit points |
+| `stress` | Yes | Integer or string | Stress capacity |
+| `atk` | Yes | String | Attack modifier, e.g. `"+3"` |
+| `attack` | Yes | String | Name of the attack or weapon |
+| `range` | Yes | String | See **Attack ranges** below |
+| `damage` | Yes | String | Dice expression, e.g. `"1d12+2 phy"` |
+| `experience` | No | String | Optional tag, e.g. `"Tremor Sense +2"` |
+| `feature` | No | Array | Actions, reactions, and passives — see **Feature object** below |
+
+> **Threshold note:** Provide either the combined `thresholds` string **or** the pair
+> `threshold_major` / `threshold_severe`. You do not need both. Minions with no damage
+> thresholds use `"thresholds": "None"`.
+>
+> **Numeric strings:** `tier`, `difficulty`, `hp`, and `stress` accept either a JSON
+> number or a numeric string (e.g. `"12"`) for compatibility with SRD tooling that
+> exports all fields as strings.
+
+### Adversary types
+
+| `type` value | Role |
+|---|---|
+| `"Bruiser"` | Tough; deliver powerful attacks |
+| `"Horde"` | Groups acting as one unit — special HP and attack rules apply |
+| `"Leader"` | Command and summon other adversaries; high stress capacity |
+| `"Minion"` | Easily dispatched; dangerous in numbers |
+| `"Ranged"` | Fragile in melee; deal high damage at range |
+| `"Skulk"` | Maneuver and ambush |
+| `"Social"` | Conversation-based challenges |
+| `"Solo"` | Designed for climactic one-on-one encounters |
+| `"Standard"` | General-purpose adversary |
+| `"Support"` | Enhance allies and disrupt opponents |
+
+Horde variants from older SRD exports (e.g. `"Horde (3/HP)"`) are normalized to
+`"Horde"` automatically.
+
+### Attack ranges
+
+| `range` value |
+|---|
+| `"Melee"` |
+| `"Very Close"` |
+| `"Close"` |
+| `"Far"` |
+| `"Very Far"` |
+
+### Damage expression format
+
+Damage strings follow the pattern `XdY[+Z] type`:
+
+| Example | Meaning |
+|---|---|
+| `"1d10+3 phy"` | Physical damage, 1d10 plus 3 |
+| `"2d6 mag"` | Magical damage, 2d6 |
+| `"1d8 phy"` | Physical damage, 1d8 |
+
+`phy` = physical, `mag` = magical, per SRD terminology.
+
+## Feature object
+
+Features are the actions, reactions, and passives that appear on adversary and environment stat blocks.
+
+```json
+{
+  "name": "Pack Tactics - Passive",
+  "text": "Deals +1 damage for each other Pack member within Very Close range.",
+  "feat_type": "passive"
+}
+```
+
+| Field | Required | Values |
+|---|---|---|
+| `name` | Yes | Unique within this adversary |
+| `text` | Yes | Rules text |
+| `feat_type` | No | `"action"`, `"reaction"`, `"passive"`. If absent, inferred from a ` - Action` / ` - Reaction` suffix in `name`; defaults to `"passive"`. |
+
+Feature types:
+- **Actions** — trigger when this adversary has the spotlight
+- **Reactions** — trigger regardless of spotlight
+- **Passives** — always in effect
+
+## Environment object
+
+Environments share the feature schema but have no HP, Stress, or attack fields.
+
+```json
+{
+  "id": "smoldering-ruins",
+  "name": "Smoldering Ruins",
+  "source": "My Homebrew Pack",
+  "description": "Crumbling walls and drifting ash make every step treacherous.",
+  "feature": [
+    {
+      "name": "Choking Smoke - Passive",
+      "text": "PCs must spend 1 Hope at the start of each round or suffer 1d4 stress.",
+      "feat_type": "passive"
+    }
+  ]
+}
+```
+
+| Field | Required | Notes |
+|---|---|---|
+| `id` | Recommended | Slug, auto-derived from `name` if absent |
+| `name` | Yes | |
+| `source` | No | Stored lowercase |
+| `description` | Yes | |
+| `feature` | No | Same feature object schema as adversaries |
+
+## Minimal working example
+
+The smallest valid `.dhpack` with one adversary and one environment:
+
+```json
+{
+  "adversaries": [
+    {
+      "name": "Cave Bat",
+      "tier": 1,
+      "type": "Minion",
+      "description": "A small, frantic bat disturbed from its roost.",
+      "difficulty": 10,
+      "thresholds": "None",
+      "hp": 2,
+      "stress": 1,
+      "atk": "+1",
+      "attack": "Bite",
+      "range": "Melee",
+      "damage": "1d4 phy"
+    }
+  ],
+  "environments": [
+    {
+      "name": "Dark Cave",
+      "description": "Complete darkness. PCs without light sources act at disadvantage.",
+      "feature": [
+        {
+          "name": "Pitch Black - Passive",
+          "text": "PCs without a light source have disadvantage on all rolls.",
+          "feat_type": "passive"
+        }
+      ]
+    }
+  ]
+}
+```
+
+Save as `my-pack.dhpack` and the file is ready to import or share.
+
+## Relationship to upstream formats
+
+| Tool | Compatibility |
+|---|---|
+| [seansbox/daggerheart-srd](https://github.com/seansbox/daggerheart-srd) | Full. Direct `.build/json/adversaries.json` exports can be renamed `.dhpack` and imported as-is (bare array format). |
+| [BeastVault](https://github.com/ly0va/beastvault) | Full. Exports in the same community format; JSON arrays import directly or can be wrapped in a pack object. |
+| [fantasy-statblocks](https://github.com/javalent/fantasy-statblocks) | Full. Field names match this schema. |
+| [daggersearch/daggerheart-data](https://github.com/daggersearch/daggerheart-data) | Not compatible — covers player-facing content (classes, ancestries, items), not adversaries. |
+
+## JSON Schema
+
+A machine-readable JSON Schema (draft 2020-12) for the `.dhpack` format is available
+in the repository at `schemas/dhpack.schema.json`. It can be used with VS Code's
+built-in JSON validation, `ajv`, or any other JSON Schema-aware tool.
+
+To enable VS Code validation, add a `$schema` field to your pack:
+
+```json
+{
+  "$schema": "https://gwillish.github.io/encounter/schemas/dhpack.schema.json",
+  "adversaries": [ ... ]
+}
+```

--- a/Encounter/Encounter.docc/Articles/GettingStarted.md
+++ b/Encounter/Encounter.docc/Articles/GettingStarted.md
@@ -1,0 +1,49 @@
+# Getting Started with Encounter
+
+Set up and run your first Daggerheart encounter.
+
+## Overview
+
+Encounter is organized around three phases: **building** a roster before the session,
+**running** a live encounter at the table, and **browsing** the compendium to plan
+future sessions.
+
+## Browsing the compendium
+
+The **Compendium** tab shows all available adversaries and environments. Use the search
+bar to filter by name or description. Tap any entry to see its full stat block, features,
+and GM notes.
+
+The compendium is pre-loaded with the Daggerheart SRD. Install content packs to add
+homebrew or third-party adversaries — see <doc:SharingAndHostingPacks> for how to find
+and add packs.
+
+## Building an encounter
+
+1. Open the **Library** tab and tap **New Encounter**.
+2. Give the encounter a name and add adversaries from the compendium browser.
+3. Use the **Difficulty** meter to check whether the encounter is appropriate for
+   your party's tier and size.
+4. Add environment elements to bring the scene to life.
+
+Encounters are saved automatically and reopen exactly as you left them.
+
+## Running a live encounter
+
+Tap **Run** to enter the live runner view.
+
+- Tap an adversary card to expand it and reveal its full stat block.
+- Use the **HP** and **Stress** controls to track damage and pressure.
+- Mark **conditions** (e.g. Prone, Restrained) directly on each card.
+- The **Fear** tracker at the top of the screen keeps the GM's fear pool visible
+  at a glance.
+
+Tap **End Encounter** when the scene is over. The app returns to the library.
+
+## Managing content sources
+
+Open **Settings → Content Sources** to view and manage installed packs. Remote sources
+show a **Refresh** button; tap it to fetch the latest version of the pack. Locally
+imported packs can be removed here if you no longer need them.
+
+See <doc:SharingAndHostingPacks> for how to install a pack by URL.

--- a/Encounter/Encounter.docc/Articles/SharingAndHostingPacks.md
+++ b/Encounter/Encounter.docc/Articles/SharingAndHostingPacks.md
@@ -1,0 +1,150 @@
+# Sharing and Hosting Content Packs
+
+Distribute your .dhpack to other Encounter users.
+
+## Overview
+
+Once you have a `.dhpack` file, there are several ways to share it — from a quick
+one-to-one AirDrop at the table to a publicly hosted URL that Encounter keeps up to
+date automatically.
+
+## Device-to-device sharing
+
+These methods work immediately with no hosting required.
+
+### AirDrop
+
+The fastest option for sharing at the table. On the sending device, tap the `.dhpack`
+file in Files and tap **Share → AirDrop**. Select the recipient's device. On the
+receiving device, tap **Open in Encounter**.
+
+Works between any combination of iPhone, iPad, and Mac running Encounter.
+
+### Files app and iCloud Drive
+
+Copy the `.dhpack` file to iCloud Drive (or any cloud storage you share with your
+group). The recipient taps the file in Files and chooses **Open in Encounter**.
+
+### Email and Messages
+
+Attach the `.dhpack` file to an email or iMessage. The recipient taps the attachment
+and opens it in Encounter. Most mail clients send the file as-is; some may warn about
+unknown file types — this is safe to dismiss.
+
+## URL-based sources
+
+Encounter supports adding a `.dhpack` file by URL. Once added, the app stores the
+pack locally and can refresh it on demand to pick up updates. This is the best option
+for packs that are actively maintained and shared with a community.
+
+### Adding a URL source
+
+1. In Encounter, open **Settings → Content Sources**.
+2. Tap **Add Source**.
+3. Paste the URL to the `.dhpack` file and give the source a name.
+4. Tap **Fetch** — Encounter downloads the pack and imports the content.
+
+To update a URL source later, tap **Refresh** on the source row. Encounter sends a
+conditional request (using ETag) so it only downloads the file if it has changed.
+
+### What makes a good host URL
+
+Any URL that serves the raw `.dhpack` file directly works. For best results:
+
+- **Serve the file with standard HTTP caching headers** — `ETag` or
+  `Last-Modified`. Encounter uses these to skip re-downloading unchanged packs.
+- **Use a stable, version-pinned URL** — don't use a URL that always points to the
+  latest file (e.g. a `main` branch raw URL) if you want users to stay on a
+  specific version. See the GitHub Releases section below for a version-pinned
+  approach.
+- **HTTPS only** — plain HTTP is not permitted by App Transport Security.
+
+## Hosting options
+
+### GitHub Releases (recommended)
+
+GitHub Releases are the most reliable option for versioned packs. Each release gets
+a permanent, stable URL that never changes.
+
+1. Create a GitHub repository for your pack (or use an existing one).
+2. Go to **Releases → Draft a new release**.
+3. Tag the release with a version (e.g. `v1.0`).
+4. Attach your `.dhpack` file as a release asset.
+5. Publish the release.
+
+The asset URL follows this pattern:
+
+```
+https://github.com/<owner>/<repo>/releases/download/<tag>/<filename>.dhpack
+```
+
+This URL is permanent — it will never serve different content, even if you publish a
+new release later. Users who want the update add the new release URL as a separate
+source, or you can provide a jsDelivr URL (see below) that always resolves to the
+latest release.
+
+### jsDelivr CDN
+
+[jsDelivr](https://www.jsdelivr.com/) can serve GitHub release assets from a CDN with
+aggressive caching and high availability. The URL format is:
+
+```
+https://cdn.jsdelivr.net/gh/<owner>/<repo>@<tag>/<filename>.dhpack
+```
+
+jsDelivr also supports a `@latest` alias that always resolves to the most recent
+GitHub release:
+
+```
+https://cdn.jsdelivr.net/gh/<owner>/<repo>@latest/<filename>.dhpack
+```
+
+> **Note:** Use `@latest` only if you want users to always get the newest version
+> automatically. For a stable, opt-in update experience, use a version-pinned URL.
+
+### GitHub Gist
+
+A quick option for small packs with no repository setup required.
+
+1. Go to [gist.github.com](https://gist.github.com) and create a new gist.
+2. Paste your pack JSON and name the file with a `.dhpack` extension.
+3. Click **Create public gist**.
+4. On the gist page, click **Raw** to get the direct file URL.
+
+Gist raw URLs look like:
+
+```
+https://gist.githubusercontent.com/<user>/<gist-id>/raw/<filename>.dhpack
+```
+
+> **Note:** The raw URL for a gist changes with every edit. To share a stable URL,
+> pin to a specific revision by appending the commit hash to the URL.
+
+### Static hosting (Netlify, Vercel, S3, etc.)
+
+Any static file host that serves files over HTTPS works. Upload your `.dhpack` file
+and share the direct file URL. For best results, configure the host to set
+`Content-Type: application/json` and `ETag` response headers.
+
+### Self-hosted server
+
+If you run your own server, serve the `.dhpack` file as a static asset. Ensure the
+server sends `ETag` or `Last-Modified` headers so Encounter can use conditional
+requests to avoid re-downloading unchanged content.
+
+## QR codes
+
+A QR code pointing to a hosted pack URL is a convenient way to share a pack at the
+game table — attendees can scan it with the camera app and open the URL directly in
+Encounter.
+
+Any QR code generator works. Encode the full HTTPS URL to the `.dhpack` file. On iOS,
+the camera app recognizes QR codes and shows a notification to open the URL; if
+Encounter is installed and the URL serves a `.dhpack`, the OS routes it to the app.
+
+## Listing your pack
+
+Once your pack is hosted, share the URL wherever your group or community hangs out:
+Discord, Mastodon, Reddit, itch.io, or a dedicated blog post. Including the direct
+`.dhpack` URL and a QR code in your post makes it easy for people to add the source
+without copy-pasting.

--- a/Encounter/Encounter.docc/Encounter.md
+++ b/Encounter/Encounter.docc/Encounter.md
@@ -1,0 +1,76 @@
+# ``Encounter``
+
+Daggerheart encounter prep and run app for iOS and macOS.
+
+## Overview
+
+Encounter helps game masters set up and track Daggerheart encounters at the table.
+Load adversaries and environments from the built-in SRD compendium, build an encounter
+roster, then run it live — tracking HP, stress, conditions, and turn order as the scene
+unfolds.
+
+The app is built with SwiftUI and targets iOS 26, macOS 26, and visionOS 26.
+
+### Content packs
+
+Encounter supports community and homebrew content through the `.dhpack` format — a
+plain JSON file containing adversaries, environments, or both. Packs can be imported
+from Files or AirDrop, or added as a live URL source that the app keeps up to date.
+
+- <doc:DHPackFormat> — the complete file format reference
+- <doc:AuthoringAPack> — step-by-step guide to creating your own pack
+- <doc:SharingAndHostingPacks> — how to distribute and host a pack
+
+### Getting started
+
+- <doc:GettingStarted>
+
+## Topics
+
+### App Usage
+
+- <doc:GettingStarted>
+
+### Content Packs
+
+- <doc:DHPackFormat>
+- <doc:AuthoringAPack>
+- <doc:SharingAndHostingPacks>
+
+### Catalog Models
+
+- ``Adversary``
+- ``AdversaryType``
+- ``AttackRange``
+- ``AdversaryFeature``
+- ``FeatureType``
+- ``DaggerheartEnvironment``
+
+### Data Store
+
+- ``Compendium``
+- ``CompendiumError``
+
+### Content Sources
+
+- ``ContentSource``
+- ``ContentStore``
+- ``ContentFetcher``
+- ``ContentStoreError``
+- ``DHPackContent``
+- ``ContentFingerprint``
+
+### Encounter Session
+
+- ``EncounterSession``
+- ``EncounterDefinition``
+- ``AdversarySlot``
+- ``EnvironmentSlot``
+- ``PlayerSlot``
+- ``Condition``
+
+### Difficulty
+
+- ``DifficultyBudget``
+- ``EncounterStore``
+- ``SessionRegistry``

--- a/README.md
+++ b/README.md
@@ -7,11 +7,26 @@ Built with SwiftUI, targeting iOS 26, macOS 26, and visionOS 26.
 
 ## Documentation
 
+Full documentation is hosted at **[gwillish.github.io/encounter](https://gwillish.github.io/encounter/documentation/encounter/)** (see [issue #20](https://github.com/gwillish/encounter/issues/20) for CI setup).
+
 - `CLAUDE.md` — full technical context, conventions, and build instructions for
   development with Claude Code
 - `docs/data-schema.md` — Daggerheart JSON schema reference and source links
 - `docs/decisions/` — Architecture Decision Records (ADRs): the history of
   significant architectural, data-format, and UX choices made during development
+
+## Content Packs
+
+Encounter supports community and homebrew content through the `.dhpack` format — a
+plain JSON file containing adversaries, environments, or both.
+
+- [.dhpack format reference](https://gwillish.github.io/encounter/documentation/encounter/dhpackformat) — complete schema, field tables, and examples
+- [Authoring a pack](https://gwillish.github.io/encounter/documentation/encounter/authoringapack) — three paths: text editor, in-app export, or programmatic generation
+- [Sharing and hosting](https://gwillish.github.io/encounter/documentation/encounter/sharingandhostingpacks) — AirDrop, URL sources, GitHub Releases, jsDelivr, Gist
+
+The JSON Schema for `.dhpack` is at [`schemas/dhpack.schema.json`](schemas/dhpack.schema.json).
+Add `"$schema": "https://gwillish.github.io/encounter/schemas/dhpack.schema.json"` to
+your pack file to enable validation and autocomplete in VS Code.
 
 ## Architecture Decision Records
 

--- a/schemas/dhpack.schema.json
+++ b/schemas/dhpack.schema.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://gwillish.github.io/encounter/schemas/dhpack.schema.json",
+  "title": "DHPack",
+  "description": "A .dhpack content pack for the Encounter app. Accepts either a pack wrapper object (recommended) or a bare adversary array (seansbox/daggerheart-srd export format).",
+  "oneOf": [
+    { "$ref": "#/$defs/PackWrapper" },
+    {
+      "type": "array",
+      "items": { "$ref": "#/$defs/Adversary" },
+      "description": "Bare adversary array — seansbox/daggerheart-srd direct export format."
+    }
+  ],
+  "$defs": {
+    "PackWrapper": {
+      "type": "object",
+      "description": "Recommended top-level structure. Supports adversaries, environments, or both.",
+      "properties": {
+        "$schema": {
+          "type": "string",
+          "description": "Optional $schema reference for editor validation."
+        },
+        "adversaries": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Adversary" },
+          "description": "Array of adversary objects to import."
+        },
+        "environments": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Environment" },
+          "description": "Array of environment objects to import."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Adversary": {
+      "type": "object",
+      "description": "A Daggerheart adversary definition.",
+      "required": [
+        "name",
+        "tier",
+        "type",
+        "description",
+        "difficulty",
+        "hp",
+        "stress",
+        "atk",
+        "attack",
+        "range",
+        "damage"
+      ],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "URL-safe slug, e.g. 'iron-golem'. Auto-derived from name if absent."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Display name."
+        },
+        "source": {
+          "type": "string",
+          "description": "Pack name, author, or 'homebrew'. Stored lowercase."
+        },
+        "tier": {
+          "$ref": "#/$defs/IntOrNumericString",
+          "description": "PC level tier 1–4 this adversary is designed for."
+        },
+        "type": {
+          "type": "string",
+          "enum": [
+            "Bruiser",
+            "Horde",
+            "Leader",
+            "Minion",
+            "Ranged",
+            "Skulk",
+            "Social",
+            "Solo",
+            "Standard",
+            "Support"
+          ],
+          "description": "Adversary role. Horde variant strings like 'Horde (3/HP)' are normalized to 'Horde' on import."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1,
+          "description": "One-line appearance or demeanor."
+        },
+        "motives_and_tactics": {
+          "type": "string",
+          "description": "GM-facing guidance on how to run this adversary."
+        },
+        "difficulty": {
+          "$ref": "#/$defs/IntOrNumericString",
+          "description": "DC for all player rolls against this adversary."
+        },
+        "thresholds": {
+          "type": "string",
+          "pattern": "^(None|\\d+/\\d+|\\d+/None|None/\\d+)$",
+          "description": "Combined major/severe threshold string, e.g. '8/15'. Use 'None' for minions with no damage thresholds. Provide either this field or threshold_major + threshold_severe."
+        },
+        "threshold_major": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Pre-split alternative to thresholds. Damage required for a Major hit."
+        },
+        "threshold_severe": {
+          "type": "integer",
+          "minimum": 0,
+          "description": "Pre-split alternative to thresholds. Damage required for a Severe hit."
+        },
+        "hp": {
+          "$ref": "#/$defs/IntOrNumericString",
+          "description": "Hit points."
+        },
+        "stress": {
+          "$ref": "#/$defs/IntOrNumericString",
+          "description": "Stress capacity."
+        },
+        "atk": {
+          "type": "string",
+          "pattern": "^[+-]\\d+$",
+          "description": "Attack modifier string, e.g. '+3' or '-1'."
+        },
+        "attack": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Name of the standard attack or weapon."
+        },
+        "range": {
+          "type": "string",
+          "enum": ["Melee", "Very Close", "Close", "Far", "Very Far"],
+          "description": "Attack range."
+        },
+        "damage": {
+          "type": "string",
+          "pattern": "^\\d+d\\d+(\\+\\d+)?\\s+(phy|mag)$",
+          "description": "Damage expression, e.g. '1d12+2 phy' or '2d6 mag'."
+        },
+        "experience": {
+          "type": "string",
+          "description": "Optional experience tag, e.g. 'Tremor Sense +2'."
+        },
+        "feature": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Feature" },
+          "description": "Actions, reactions, and passives."
+        }
+      },
+      "oneOf": [
+        {
+          "required": ["thresholds"],
+          "description": "Combined threshold string variant."
+        },
+        {
+          "required": ["threshold_major", "threshold_severe"],
+          "description": "Pre-split threshold keys variant."
+        }
+      ],
+      "additionalProperties": false
+    },
+    "Environment": {
+      "type": "object",
+      "description": "A Daggerheart environment — a scene element with features but no HP or Stress.",
+      "required": ["name", "description"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "pattern": "^[a-z0-9][a-z0-9-]*$",
+          "description": "URL-safe slug. Auto-derived from name if absent."
+        },
+        "name": {
+          "type": "string",
+          "minLength": 1
+        },
+        "source": {
+          "type": "string",
+          "description": "Pack name or author. Stored lowercase."
+        },
+        "description": {
+          "type": "string",
+          "minLength": 1
+        },
+        "feature": {
+          "type": "array",
+          "items": { "$ref": "#/$defs/Feature" },
+          "description": "Passives, reactions, and actions this environment contributes to the scene."
+        }
+      },
+      "additionalProperties": false
+    },
+    "Feature": {
+      "type": "object",
+      "description": "A named action, reaction, or passive on an adversary or environment.",
+      "required": ["name", "text"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Unique name within this adversary or environment. May include a ' - Type' suffix (e.g. 'Bite - Action') to allow feat_type to be inferred."
+        },
+        "text": {
+          "type": "string",
+          "minLength": 1,
+          "description": "Rules text."
+        },
+        "feat_type": {
+          "type": "string",
+          "enum": ["action", "reaction", "passive"],
+          "description": "Feature category. If absent, inferred from a ' - Action' or ' - Reaction' suffix in name; defaults to 'passive'."
+        }
+      },
+      "additionalProperties": false
+    },
+    "IntOrNumericString": {
+      "description": "Accepts either a JSON integer or a string containing an integer, for compatibility with SRD tooling that serializes all numeric fields as strings.",
+      "oneOf": [
+        { "type": "integer" },
+        { "type": "string", "pattern": "^\\d+$" }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
Resolves #15.

## Summary

- **`Encounter/Encounter.docc/`** — new DocC catalog for the `Encounter` app target (auto-included via `PBXFileSystemSynchronizedRootGroup`)
  - Landing page with topic groups for all public types
  - `GettingStarted` — app usage: compendium browser, encounter builder, live runner, source management
  - `DHPackFormat` — complete schema reference: both top-level structures, all adversary/environment fields, type/range enums, damage format, feature objects, minimal example, upstream compatibility table, `$schema` usage
  - `AuthoringAPack` — three authoring paths: text editor (with validation tips), in-app export (placeholder for #21), programmatic generation
  - `SharingAndHostingPacks` — AirDrop, Files, email, URL source setup (with ETag detail), GitHub Releases, jsDelivr, Gist, static hosting, QR codes

- **`schemas/dhpack.schema.json`** — JSON Schema draft 2020-12; covers pack wrapper + bare adversary array, all required/optional fields with enums and patterns, `IntOrNumericString` helper for loose-typed SRD fields, `oneOf` for threshold variants

- **`README.md`** — new Content Packs section linking all four articles and the schema file

## Test plan

- [x] `xcodebuild docbuild -scheme Encounter -destination 'platform=macOS' OTHER_DOCC_FLAGS="--warnings-as-errors"` → `** BUILD DOCUMENTATION SUCCEEDED **` with zero warnings
- [x] All four article pages confirmed present in the `.doccarchive` output
- [x] All public model/service types appear in the archive

## Related issues

- #20 — CI to build and deploy DocC to GitHub Pages (hosting TBD)
- #19 — Swift Package extraction (future SPI hosting + `validate-dhpack` CLI)
- #21 — In-app export of homebrew adversaries as `.dhpack` (referenced in `AuthoringAPack`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)