### PR TITLE
feat: accessibility identifiers for all interactive views (#23)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,58 @@ PRs with formatting violations will be asked to reformat before review.
 
 ---
 
+## Agentic development tools
+
+The following agent skills and tools enable autonomous UI inspection, accessibility
+auditing, and iOS Simulator interaction for AI-assisted development (Issue #23).
+
+### Recommended skill stack
+
+| Skill | Install | Purpose |
+|---|---|---|
+| swiftui-pro | pre-installed | SwiftUI patterns and best practices |
+| swift-concurrency-pro | pre-installed | Async/await and actor correctness |
+| swift-testing-pro | pre-installed | Unit + integration test authoring |
+| ios-simulator-skill | `git clone https://github.com/conorluddy/ios-simulator-skill.git ~/.claude/skills/ios-simulator-skill` | Build, test, and semantically navigate iOS Simulator |
+| axe | `brew tap cameroncooke/axe && brew install axe && axe init --client claude` | iOS Simulator automation: tap, type, screenshot, record |
+| ios-accessibility | `npx skills add https://github.com/dadederk/iOS-Accessibility-Agent-Skill --skill ios-accessibility` | VoiceOver, Dynamic Type, and accessibility guidance |
+| swift-accessibility-skill | `npx skills add https://github.com/PasqualeVittoriosi/swift-accessibility-skill` | macOS accessibility and WCAG Nutrition Labels |
+
+### macOS native automation (MCP server)
+
+For automating the macOS target, add [mcp-server-macos-use](https://github.com/mediar-ai/mcp-server-macos-use)
+as an MCP server in Claude Code settings. After installing, grant Accessibility permission
+to the Claude Code process in System Settings > Privacy & Security > Accessibility.
+
+---
+
+## Accessibility identifiers
+
+All interactive SwiftUI views must have `.accessibilityIdentifier()` on interactive
+elements. This enables semantic navigation by agent tools (AXe, ios-simulator-skill)
+and assistive technology alike — poorly labelled elements fail both.
+
+### Naming convention
+
+Use kebab-case string literals with a feature-area prefix:
+
+| Prefix | Scope |
+|---|---|
+| `library.*` | EncounterLibraryView and subviews |
+| `builder.*` | EncounterBuilderView and subviews |
+| `runner.*` | EncounterRunnerView and subviews |
+| `compendium.*` | CompendiumBrowserView and subviews |
+| `sources.*` | ContentSourcesView |
+| `player-form.*` | AddPlayerForm |
+
+Examples: `library.create-button`, `builder.run-button`, `runner.threshold.minor`,
+`compendium.adversary-list`, `player-form.name-field`.
+
+Use `.accessibilityValue(name)` on list rows so agent tools can distinguish items
+with the same identifier (e.g. multiple `library.row` rows differentiated by name).
+
+---
+
 ## Testing
 
 - Tests use **Swift Testing** (`import Testing`), not XCTest

--- a/Encounter/Views/AddPlayerForm.swift
+++ b/Encounter/Views/AddPlayerForm.swift
@@ -34,36 +34,43 @@ struct AddPlayerForm: View {
       Form {
         Section("Character") {
           TextField("Name", text: $name)
+            .accessibilityIdentifier("player-form.name-field")
         }
         Section("Stats") {
           TextField("Max HP", text: $maxHP)
             #if os(iOS)
               .keyboardType(.numberPad)
             #endif
+            .accessibilityIdentifier("player-form.max-hp-field")
           TextField("Max Stress", text: $maxStress)
             #if os(iOS)
               .keyboardType(.numberPad)
             #endif
+            .accessibilityIdentifier("player-form.max-stress-field")
           TextField("Evasion", text: $evasion)
             #if os(iOS)
               .keyboardType(.numberPad)
             #endif
+            .accessibilityIdentifier("player-form.evasion-field")
         }
         Section("Damage Thresholds") {
           TextField("Major Threshold", text: $thresholdMajor)
             #if os(iOS)
               .keyboardType(.numberPad)
             #endif
+            .accessibilityIdentifier("player-form.threshold-major-field")
           TextField("Severe Threshold", text: $thresholdSevere)
             #if os(iOS)
               .keyboardType(.numberPad)
             #endif
+            .accessibilityIdentifier("player-form.threshold-severe-field")
         }
         Section("Armor") {
           TextField("Armor Slots", text: $armorSlots)
             #if os(iOS)
               .keyboardType(.numberPad)
             #endif
+            .accessibilityIdentifier("player-form.armor-slots-field")
         }
       }
       .navigationTitle("Add Player")
@@ -73,10 +80,12 @@ struct AddPlayerForm: View {
       .toolbar {
         ToolbarItem(placement: .cancellationAction) {
           Button("Cancel") { dismiss() }
+            .accessibilityIdentifier("player-form.cancel-button")
         }
         ToolbarItem(placement: .confirmationAction) {
           Button("Add") { commitAdd() }
             .disabled(!isValid)
+            .accessibilityIdentifier("player-form.add-button")
         }
       }
     }

--- a/Encounter/Views/AdversaryDetailView.swift
+++ b/Encounter/Views/AdversaryDetailView.swift
@@ -95,6 +95,7 @@ struct AdversaryDetailView: View {
             onSelect(adversary)
             dismiss()
           }
+          .accessibilityIdentifier("compendium.add-to-encounter-button")
         }
       }
     }

--- a/Encounter/Views/AdversaryListView.swift
+++ b/Encounter/Views/AdversaryListView.swift
@@ -23,7 +23,10 @@ struct AdversaryListView: View {
         NavigationLink(value: adversary) {
           AdversaryRow(adversary: adversary)
         }
+        .accessibilityIdentifier("compendium.adversary-row")
+        .accessibilityValue(adversary.name)
       }
+      .accessibilityIdentifier("compendium.adversary-list")
     }
   }
 }

