### PR TITLE
docs: mark SRD data as complete (closes #24)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -117,9 +117,9 @@ Full schema documentation: `docs/data-schema.md`
 | Player content (classes, ancestries, items) | daggersearch/daggerheart-data | Not yet imported; no adversaries in this repo |
 | Homebrew schema | Same as SRD JSON | Decoder accepts both `thresholds: "8/15"` and pre-split keys |
 
-The bundled `adversaries.json` and `environments.json` in `Encounter/Resources/` are
-sample/stub files. Replace them with the full SRD exports from seansbox/daggerheart-srd
-to get the complete adversary list.
+The bundled `adversaries.json` and `environments.json` in `Encounter/Resources/` contain
+the complete SRD exports from seansbox/daggerheart-srd (129 adversaries, 19 environments).
+See `Encounter/Resources/README.md` for license attribution.
 
 ---
 


### PR DESCRIPTION
## Summary

- The full SRD data was already imported in PR #10 (129 adversaries, 19 environments)
- All `SRDDecodeTests` pass, covering every acceptance criterion in the issue
- CLAUDE.md still described the files as "sample/stub" — corrected to reflect current state

## Test plan

- [x] `SRDDecodeTests/allSRDAdversariesDecodeWithoutError` — passes
- [x] `SRDDecodeTests/allSRDEnvironmentsDecodeWithoutError` — passes
- [x] `SRDDecodeTests/srdAdversaryCountMatchesExpected` (129) — passes
- [x] `SRDDecodeTests/srdEnvironmentCountMatchesExpected` (19) — passes
- [x] `SRDDecodeTests/srdAdversaryIDsAreUnique` — passes
- [x] `SRDDecodeTests/srdAdversariesHaveNonEmptyFeatureText` — passes

Closes #24