### PR TITLE
Add first principles, contributor guidelines, and ADRs 34–36

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -24,9 +24,11 @@ Encounter/
 ├── EncounterUITests/           # XCUITest UI tests
 ├── docs/
 │   ├── data-schema.md          # Daggerheart JSON schema reference + source links
+│   ├── first-principles.md     # Product principles — what the app is and isn't
 │   └── decisions/              # Architecture Decision Records (ADRs)
 │       └── README.md           # ADR format, lifecycle, and superseded process
 ├── README.md                   # Project overview
+├── CONTRIBUTING.md             # Contributor guidelines, scope boundaries, PR process
 └── CLAUDE.md                   # This file
 ```
 
@@ -223,19 +225,22 @@ was learned worth preserving, don't bring the ADR to `main`.
   platform-specific adaptations.
 - **Daggerheart-specific naming:** Use game terms as-is (`hp`, `stress`, `fear`, `hope`,
   `difficulty`, `thresholds`). Do not rename to generic terms like `health` or `defense`.
+- **Formatting:** `swift-format` (built-in Swift toolchain). Run before committing:
+  `swift-format format --recursive --in-place Encounter/`
 
 ---
 
-## Known Gaps / Next Steps
+## Roadmap and Scope
 
-- [ ] `adversaries.json` / `environments.json` are stub data — replace with full SRD export and move to writable content directory (see ADRs on content architecture)
-- [ ] No dice rolling logic — `damage` strings are stored raw (e.g. `"1d12+2 phy"`)
-- [ ] Horde adversary rules (shared HP pool, modified attack) not yet implemented
-- [ ] Adversary creation UI and difficulty meter — deferred to a dedicated design session
-- [ ] No iCloud sync or Handoff between iOS and macOS
+- **Development roadmap:** GitHub issues organized by milestone (Phase 0 through Phase 6)
+- **First principles and scope boundaries:** [`docs/first-principles.md`](docs/first-principles.md)
+- **Contributor guidelines:** [`CONTRIBUTING.md`](CONTRIBUTING.md)
 
-### Future (out of scope for v1)
+### Deferred (planned, not yet scheduled)
 
-- [ ] LLM-assisted ad-hoc encounter generation from description
-- [ ] Continuity/Handoff between Mac and iPhone
-- [ ] Player companion app with live status push to GM
+- LLM-assisted ad-hoc encounter generation from description
+- Continuity/Handoff between Mac and iPhone mid-session
+- Player companion app with live GM sync
+- Swift Package extraction — when a second app exists that needs the models
+- Hope tracking per player — pending playtesting to determine GM visibility needs
+- In-app rules/condition tooltips — pending licensing clarity

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,129 @@
+# Contributing to Encounter
+
+Encounter is an open-source Daggerheart encounter prep and run app for iOS and
+macOS, built for Game Masters who need to set up and track encounters at the table.
+
+Before contributing, read the [first principles](docs/first-principles.md). They
+define what this app is, who it is for, and what it will never become. The
+guidelines below flow directly from those principles.
+
+---
+
+## Scope
+
+### In scope for v1
+
+- Encounter prep: adversary roster, player configuration, GM notes, difficulty assessor
+- Live encounter running: adversary HP/stress/conditions, Fear tracker, player strip
+- Compendium: browse and search SRD adversaries and environments
+- Content packs: import `.dhpack` files via URL, AirDrop, or file share; remove sources
+- Homebrew adversary creation with power validation and export as `.dhpack`
+- iCloud sync (ubiquity containers) across a GM's own devices
+
+### Explicitly out of scope for this app
+
+These will not be accepted as contributions, regardless of implementation quality:
+
+| What | Why |
+|---|---|
+| Campaign management (session history, arc tracking, world state) | Outside the encounter lifecycle — see Principle 2 |
+| PC character creation, leveling, or advancement | Not a GM tool responsibility |
+| PC character sheets | Demiplane provides this; not in scope here |
+| Initiative tracking | Daggerheart uses spotlight rotation, not initiative — see ADR-0021 |
+| Dice rolling | Physical dice stay physical — see Principle 4 |
+| In-app rules browser or SRD display | Licensing questions unresolved; see Principle 4 |
+| Spell or ability management | Not a Daggerheart concept |
+| Multi-GM collaboration | Single-GM scope only |
+| Background sync or push notifications | All updates are user-initiated — see Principle 3 and ADR-0018 |
+
+### Not in scope for this app, but not a hard no
+
+- **Android** — a future Android-native app using Swift for Android is not excluded,
+  but it is a separate project and a separate decision
+- **Swift Package extraction** — the model layer will be extracted into a shared
+  package when a second app is being built that needs it; premature extraction
+  adds overhead for one consumer
+
+---
+
+## Proposing features
+
+1. **Open an issue first.** Discuss before writing code.
+2. **A human must be the proposer.** AI-generated feature proposals without a human
+   author will not be considered. This applies to issues and PRs alike.
+3. **Reference the first principles.** Explain how the feature fits within the
+   encounter lifecycle and which principle(s) it supports.
+4. **For significant design decisions**, an Architecture Decision Record (ADR) in
+   `docs/decisions/` is required before implementation begins. See
+   [docs/decisions/README.md](docs/decisions/README.md) for the format and process.
+
+---
+
+## Code expectations
+
+- **Language:** Swift 6, latest stable toolchain
+- **UI framework:** SwiftUI only — no UIKit imports
+- **No force-unwrap** in model or view code — use `guard let` or optional chaining
+- **Access control:** `public` on all model types and properties (anticipates future
+  Swift Package extraction); `internal` on views
+- **Naming:** use Daggerheart game terms as-is (`hp`, `stress`, `fear`, `hope`,
+  `difficulty`, `thresholds`) — do not rename to generic equivalents
+- **File layout:** one primary type per file; filename matches type name
+- **Concurrency:** `SWIFT_DEFAULT_ACTOR_ISOLATION = MainActor` is active — all model
+  types must be either Sendable value types or explicitly isolated `@Observable`
+  classes; do not add `nonisolated` without a specific reason
+
+---
+
+## Formatting
+
+This project uses **`swift-format`** (the built-in Swift toolchain formatter).
+
+Run it before every commit:
+
+```bash
+swift-format format --recursive --in-place Encounter/
+swift-format lint --recursive Encounter/
+```
+
+PRs with formatting violations will be asked to reformat before review.
+
+---
+
+## Testing
+
+- Tests use **Swift Testing** (`import Testing`), not XCTest
+- **TDD:** write a failing test first, then implement — red before green
+- All model mutations must have test coverage
+- UI tests are required for critical user flows before a PR is ready
+- Run the unit test suite before every PR:
+
+```bash
+xcodebuild test \
+  -scheme Encounter \
+  -destination 'platform=macOS' \
+  -resultBundlePath TestResults.xcresult
+```
+
+---
+
+## Architecture Decision Records
+
+Significant architectural, data-format, and UX decisions are recorded as ADRs in
+`docs/decisions/`. See [docs/decisions/README.md](docs/decisions/README.md) for
+the full format, lifecycle, and superseded process.
+
+**Never edit or delete an existing ADR.** If a decision was wrong or needs to
+change, write a new superseding ADR. The history is preserved intentionally.
+
+---
+
+## Pull request process
+
+1. **Link to an issue.** Every PR must reference the issue it addresses.
+2. **Human author required.** AI-generated code is permitted; the PR author and at
+   least one reviewer must be human. PRs without a human author will not be merged.
+3. **Tests required.** New behavior without tests will not be merged.
+4. **swift-format clean.** Run the formatter before pushing.
+5. **Human review required.** All PRs require approval from a human reviewer before
+   merge, regardless of how the code was written.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -32,7 +32,7 @@ These will not be accepted as contributions, regardless of implementation qualit
 | Initiative tracking | Daggerheart uses spotlight rotation, not initiative — see ADR-0021 |
 | Dice rolling | Physical dice stay physical — see Principle 4 |
 | In-app rules browser or SRD display | Licensing questions unresolved; see Principle 4 |
-| Spell or ability management | Not a Daggerheart concept |
+| Domain ability and class feature browsing | Outside the encounter lifecycle — see Principle 2 |
 | Multi-GM collaboration | Single-GM scope only |
 | Background sync or push notifications | All updates are user-initiated — see Principle 3 and ADR-0018 |
 

--- a/docs/decisions/0034-swift-format-project-formatter.md
+++ b/docs/decisions/0034-swift-format-project-formatter.md
@@ -1,0 +1,50 @@
+# ADR-0034: swift-format as project formatter
+
+**Status:** Accepted
+**Date:** 2026-03-22
+
+## Context
+
+As the project grows and opens to contributors (including agentic ones), consistent
+code formatting becomes important for readability and review. Several tools are
+available for Swift projects. We needed to pick one and commit to it so that
+`CONTRIBUTING.md` and eventual CI enforcement have a clear target.
+
+## Decision
+
+Use the Swift toolchain's built-in `swift-format` for all code formatting and
+linting. Run it before every commit as a convention; enforce it in CI as part of
+the Phase 6 contributor guidelines work (issue #49).
+
+```bash
+swift-format format --recursive --in-place Encounter/
+swift-format lint --recursive Encounter/
+```
+
+## Options Considered
+
+**SwiftLint** — widely used, large rule set, supports custom rules and inline
+disable comments. Requires an external dependency (SPM or Homebrew). Does not
+auto-format; only warns. Would need SwiftFormat alongside it for actual
+reformatting.
+
+**SwiftFormat (Nicklockwood)** — popular auto-formatter with extensive options.
+Another external dependency. Separate from the toolchain; version pinning required.
+
+**No formatter** — inconsistent style across contributors and AI-generated code.
+Harder to review diffs. Not acceptable for an open-source project.
+
+**swift-format (chosen)** — ships with the Swift toolchain; no additional
+dependency to install or version-pin. Updated with the language. Enforces a
+consistent style that tracks the official Swift style guidelines. Reformats
+automatically with `--in-place`. The `lint` subcommand can gate PRs in CI
+without requiring a separate tool.
+
+## Consequences
+
+- All contributors and AI agents must run `swift-format format` before committing.
+- PRs with formatting violations will be asked to reformat before review.
+- CI will enforce `swift-format lint` in Phase 6 (issue #49).
+- No additional package or Homebrew dependency is introduced.
+- Style is determined by swift-format's defaults; project-specific overrides can
+  be added via a `.swift-format` configuration file if needed in the future.

--- a/docs/decisions/0035-local-first-no-required-remote-services.md
+++ b/docs/decisions/0035-local-first-no-required-remote-services.md
@@ -1,0 +1,65 @@
+# ADR-0035: Local-first architecture — no required remote services
+
+**Status:** Accepted
+**Date:** 2026-03-22
+
+## Context
+
+The app targets Game Masters running sessions at a physical table, often in
+environments with unreliable or absent network connectivity (game stores, homes
+with spotty Wi-Fi, conventions). A GM mid-combat cannot afford an app that
+stalls, shows a loading spinner, or loses state because a remote service is
+unavailable.
+
+Additionally, requiring an account or backend login adds friction for a GM who
+just wants to open the app and run a game. We needed to establish a clear
+architectural position on remote service dependency before building the UI layers.
+
+## Decision
+
+All core functionality — building encounters, running sessions, browsing the
+compendium, managing content sources — operates entirely on-device. No account,
+login, or remote service is required at runtime.
+
+Remote connectivity is additive:
+
+- **iCloud sync** (ubiquity containers, ADR-0008) is the one opt-in remote
+  feature. It syncs when available and fails gracefully when not. The app never
+  blocks on it.
+- **Content source fetching** (ADR-0018) is always user-initiated. The app never
+  fetches in the background. Cached content is always available regardless of
+  network state.
+- **Future extensions** — local-network sharing between GM and player apps, and
+  eventual remote sync for distributed/online play — are valid extensions of this
+  foundation. They must be designed as additive layers, not replacements for the
+  on-device core.
+
+## Options Considered
+
+**Require a backend for sync from the start** — enables richer multi-device
+features, but couples app availability to service availability. A GM at the
+table is blocked if the backend is down. Violates Principle 3 (no surprises
+during play).
+
+**Require iCloud account** — simpler than a custom backend, but excludes
+offline use and users without Apple IDs. Adds a login step before first use.
+
+**Local-only, no sync ever** — simplest, but GMs with both a Mac and iPhone
+lose the ability to prep on one device and run on another. iCloud sync is
+specifically valued for this use case.
+
+**Local-first with iCloud as additive (chosen)** — the app always works
+fully offline. iCloud sync is a background capability that improves the
+experience when available without ever being required for it.
+
+## Consequences
+
+- `EncounterStore`, `ContentStore`, `SessionRegistry`, and `Compendium` must
+  all function fully without network access.
+- `ContentSource` fetch failures are non-fatal — cached content remains
+  available; the user is informed but not blocked.
+- No user account, login screen, or authentication flow is introduced for v1.
+- Future player-sync and remote-play features must be designed as additive
+  layers that degrade gracefully to local-only when unavailable.
+- iCloud sync failure must be surfaced to the user (not silently ignored) but
+  must never block the encounter workflow.

--- a/docs/decisions/0036-player-owned-state-boundary.md
+++ b/docs/decisions/0036-player-owned-state-boundary.md
@@ -1,0 +1,76 @@
+# ADR-0036: Player-owned state boundary — Hope excluded, GM-applied conditions included
+
+**Status:** Accepted
+**Date:** 2026-03-22
+
+## Context
+
+The encounter runner needs to track some player-facing state so the GM can
+manage combat effectively. But the app is a GM tool, not a character sheet.
+We needed a clear rule for which player state belongs in this app and which
+belongs to the player (and eventually a future player-side app).
+
+The two concrete decisions that forced this question:
+1. **Hope** — GMs grant Hope to players; players track their balance and spend it.
+2. **Conditions** — GMs apply conditions (Restrained, Vulnerable, Hidden) to
+   players; the GM needs to see and manage them during combat.
+
+## Decision
+
+The GM app tracks state the GM **controls and applies**. It does not replicate
+state that belongs to the player.
+
+**Included in `PlayerSlot`:**
+- `currentHP` / `maxHP` — GM applies damage; needs to track it
+- `currentStress` / `maxStress` — GM applies stress; needs to track it
+- `currentArmorSlots` / `armorSlots` — GM tracks armor consumption
+- `conditions: Set<Condition>` — GM applies conditions (Restrained, Vulnerable,
+  Hidden); must see and toggle them mid-combat
+- `evasion`, `thresholdMajor`, `thresholdSevere` — reference values the GM
+  needs when resolving attacks against players
+
+**Excluded from `PlayerSlot`:**
+- **Hope** — the GM grants Hope, but the *player* tracks their balance and decides
+  when to spend it. Hope management is a player-side responsibility. Including it
+  here would pull in player-sheet territory without providing meaningful GM value.
+- Character advancement, class features, ancestry traits — out of scope for the
+  encounter lifecycle entirely.
+
+**Architecture consideration:** The model must leave the door open for a future
+player-side app to share Hope (and other player state) bidirectionally via a sync
+layer. `PlayerSlot` should not have fields that would conflict with that future
+sync design.
+
+## Options Considered
+
+**Track all player state in the GM app** — complete information at the GM's
+fingertips, but couples the app to full character sheet data. Scope creep; out
+of scope per Principle 2 (the encounter is the unit of work).
+
+**Track Hope in the GM app** — some GMs want visibility into player Hope pools
+to pace Fear generation and encounter difficulty. However, Hope spend decisions
+belong to the player; making the GM the authoritative tracker creates confusion
+about who owns the value. Deferred pending playtesting to determine if GM
+visibility is actually needed at the table.
+
+**Exclude all player tracking** — the runner can't function without HP, stress,
+and armor. GMs need enough player state to resolve incoming attacks and apply
+damage correctly.
+
+**GM-controlled state only (chosen)** — clean boundary: the GM app owns what
+the GM does at the table. Player-decision state (Hope, resource spends) stays
+with the player.
+
+## Consequences
+
+- `PlayerSlot` has no Hope field. This is intentional and should not be added
+  without revisiting this ADR.
+- The player popover in the runner exposes HP, Stress, Armor Slots, and
+  Conditions — not Hope or any other player-sheet data.
+- Hope tracking may be reconsidered after playtesting reveals whether GMs
+  genuinely need GM-side visibility into player Hope balances.
+- A future player companion app that tracks Hope must be designed with a sync
+  interface that does not conflict with the existing `PlayerSlot` model.
+- The `Condition` type (Hidden, Restrained, Vulnerable, custom) is shared
+  between `AdversarySlot` and `PlayerSlot` — conditions are always GM-applied
+  in the runner.

--- a/docs/first-principles.md
+++ b/docs/first-principles.md
@@ -1,0 +1,115 @@
+# Encounter — First Principles
+
+These principles guide every product and technical decision in this app.
+They define what the app is, who it is for, and what it will never become.
+When facing an ambiguous decision, return here first.
+
+---
+
+## 1. The GM at the table is the primary user
+
+Every interaction is designed for a Game Master running a game with players watching.
+Speed, clarity, and minimal taps during combat take priority over configurability,
+data completeness, or power-user features.
+
+If a feature creates friction at the table, it doesn't belong in the runner.
+If it belongs in prep, it should be invisible during play.
+
+## 2. The encounter is the unit of work
+
+The app's spine is a single lifecycle: **Plan → Build → Run**.
+
+Features that don't fit somewhere in that arc — campaign arc tracking, world-building,
+character advancement, loot tables, NPC relationship webs — are out of scope for
+this app. The encounter boundary is the product boundary.
+
+## 3. No surprises during play
+
+Content updates, network fetches, and data migrations are always user-initiated
+and happen outside of an active session. Nothing changes state underneath a GM
+during combat.
+
+iCloud sync is the one exception — but it must be surfaced, not silently applied
+mid-session.
+
+## 4. The app augments the table; it doesn't replace it
+
+Physical dice stay physical. Social moments — rolling, players spending Hope,
+the drama of a crit — belong to the players and the table. The app removes
+bookkeeping friction; it does not automate or intercept the play experience.
+
+Don't intercede in the physical and social experience at the table unless
+explicitly asked.
+
+## 5. Player-owned state stays with the player
+
+The GM app tracks what the GM controls and applies: conditions, adversary state,
+the Fear pool. It does not replicate state that belongs to the player — Hope
+balances, character advancement, character sheet data.
+
+The architecture leaves the door open for a future player-side app to share
+that state bidirectionally. This app does not own it.
+
+## 6. Daggerheart rules are authoritative, not approximated
+
+All mechanics must match the SRD exactly. No house-rule defaults, no "close enough."
+When a rule is ambiguous in the SRD, the interpretation is recorded as an ADR.
+
+The app supports the game as written — it is a tool, not a variant ruleset.
+
+## 7. Content is open, not locked
+
+The `.dhpack` format is publicly documented, plain JSON, and independent of this app.
+Adversaries and environments are portable across tools.
+
+Any GM should be able to create, share, and import content without approval,
+proprietary tooling, or encoding. The app is an open platform for Daggerheart content.
+
+## 8. GM authority is absolute
+
+The SRD provides defaults, formulas, and guidance, and the app implements them
+faithfully. But the GM is always in control of every value, regardless of what
+the rules say.
+
+HP, Fear, conditions, budget thresholds, damage applied — all must be directly
+editable by the GM at any time. A GM should be able to fudge a roll result,
+quietly heal an adversary, or ignore the difficulty budget entirely if it serves
+the story at the table.
+
+Difficulty warnings and balance indicators are advisory information only.
+They never block, prevent, or require confirmation to override.
+
+## 9. Platform-native, not least-common-denominator
+
+iPhone is the primary run-time device (at the table). Mac is the primary prep
+device (building encounters, managing content). visionOS is a supported build
+target but receives no platform-specific design work at this stage.
+
+Adapt each platform appropriately with `#if os()`, `NavigationSplitView` vs
+`NavigationStack`, and platform-idiomatic gestures. Don't force a single layout
+on all three platforms.
+
+## 10. Value types for catalog data; observable classes for live state
+
+Immutable catalog data — adversaries, environments, packs — is always value types
+(structs and enums). Live session state — `EncounterSession`, `AdversarySlot`,
+`PlayerSlot` — is mutable observable classes.
+
+This boundary is not negotiable. Crossing it produces the snapshot/live mismatch
+bugs the project has already eliminated (see ADR-0011).
+
+## 11. Local-first, always
+
+All core functionality operates entirely on-device. No required accounts, no
+mandatory login, no remote service dependency at runtime.
+
+iCloud sync is additive: it works when available and fails gracefully when not.
+Future local-network sharing (GM and player apps on the same table network) and
+eventual remote support for distributed play are valid extensions of this
+foundation — not requirements that change the core.
+
+---
+
+*These principles are intended to be stable. If a principle needs to change,
+treat it like an ADR: write a new entry that supersedes the old one and
+explains what changed and why. Do not silently edit the principles above.*