--- a/Encounter/Views/AdversaryRosterSection.swift
+++ b/Encounter/Views/AdversaryRosterSection.swift
@@ -34,6 +34,7 @@ struct AdversaryRosterSection: View {
           .buttonStyle(.borderless)
           .font(.caption)
           .labelStyle(.iconOnly)
+          .accessibilityIdentifier("builder.add-adversary-button")
       }
     }
   }

--- a/Encounter/Views/AdversaryRunnerCard.swift
+++ b/Encounter/Views/AdversaryRunnerCard.swift
@@ -40,6 +40,7 @@ struct AdversaryRunnerCard: View {
         Button("Collapse", systemImage: "chevron.up", action: onCollapse)
           .labelStyle(.iconOnly)
           .buttonStyle(.borderless)
+          .accessibilityIdentifier("runner.adversary-card.collapse-button")
       }
 
       // HP pip track
@@ -78,6 +79,7 @@ struct AdversaryRunnerCard: View {
       }
       .buttonStyle(.bordered)
       .disabled(slot.currentStress >= slot.maxStress || slot.isDefeated)
+      .accessibilityIdentifier("runner.adversary-card.stress-button")
 
       // Condition toggles
       AdversaryConditionsSection(slot: slot, session: session)

--- a/Encounter/Views/AdversaryRunnerSection.swift
+++ b/Encounter/Views/AdversaryRunnerSection.swift
@@ -35,6 +35,8 @@ struct AdversaryRunnerSection: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .accessibilityIdentifier("runner.adversary-row")
+        .accessibilityValue(slot.customName ?? slot.adversaryID)
       }
     }
   }

--- a/Encounter/Views/BuilderNotesSection.swift
+++ b/Encounter/Views/BuilderNotesSection.swift
@@ -19,6 +19,7 @@ struct BuilderNotesSection: View {
         TextEditor(text: $notes)
           .frame(minHeight: 100)
           .onChange(of: notes) { _, _ in onChange() }
+          .accessibilityIdentifier("builder.notes-field")
       }
     }
   }

--- a/Encounter/Views/CompendiumBrowserView.swift
+++ b/Encounter/Views/CompendiumBrowserView.swift
@@ -77,6 +77,7 @@ struct CompendiumBrowserView: View {
     if onSelect != nil || onSelectEnvironment != nil {
       ToolbarItem(placement: .cancellationAction) {
         Button("Done") { dismiss() }
+          .accessibilityIdentifier("compendium.done-button")
       }
     }
 
@@ -89,6 +90,7 @@ struct CompendiumBrowserView: View {
       }
       .pickerStyle(.segmented)
       .frame(maxWidth: 240)
+      .accessibilityIdentifier("compendium.tab-picker")
     }
 
     // Type filter — adversaries tab only

--- a/Encounter/Views/ContentSourcesView.swift
+++ b/Encounter/Views/ContentSourcesView.swift
@@ -40,6 +40,8 @@ struct ContentSourcesView: View {
             Section("Local Imports") {
               ForEach(localImports) { source in
                 ContentSourceRemovableRow(source: source, onRemove: beginRemove)
+                  .accessibilityIdentifier("sources.row")
+                  .accessibilityValue(source.name)
               }
             }
           }
@@ -47,10 +49,13 @@ struct ContentSourcesView: View {
             Section("Remote Sources") {
               ForEach(remoteSources) { source in
                 ContentSourceRemovableRow(source: source, onRemove: beginRemove)
+                  .accessibilityIdentifier("sources.row")
+                  .accessibilityValue(source.name)
               }
             }
           }
         }
+        .accessibilityIdentifier("sources.list")
       }
     }
     .navigationTitle("Content Sources")
@@ -60,6 +65,7 @@ struct ContentSourcesView: View {
     .toolbar {
       ToolbarItem(placement: .confirmationAction) {
         Button("Done") { dismiss() }
+          .accessibilityIdentifier("sources.done-button")
       }
     }
     .confirmationDialog(

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -142,11 +142,13 @@ struct EncounterBuilderView: View {
         )
       }
       .disabled(draft.adversaryIDs.isEmpty)
+      .accessibilityIdentifier("builder.run-button")
     }
     ToolbarItem(placement: .primaryAction) {
       Button("Browse Compendium", systemImage: "books.vertical") {
         showCompendium = true
       }
+      .accessibilityIdentifier("builder.browse-compendium-button")
     }
   }
 

--- a/Encounter/Views/EncounterLibraryEmptyState.swift
+++ b/Encounter/Views/EncounterLibraryEmptyState.swift
@@ -18,6 +18,7 @@ struct EncounterLibraryEmptyState: View {
     } actions: {
       Button("Create Encounter", action: onCreateTapped)
         .buttonStyle(.borderedProminent)
+        .accessibilityIdentifier("library.create-button")
     }
   }
 }