### PR DESCRIPTION
## Summary

- **`docs/first-principles.md`** — 11 product principles defining what the app is, who it is for, and what it will never become. Stable reference for all development and contribution decisions.
- **`CONTRIBUTING.md`** — public-facing scope boundaries (in scope / hard no / not in scope), code and testing expectations, swift-format requirement, ADR process, and PR policy (human proposer and reviewer required; AI-generated code permitted).
- **`CLAUDE.md`** — updated project structure tree, swift-format added to Conventions, stale Known Gaps section replaced with forward references to new docs.
- **ADR-0034** — adopt `swift-format` (built-in Swift toolchain) as project formatter.
- **ADR-0035** — local-first architecture: all core functionality on-device; iCloud sync and content fetching are additive and user-initiated.
- **ADR-0036** — player-owned state boundary: Hope excluded from `PlayerSlot`; GM-applied conditions included; architecture leaves room for future player-side sync.

## Context

This work came out of a planning session that established the product identity for the app before Phase 3 (Encounter Builder) development begins. The first principles and CONTRIBUTING.md are specifically intended to provide clear guardrails for open-source contributors, including agentic contributors working autonomously.

## Test plan

- [ ] Verify `docs/first-principles.md` renders correctly on GitHub
- [ ] Verify `CONTRIBUTING.md` renders correctly on GitHub (scope tables, code blocks)
- [ ] Verify ADR files follow the established format (`docs/decisions/README.md`)
- [ ] Confirm `CLAUDE.md` references to new files resolve correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)