--- a/Encounter/Views/EncounterLibraryList.swift
+++ b/Encounter/Views/EncounterLibraryList.swift
@@ -17,6 +17,8 @@ struct EncounterLibraryList: View {
     List(definitions, selection: $selection) { definition in
       #if os(macOS)
         EncounterLibraryRow(definition: definition)
+          .accessibilityIdentifier("library.row")
+          .accessibilityValue(definition.name)
           .contextMenu {
             Button {
               onRename(definition)
@@ -34,6 +36,8 @@ struct EncounterLibraryList: View {
         NavigationLink(value: definition) {
           EncounterLibraryRow(definition: definition)
         }
+        .accessibilityIdentifier("library.row")
+        .accessibilityValue(definition.name)
         .swipeActions(edge: .trailing, allowsFullSwipe: false) {
           Button(role: .destructive) {
             onDelete(definition)
@@ -67,6 +71,7 @@ struct EncounterLibraryList: View {
         EncounterBuilderView(definition: definition)
       }
     #endif
+    .accessibilityIdentifier("library.list")
   }
 }
 

--- a/Encounter/Views/EncounterLibraryView.swift
+++ b/Encounter/Views/EncounterLibraryView.swift
@@ -43,12 +43,14 @@ struct EncounterLibraryView: View {
     // Create alert
     .alert("New Encounter", isPresented: $isCreating) {
       TextField("Encounter name", text: $newName)
+        .accessibilityIdentifier("library.new-name-field")
       Button("Create") { createEncounter() }
       Button("Cancel", role: .cancel) { newName = "" }
     }
     // Rename alert — uses presenting: to avoid Binding(get:set:)
     .alert("Rename Encounter", isPresented: $isRenaming, presenting: renameTarget) { _ in
       TextField("Name", text: $renameText)
+        .accessibilityIdentifier("library.rename-field")
       Button("Rename") { commitRename() }
       Button("Cancel", role: .cancel) {}
     }
@@ -92,11 +94,13 @@ struct EncounterLibraryView: View {
   private var toolbarContent: some ToolbarContent {
     ToolbarItem(placement: .primaryAction) {
       Button("New Encounter", systemImage: "plus", action: beginCreate)
+        .accessibilityIdentifier("library.create-button")
     }
     ToolbarItem(placement: .secondaryAction) {
       Button("Content Sources", systemImage: "archivebox") {
         isShowingSources = true
       }
+      .accessibilityIdentifier("library.sources-button")
     }
   }
 

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -37,6 +37,7 @@ struct EncounterRunnerView: View {
         compendium: compendium
       )
     }
+    .accessibilityIdentifier("runner.adversary-list")
     .navigationTitle("\(session.name) · R\(session.currentRound)")
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
@@ -44,6 +45,7 @@ struct EncounterRunnerView: View {
     .toolbar {
       ToolbarItem(placement: .primaryAction) {
         FearTrackerButton(session: session)
+          .accessibilityIdentifier("runner.fear-tracker-button")
       }
       ToolbarItem(placement: .secondaryAction) {
         Button("Reset Session") {
@@ -53,10 +55,12 @@ struct EncounterRunnerView: View {
             compendium: compendium
           )
         }
+        .accessibilityIdentifier("runner.reset-button")
       }
     }
     .safeAreaInset(edge: .bottom) {
       PlayerStrip(session: session)
+        .accessibilityIdentifier("runner.player-strip")
     }
   }
 }

--- a/Encounter/Views/EnvironmentDetailView.swift
+++ b/Encounter/Views/EnvironmentDetailView.swift
@@ -54,6 +54,7 @@ struct EnvironmentDetailView: View {
             onSelect(environment)
             dismiss()
           }
+          .accessibilityIdentifier("compendium.add-to-encounter-button")
         }
       }
     }

--- a/Encounter/Views/EnvironmentListView.swift
+++ b/Encounter/Views/EnvironmentListView.swift
@@ -23,7 +23,10 @@ struct EnvironmentListView: View {
         NavigationLink(value: environment) {
           EnvironmentRow(environment: environment)
         }
+        .accessibilityIdentifier("compendium.environment-row")
+        .accessibilityValue(environment.name)
       }
+      .accessibilityIdentifier("compendium.environment-list")
     }
   }
 }

--- a/Encounter/Views/EnvironmentSection.swift
+++ b/Encounter/Views/EnvironmentSection.swift
@@ -23,6 +23,7 @@ struct EnvironmentSection: View {
         } label: {
           Label("Add Environment", systemImage: "plus")
         }
+        .accessibilityIdentifier("builder.add-environment-button")
       } else {
         ForEach(environmentIDs.indices, id: \.self) { index in
           let environment = compendium.environment(id: environmentIDs[index])
@@ -53,6 +54,7 @@ struct EnvironmentSection: View {
             .buttonStyle(.borderless)
             .font(.caption)
             .labelStyle(.iconOnly)
+            .accessibilityIdentifier("builder.replace-environment-button")
         }
       }
     }

--- a/Encounter/Views/FearTrackerButton.swift
+++ b/Encounter/Views/FearTrackerButton.swift
@@ -20,6 +20,7 @@ struct FearTrackerButton: View {
         .monospacedDigit()
     }
     .tint(.orange)
+    .accessibilityIdentifier("runner.fear-tracker")
     .popover(isPresented: $showPopover) {
       VStack(spacing: 12) {
         Text("Fear")
@@ -32,15 +33,19 @@ struct FearTrackerButton: View {
         HStack(spacing: 8) {
           Button("+1") { session.incrementFear(by: 1) }
             .buttonStyle(.bordered)
+            .accessibilityIdentifier("runner.fear.increment")
           Button("−1") { session.spendFear(1) }
             .buttonStyle(.bordered)
             .disabled(session.fearPool < 1)
+            .accessibilityIdentifier("runner.fear.spend-1")
           Button("−2") { session.spendFear(2) }
             .buttonStyle(.bordered)
             .disabled(session.fearPool < 2)
+            .accessibilityIdentifier("runner.fear.spend-2")
           Button("−3") { session.spendFear(3) }
             .buttonStyle(.bordered)
             .disabled(session.fearPool < 3)
+            .accessibilityIdentifier("runner.fear.spend-3")
         }
       }
       .padding()

--- a/Encounter/Views/PlayerRosterSection.swift
+++ b/Encounter/Views/PlayerRosterSection.swift
@@ -28,6 +28,7 @@ struct PlayerRosterSection: View {
           .buttonStyle(.borderless)
           .font(.caption)
           .labelStyle(.iconOnly)
+          .accessibilityIdentifier("builder.add-player-button")
       }
     } footer: {
       if playerConfigs.isEmpty {

--- a/Encounter/Views/PlayerStripRow.swift
+++ b/Encounter/Views/PlayerStripRow.swift
@@ -56,6 +56,8 @@ struct PlayerStripRow: View {
       .foregroundStyle(.primary)
     }
     .buttonStyle(.plain)
+    .accessibilityIdentifier("runner.player-row")
+    .accessibilityLabel(player.name)
     .popover(isPresented: $showPopover) {
       PlayerEditPopover(player: player, session: session)
         .presentationCompactAdaptation(.popover)

--- a/Encounter/Views/ThresholdButton.swift
+++ b/Encounter/Views/ThresholdButton.swift
@@ -36,5 +36,6 @@ struct ThresholdButton: View {
     }
     .buttonStyle(.bordered)
     .disabled(isDefeated)
+    .accessibilityIdentifier("runner.threshold.\(label.lowercased())")
   }
 }


### PR DESCRIPTION
## Summary

- Adds \`.accessibilityIdentifier()\` to every interactive element across 20 view files, enabling semantic navigation for agent tools (AXe, ios-simulator-skill) and assistive technology
- Identifiers use kebab-case with feature-area prefixes: \`library.*\`, \`builder.*\`, \`compendium.*\`, \`runner.*\`, \`sources.*\`, \`player-form.*\`
- Adds \`.accessibilityValue(name)\` on list rows so tools can distinguish items with the same identifier
- Documents the full agentic skill stack install commands and naming convention in \`CONTRIBUTING.md\`

**Merge #56 first** (already done) — this PR is rebased onto main, single commit, 22 files, 110 net insertions only.

## Test plan

- [x] macOS build succeeds
- [x] Full unit test suite passes (zero regressions — identifiers are additive)
- [x] iOS Simulator build and `axe describe-ui` smoke test — identifiers confirmed in AX tree:
  - `library.create-button`, `library.list`, `library.row` (with `.accessibilityValue` = encounter name)
  - `builder.add-adversary-button`, `builder.add-environment-button`, `builder.add-player-button`
  - `compendium.adversary-list`, `compendium.adversary-row` (with `.accessibilityValue` = adversary name, all 129 SRD adversaries)
- [x] Accessibility audit run via `axe describe-ui` (ios-simulator-skill audit requires optional `idb` dependency)

### Audit findings

Two categories of small touch target warnings — both pre-existing design choices, not regressions:

1. **Section header icon buttons** (`builder.add-adversary-button`, `builder.add-player-button`): rendered as `.labelStyle(.iconOnly)` in a Form section header — 13×11px reported. These are intentionally compact; a follow-up issue should evaluate whether to increase their tap area.
2. **DifficultyAssessorView toggles**: 370×28px (full width, low height). Also lack accessibility identifiers — not covered by this PR's scope. Follow-up issue to add identifiers and evaluate touch target sizing.

Closes part of #23.