### PR TITLE
chore: apply swift-format to entire codebase

### DIFF
--- a/Encounter/ContentView.swift
+++ b/Encounter/ContentView.swift
@@ -8,36 +8,37 @@
 import SwiftUI
 
 struct ContentView: View {
-    @Environment(EncounterStore.self) private var store
-    @State private var selection: EncounterDefinition.ID?
+  @Environment(EncounterStore.self) private var store
+  @State private var selection: EncounterDefinition.ID?
 
-    var body: some View {
-        #if os(macOS)
-        NavigationSplitView {
-            EncounterLibraryView(selection: $selection)
-        } detail: {
-            NavigationStack {
-                if let id = selection,
-                   let definition = store.definitions.first(where: { $0.id == id }) {
-                    EncounterBuilderView(definition: definition)
-                        .id(id)
-                } else {
-                    Text("Select an encounter")
-                        .foregroundStyle(.secondary)
-                }
-            }
-        }
-        #else
+  var body: some View {
+    #if os(macOS)
+      NavigationSplitView {
+        EncounterLibraryView(selection: $selection)
+      } detail: {
         NavigationStack {
-            EncounterLibraryView(selection: $selection)
+          if let id = selection,
+            let definition = store.definitions.first(where: { $0.id == id })
+          {
+            EncounterBuilderView(definition: definition)
+              .id(id)
+          } else {
+            Text("Select an encounter")
+              .foregroundStyle(.secondary)
+          }
         }
-        #endif
-    }
+      }
+    #else
+      NavigationStack {
+        EncounterLibraryView(selection: $selection)
+      }
+    #endif
+  }
 }
 
 #Preview {
-    ContentView()
-        .environment(EncounterStore(directory: .temporaryDirectory))
-        .environment(Compendium())
-        .environment(SessionRegistry())
+  ContentView()
+    .environment(EncounterStore(directory: .temporaryDirectory))
+    .environment(Compendium())
+    .environment(SessionRegistry())
 }

--- a/Encounter/EncounterApp.swift
+++ b/Encounter/EncounterApp.swift
@@ -9,57 +9,57 @@ import SwiftUI
 
 @main
 struct EncounterApp: App {
-    @State private var compendium      = Compendium()
-    @State private var store           = EncounterStore(directory: EncounterStore.localDirectory)
-    @State private var sessionRegistry = SessionRegistry()
-    // Initialized with the local placeholder directory so the store is non-nil
-    // from the first render. relocate(to:) is called in .task once the real
-    // directory is resolved, before loadOnStartup() reads or writes anything.
-    @State private var contentStore    = ContentStore(
-        contentDirectory: ContentStore.localContentDirectory,
-        compendium: Compendium()   // placeholder; replaced by the real compendium below
-    )
+  @State private var compendium = Compendium()
+  @State private var store = EncounterStore(directory: EncounterStore.localDirectory)
+  @State private var sessionRegistry = SessionRegistry()
+  // Initialized with the local placeholder directory so the store is non-nil
+  // from the first render. relocate(to:) is called in .task once the real
+  // directory is resolved, before loadOnStartup() reads or writes anything.
+  @State private var contentStore = ContentStore(
+    contentDirectory: ContentStore.localContentDirectory,
+    compendium: Compendium()  // placeholder; replaced by the real compendium below
+  )
 
-    var body: some Scene {
-        WindowGroup {
-            ContentView()
-                .environment(compendium)
-                .environment(store)
-                .environment(sessionRegistry)
-                .environment(contentStore)
-                .task {
-                    let dir = await EncounterStore.defaultDirectory()
-                    store.relocate(to: dir)
+  var body: some Scene {
+    WindowGroup {
+      ContentView()
+        .environment(compendium)
+        .environment(store)
+        .environment(sessionRegistry)
+        .environment(contentStore)
+        .task {
+          let dir = await EncounterStore.defaultDirectory()
+          store.relocate(to: dir)
 
-                    // Content lives alongside encounters in the same Application
-                    // Support root, one level up from the Encounters subdirectory.
-                    let contentDir = dir.deletingLastPathComponent()
-                        .appending(path: "Content", directoryHint: .isDirectory)
+          // Content lives alongside encounters in the same Application
+          // Support root, one level up from the Encounters subdirectory.
+          let contentDir = dir.deletingLastPathComponent()
+            .appending(path: "Content", directoryHint: .isDirectory)
 
-                    // Wire in the real Compendium and switch to the resolved directory.
-                    // configure() avoids recreating ContentStore just to swap the reference.
-                    contentStore.configure(compendium: compendium)
-                    await contentStore.relocate(to: contentDir)
+          // Wire in the real Compendium and switch to the resolved directory.
+          // configure() avoids recreating ContentStore just to swap the reference.
+          contentStore.configure(compendium: compendium)
+          await contentStore.relocate(to: contentDir)
 
-                    // All three loads are independent — run concurrently.
-                    async let compendiumLoad: Void = compendium.load()
-                    async let storeLoad: Void      = store.load()
-                    async let contentLoad: Void    = contentStore.loadOnStartup()
-                    do { try await compendiumLoad } catch {}
-                    await storeLoad
-                    await contentLoad
-                }
-                // onOpenURL on the root view handles .dhpack file opens on both
-                // iOS and macOS. contentStore is non-nil from first render, so
-                // there is no startup race.
-                .onOpenURL { url in
-                    guard url.pathExtension.lowercased() == "dhpack" else { return }
-                    guard url.startAccessingSecurityScopedResource() else { return }
-                    Task { @MainActor in
-                        defer { url.stopAccessingSecurityScopedResource() }
-                        await contentStore.importPack(from: url)
-                    }
-                }
+          // All three loads are independent — run concurrently.
+          async let compendiumLoad: Void = compendium.load()
+          async let storeLoad: Void = store.load()
+          async let contentLoad: Void = contentStore.loadOnStartup()
+          do { try await compendiumLoad } catch {}
+          await storeLoad
+          await contentLoad
+        }
+        // onOpenURL on the root view handles .dhpack file opens on both
+        // iOS and macOS. contentStore is non-nil from first render, so
+        // there is no startup race.
+        .onOpenURL { url in
+          guard url.pathExtension.lowercased() == "dhpack" else { return }
+          guard url.startAccessingSecurityScopedResource() else { return }
+          Task { @MainActor in
+            defer { url.stopAccessingSecurityScopedResource() }
+            await contentStore.importPack(from: url)
+          }
         }
     }
+  }
 }

--- a/Encounter/Models/Adversary.swift
+++ b/Encounter/Models/Adversary.swift
@@ -22,55 +22,55 @@ import Foundation
 /// Source: Daggerheart SRD "Using Adversaries" — each type modifies
 /// how the adversary is run at the table.
 nonisolated public enum AdversaryType: String, Codable, CaseIterable, Sendable {
-    /// Tough; deliver powerful attacks. Usually have extra HP.
-    case bruiser  = "Bruiser"
-    /// Groups of identical creatures acting as a single unit.
-    /// Special HP/attack rules apply; see SRD "Horde" section.
-    case horde    = "Horde"
-    /// Command and summon other adversaries. High stress capacity.
-    case leader   = "Leader"
-    /// Easily dispatched but dangerous in numbers.
-    case minion   = "Minion"
-    /// Fragile up close; deal high damage at range.
-    case ranged   = "Ranged"
-    /// Maneuver and exploit opportunities to ambush.
-    case skulk    = "Skulk"
-    /// Present conversation-based challenges.
-    case social   = "Social"
-    /// Designed for one-on-one or climactic encounters.
-    case solo     = "Solo"
-    /// Catch-all for adversaries without an explicit type label.
-    case standard = "Standard"
-    /// Enhance allies and disrupt opponents.
-    case support  = "Support"
+  /// Tough; deliver powerful attacks. Usually have extra HP.
+  case bruiser = "Bruiser"
+  /// Groups of identical creatures acting as a single unit.
+  /// Special HP/attack rules apply; see SRD "Horde" section.
+  case horde = "Horde"
+  /// Command and summon other adversaries. High stress capacity.
+  case leader = "Leader"
+  /// Easily dispatched but dangerous in numbers.
+  case minion = "Minion"
+  /// Fragile up close; deal high damage at range.
+  case ranged = "Ranged"
+  /// Maneuver and exploit opportunities to ambush.
+  case skulk = "Skulk"
+  /// Present conversation-based challenges.
+  case social = "Social"
+  /// Designed for one-on-one or climactic encounters.
+  case solo = "Solo"
+  /// Catch-all for adversaries without an explicit type label.
+  case standard = "Standard"
+  /// Enhance allies and disrupt opponents.
+  case support = "Support"
 
-    // SRD JSON encodes horde variants with HP-per-unit notation,
-    // e.g. "Horde (3/HP)". Normalise all to .horde.
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.singleValueContainer()
-        let raw = try container.decode(String.self)
-        if let exact = Self(rawValue: raw) {
-            self = exact
-        } else if raw.hasPrefix("Horde") {
-            self = .horde
-        } else {
-            throw DecodingError.dataCorruptedError(
-                in: container,
-                debugDescription: "Unknown AdversaryType '\(raw)'"
-            )
-        }
+  // SRD JSON encodes horde variants with HP-per-unit notation,
+  // e.g. "Horde (3/HP)". Normalise all to .horde.
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.singleValueContainer()
+    let raw = try container.decode(String.self)
+    if let exact = Self(rawValue: raw) {
+      self = exact
+    } else if raw.hasPrefix("Horde") {
+      self = .horde
+    } else {
+      throw DecodingError.dataCorruptedError(
+        in: container,
+        debugDescription: "Unknown AdversaryType '\(raw)'"
+      )
     }
+  }
 }
 
 // MARK: - AttackRange
 
 /// Distance bands used for attacks and abilities in Daggerheart.
 nonisolated public enum AttackRange: String, Codable, CaseIterable, Sendable {
-    case melee     = "Melee"
-    case veryClose = "Very Close"
-    case close     = "Close"
-    case far       = "Far"
-    case veryFar   = "Very Far"
+  case melee = "Melee"
+  case veryClose = "Very Close"
+  case close = "Close"
+  case far = "Far"
+  case veryFar = "Very Far"
 }
 
 // MARK: - FeatureType
@@ -81,57 +81,58 @@ nonisolated public enum AttackRange: String, Codable, CaseIterable, Sendable {
 /// - **Reactions** trigger regardless of who has the spotlight.
 /// - **Passives** are always in effect.
 nonisolated public enum FeatureType: String, Codable, CaseIterable, Sendable {
-    case action   = "action"
-    case reaction = "reaction"
-    case passive  = "passive"
+  case action = "action"
+  case reaction = "reaction"
+  case passive = "passive"
 
-    /// Infers the feature type from the " - Type" suffix in SRD feature names,
-    /// e.g. "Earth Eruption - Action" → .action. Defaults to .passive.
-    static func inferred(from featureName: String) -> FeatureType {
-        let lower = featureName.lowercased()
-        if lower.hasSuffix("- action") { return .action }
-        if lower.hasSuffix("- reaction") { return .reaction }
-        return .passive
-    }
+  /// Infers the feature type from the " - Type" suffix in SRD feature names,
+  /// e.g. "Earth Eruption - Action" → .action. Defaults to .passive.
+  static func inferred(from featureName: String) -> FeatureType {
+    let lower = featureName.lowercased()
+    if lower.hasSuffix("- action") { return .action }
+    if lower.hasSuffix("- reaction") { return .reaction }
+    return .passive
+  }
 }
 
 // MARK: - AdversaryFeature
 
 /// A single named feature (action, reaction, or passive) on an adversary or environment.
 nonisolated public struct AdversaryFeature: Codable, Identifiable, Sendable, Equatable, Hashable {
-    // `id` uses name because feature names are unique within a given adversary.
-    public var id: String { name }
+  // `id` uses name because feature names are unique within a given adversary.
+  public var id: String { name }
 
-    public let name: String
-    public let text: String
-    public let featType: FeatureType
+  public let name: String
+  public let text: String
+  public let featType: FeatureType
 
-    // Community JSON uses "feat_type"; SRD JSON omits it entirely.
-    // When absent, type is inferred from the " - Type" suffix in the feature name.
-    enum CodingKeys: String, CodingKey {
-        case name
-        case text
-        case featType = "feat_type"
+  // Community JSON uses "feat_type"; SRD JSON omits it entirely.
+  // When absent, type is inferred from the " - Type" suffix in the feature name.
+  enum CodingKeys: String, CodingKey {
+    case name
+    case text
+    case featType = "feat_type"
+  }
+
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    name = try c.decode(String.self, forKey: .name)
+    text = try c.decode(String.self, forKey: .text)
+    if let rawType = try c.decodeIfPresent(String.self, forKey: .featType),
+      let parsed = FeatureType(rawValue: rawType)
+    {
+      featType = parsed
+    } else {
+      // SRD JSON omits feat_type; infer from the " - Type" name suffix.
+      featType = FeatureType.inferred(from: name)
     }
+  }
 
-    public init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        name = try c.decode(String.self, forKey: .name)
-        text = try c.decode(String.self, forKey: .text)
-        if let rawType = try c.decodeIfPresent(String.self, forKey: .featType),
-           let parsed = FeatureType(rawValue: rawType) {
-            featType = parsed
-        } else {
-            // SRD JSON omits feat_type; infer from the " - Type" name suffix.
-            featType = FeatureType.inferred(from: name)
-        }
-    }
-
-    public init(name: String, text: String, featType: FeatureType) {
-        self.name = name
-        self.text = text
-        self.featType = featType
-    }
+  public init(name: String, text: String, featType: FeatureType) {
+    self.name = name
+    self.text = text
+    self.featType = featType
+  }
 }
 
 // MARK: - Adversary
@@ -150,227 +151,230 @@ nonisolated public struct AdversaryFeature: Codable, Identifiable, Sendable, Equ
 /// are accepted.
 nonisolated public struct Adversary: Codable, Identifiable, Sendable, Equatable, Hashable {
 
-    // MARK: Identity
-    /// URL-safe slug, e.g. `"acid-burrower"`. Used as stable ID for cross-referencing.
-    public let id: String
-    public let name: String
-    /// Content source tag, always lowercased: `"srd"`, `"homebrew"`, a book name, etc.
-    /// Values from external JSON are normalized to lowercase at decode time.
-    public let source: String
-    /// `true` if this adversary comes from a non-SRD source (homebrew or a named book).
-    public var isHomebrew: Bool { source != "srd" }
+  // MARK: Identity
+  /// URL-safe slug, e.g. `"acid-burrower"`. Used as stable ID for cross-referencing.
+  public let id: String
+  public let name: String
+  /// Content source tag, always lowercased: `"srd"`, `"homebrew"`, a book name, etc.
+  /// Values from external JSON are normalized to lowercase at decode time.
+  public let source: String
+  /// `true` if this adversary comes from a non-SRD source (homebrew or a named book).
+  public var isHomebrew: Bool { source != "srd" }
 
-    // MARK: Classification
-    /// Opposes PCs of the matching tier (1–4).
-    public let tier: Int
-    public let type: AdversaryType
+  // MARK: Classification
+  /// Opposes PCs of the matching tier (1–4).
+  public let tier: Int
+  public let type: AdversaryType
 
-    // MARK: Description
-    public let description: String
-    /// GM-facing guidance on how to play this adversary at the table.
-    public let motivesAndTactics: String?
+  // MARK: Description
+  public let description: String
+  /// GM-facing guidance on how to play this adversary at the table.
+  public let motivesAndTactics: String?
 
-    // MARK: Core Stats
-    /// The DC for all player rolls made against this adversary.
-    /// Adversaries never roll Evasion — they use a flat Difficulty.
-    public let difficulty: Int
-    /// Damage required to trigger a **Major** hit on this adversary.
-    public let thresholdMajor: Int
-    /// Damage required to trigger a **Severe** hit on this adversary.
-    public let thresholdSevere: Int
-    public let hp: Int
-    public let stress: Int
+  // MARK: Core Stats
+  /// The DC for all player rolls made against this adversary.
+  /// Adversaries never roll Evasion — they use a flat Difficulty.
+  public let difficulty: Int
+  /// Damage required to trigger a **Major** hit on this adversary.
+  public let thresholdMajor: Int
+  /// Damage required to trigger a **Severe** hit on this adversary.
+  public let thresholdSevere: Int
+  public let hp: Int
+  public let stress: Int
 
-    // MARK: Standard Attack
-    /// Attack modifier string, e.g. `"+3"`.
-    public let attackModifier: String
-    /// Name of the standard attack or weapon, e.g. `"Claws"`.
-    public let attackName: String
-    public let attackRange: AttackRange
-    /// Damage expression, e.g. `"1d12+2 phy"`. Parse with a dice library as needed.
-    public let damage: String
+  // MARK: Standard Attack
+  /// Attack modifier string, e.g. `"+3"`.
+  public let attackModifier: String
+  /// Name of the standard attack or weapon, e.g. `"Claws"`.
+  public let attackName: String
+  public let attackRange: AttackRange
+  /// Damage expression, e.g. `"1d12+2 phy"`. Parse with a dice library as needed.
+  public let damage: String
 
-    // MARK: Additional
-    /// Optional experience tag, e.g. `"Tremor Sense +2"`.
-    public let experience: String?
-    /// Actions, reactions, and passives for this adversary.
-    public let features: [AdversaryFeature]
+  // MARK: Additional
+  /// Optional experience tag, e.g. `"Tremor Sense +2"`.
+  public let experience: String?
+  /// Actions, reactions, and passives for this adversary.
+  public let features: [AdversaryFeature]
 
-    // MARK: - CodingKeys
+  // MARK: - CodingKeys
 
-    enum CodingKeys: String, CodingKey {
-        case id, name, source, tier, type, description
-        case motivesAndTactics  = "motives_and_tactics"
-        case difficulty
-        // Raw combined key from community JSON ("8/15"):
-        case thresholds
-        // Pre-split alternative keys (our own export format):
-        case thresholdMajor     = "threshold_major"
-        case thresholdSevere    = "threshold_severe"
-        case hp, stress
-        case attackModifier     = "atk"
-        case attackName         = "attack"
-        case attackRange        = "range"
-        case damage, experience
-        case features           = "feature"
+  enum CodingKeys: String, CodingKey {
+    case id, name, source, tier, type, description
+    case motivesAndTactics = "motives_and_tactics"
+    case difficulty
+    // Raw combined key from community JSON ("8/15"):
+    case thresholds
+    // Pre-split alternative keys (our own export format):
+    case thresholdMajor = "threshold_major"
+    case thresholdSevere = "threshold_severe"
+    case hp, stress
+    case attackModifier = "atk"
+    case attackName = "attack"
+    case attackRange = "range"
+    case damage, experience
+    case features = "feature"
+  }
+
+  // MARK: - Decode Helpers
+
+  /// Derives a URL-safe slug from a display name, e.g. "Acid Burrower" → "acid-burrower".
+  private static func slug(_ name: String) -> String {
+    name.lowercased()
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .filter { !$0.isEmpty }
+      .joined(separator: "-")
+  }
+
+  /// Decodes a keyed value that the source JSON may encode as either an Int or a numeric String.
+  private static func intOrString<K: CodingKey>(
+    _ container: KeyedDecodingContainer<K>, forKey key: K
+  ) throws -> Int {
+    if let intVal = try? container.decode(Int.self, forKey: key) { return intVal }
+    let str = try container.decode(String.self, forKey: key)
+    guard let intVal = Int(str) else {
+      throw DecodingError.dataCorruptedError(
+        forKey: key, in: container,
+        debugDescription: "Expected Int or numeric String, got '\(str)'"
+      )
     }
+    return intVal
+  }
 
-    // MARK: - Decode Helpers
+  // MARK: - Decodable
 
-    /// Derives a URL-safe slug from a display name, e.g. "Acid Burrower" → "acid-burrower".
-    private static func slug(_ name: String) -> String {
-        name.lowercased()
-            .components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { !$0.isEmpty }
-            .joined(separator: "-")
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+
+    // name decoded first so it can serve as the id fallback.
+    name = try c.decode(String.self, forKey: .name)
+    let rawID = try c.decodeIfPresent(String.self, forKey: .id) ?? Self.slug(name)
+    guard !rawID.isEmpty else {
+      throw DecodingError.dataCorruptedError(
+        forKey: .id, in: c,
+        debugDescription: "Adversary 'id' must not be empty (name: '\(name)')"
+      )
     }
+    id = rawID
+    // Normalize source to lowercase so "SRD", "srd", "Homebrew", etc. all compare equal.
+    source = (try c.decodeIfPresent(String.self, forKey: .source) ?? "srd").lowercased()
+    // SRD JSON encodes numeric stats as strings; homebrew may use ints.
+    tier = try Self.intOrString(c, forKey: .tier)
+    type = try c.decode(AdversaryType.self, forKey: .type)
+    description = try c.decode(String.self, forKey: .description)
+    motivesAndTactics = try c.decodeIfPresent(String.self, forKey: .motivesAndTactics)
+    difficulty = try Self.intOrString(c, forKey: .difficulty)
+    hp = try Self.intOrString(c, forKey: .hp)
+    stress = try Self.intOrString(c, forKey: .stress)
+    attackModifier = try c.decode(String.self, forKey: .attackModifier)
+    attackName = try c.decode(String.self, forKey: .attackName)
+    attackRange = try c.decode(AttackRange.self, forKey: .attackRange)
+    damage = try c.decode(String.self, forKey: .damage)
+    experience = try c.decodeIfPresent(String.self, forKey: .experience)
+    features = try c.decodeIfPresent([AdversaryFeature].self, forKey: .features) ?? []
 
-    /// Decodes a keyed value that the source JSON may encode as either an Int or a numeric String.
-    private static func intOrString<K: CodingKey>(
-        _ container: KeyedDecodingContainer<K>, forKey key: K
-    ) throws -> Int {
-        if let intVal = try? container.decode(Int.self, forKey: key) { return intVal }
-        let str = try container.decode(String.self, forKey: key)
-        guard let intVal = Int(str) else {
-            throw DecodingError.dataCorruptedError(
-                forKey: key, in: container,
-                debugDescription: "Expected Int or numeric String, got '\(str)'"
-            )
+    // Threshold decoding: prefer pre-split keys, fall back to "major/severe" string.
+    if let major = try c.decodeIfPresent(Int.self, forKey: .thresholdMajor),
+      let severe = try c.decodeIfPresent(Int.self, forKey: .thresholdSevere)
+    {
+      thresholdMajor = major
+      thresholdSevere = severe
+    } else if let raw = try c.decodeIfPresent(String.self, forKey: .thresholds) {
+      // SRD minions encode "None" — they have no damage thresholds.
+      // Some adversaries encode a partial value like "4/None" where the
+      // severe threshold is absent. Treat any "None" component as 0.
+      if raw == "None" {
+        thresholdMajor = 0
+        thresholdSevere = 0
+      } else {
+        let parts =
+          raw
+          .split(separator: "/")
+          .map { $0.trimmingCharacters(in: .whitespaces) }
+        guard parts.count == 2 else {
+          throw DecodingError.dataCorruptedError(
+            forKey: .thresholds, in: c,
+            debugDescription: "Expected 'major/severe' format, got '\(raw)'"
+          )
         }
-        return intVal
+        thresholdMajor = Int(parts[0]) ?? 0
+        thresholdSevere = Int(parts[1]) ?? 0
+      }
+    } else {
+      throw DecodingError.keyNotFound(
+        CodingKeys.thresholds,
+        DecodingError.Context(
+          codingPath: c.codingPath,
+          debugDescription:
+            "No threshold data found (tried 'thresholds', 'threshold_major'/'threshold_severe')"
+        )
+      )
     }
+  }
 
-    // MARK: - Decodable
+  // MARK: - Encodable (uses pre-split keys for clarity)
 
-    public init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(id, forKey: .id)
+    try c.encode(name, forKey: .name)
+    try c.encode(source, forKey: .source)
+    try c.encode(tier, forKey: .tier)
+    try c.encode(type, forKey: .type)
+    try c.encode(description, forKey: .description)
+    try c.encodeIfPresent(motivesAndTactics, forKey: .motivesAndTactics)
+    try c.encode(difficulty, forKey: .difficulty)
+    try c.encode(thresholdMajor, forKey: .thresholdMajor)
+    try c.encode(thresholdSevere, forKey: .thresholdSevere)
+    try c.encode(hp, forKey: .hp)
+    try c.encode(stress, forKey: .stress)
+    try c.encode(attackModifier, forKey: .attackModifier)
+    try c.encode(attackName, forKey: .attackName)
+    try c.encode(attackRange, forKey: .attackRange)
+    try c.encode(damage, forKey: .damage)
+    try c.encodeIfPresent(experience, forKey: .experience)
+    try c.encode(features, forKey: .features)
+  }
 
-        // name decoded first so it can serve as the id fallback.
-        name        = try c.decode(String.self, forKey: .name)
-        let rawID   = try c.decodeIfPresent(String.self, forKey: .id) ?? Self.slug(name)
-        guard !rawID.isEmpty else {
-            throw DecodingError.dataCorruptedError(
-                forKey: .id, in: c,
-                debugDescription: "Adversary 'id' must not be empty (name: '\(name)')"
-            )
-        }
-        id = rawID
-        // Normalize source to lowercase so "SRD", "srd", "Homebrew", etc. all compare equal.
-        source      = (try c.decodeIfPresent(String.self, forKey: .source) ?? "srd").lowercased()
-        // SRD JSON encodes numeric stats as strings; homebrew may use ints.
-        tier        = try Self.intOrString(c, forKey: .tier)
-        type        = try c.decode(AdversaryType.self, forKey: .type)
-        description = try c.decode(String.self,       forKey: .description)
-        motivesAndTactics = try c.decodeIfPresent(String.self, forKey: .motivesAndTactics)
-        difficulty  = try Self.intOrString(c, forKey: .difficulty)
-        hp          = try Self.intOrString(c, forKey: .hp)
-        stress      = try Self.intOrString(c, forKey: .stress)
-        attackModifier = try c.decode(String.self,    forKey: .attackModifier)
-        attackName  = try c.decode(String.self,       forKey: .attackName)
-        attackRange = try c.decode(AttackRange.self,  forKey: .attackRange)
-        damage      = try c.decode(String.self,       forKey: .damage)
-        experience  = try c.decodeIfPresent(String.self, forKey: .experience)
-        features    = try c.decodeIfPresent([AdversaryFeature].self, forKey: .features) ?? []
+  // MARK: - Memberwise init (for previews / tests)
 
-        // Threshold decoding: prefer pre-split keys, fall back to "major/severe" string.
-        if let major  = try c.decodeIfPresent(Int.self, forKey: .thresholdMajor),
-           let severe = try c.decodeIfPresent(Int.self, forKey: .thresholdSevere) {
-            thresholdMajor  = major
-            thresholdSevere = severe
-        } else if let raw = try c.decodeIfPresent(String.self, forKey: .thresholds) {
-            // SRD minions encode "None" — they have no damage thresholds.
-            // Some adversaries encode a partial value like "4/None" where the
-            // severe threshold is absent. Treat any "None" component as 0.
-            if raw == "None" {
-                thresholdMajor  = 0
-                thresholdSevere = 0
-            } else {
-                let parts = raw
-                    .split(separator: "/")
-                    .map { $0.trimmingCharacters(in: .whitespaces) }
-                guard parts.count == 2 else {
-                    throw DecodingError.dataCorruptedError(
-                        forKey: .thresholds, in: c,
-                        debugDescription: "Expected 'major/severe' format, got '\(raw)'"
-                    )
-                }
-                thresholdMajor  = Int(parts[0]) ?? 0
-                thresholdSevere = Int(parts[1]) ?? 0
-            }
-        } else {
-            throw DecodingError.keyNotFound(
-                CodingKeys.thresholds,
-                DecodingError.Context(
-                    codingPath: c.codingPath,
-                    debugDescription: "No threshold data found (tried 'thresholds', 'threshold_major'/'threshold_severe')"
-                )
-            )
-        }
-    }
-
-    // MARK: - Encodable (uses pre-split keys for clarity)
-
-    public func encode(to encoder: Encoder) throws {
-        var c = encoder.container(keyedBy: CodingKeys.self)
-        try c.encode(id,             forKey: .id)
-        try c.encode(name,           forKey: .name)
-        try c.encode(source,         forKey: .source)
-        try c.encode(tier,           forKey: .tier)
-        try c.encode(type,           forKey: .type)
-        try c.encode(description,    forKey: .description)
-        try c.encodeIfPresent(motivesAndTactics, forKey: .motivesAndTactics)
-        try c.encode(difficulty,     forKey: .difficulty)
-        try c.encode(thresholdMajor, forKey: .thresholdMajor)
-        try c.encode(thresholdSevere, forKey: .thresholdSevere)
-        try c.encode(hp,             forKey: .hp)
-        try c.encode(stress,         forKey: .stress)
-        try c.encode(attackModifier, forKey: .attackModifier)
-        try c.encode(attackName,     forKey: .attackName)
-        try c.encode(attackRange,    forKey: .attackRange)
-        try c.encode(damage,         forKey: .damage)
-        try c.encodeIfPresent(experience, forKey: .experience)
-        try c.encode(features,       forKey: .features)
-    }
-
-    // MARK: - Memberwise init (for previews / tests)
-
-    public init(
-        id: String,
-        name: String,
-        source: String = "srd",
-        tier: Int,
-        type: AdversaryType,
-        description: String,
-        motivesAndTactics: String? = nil,
-        difficulty: Int,
-        thresholdMajor: Int,
-        thresholdSevere: Int,
-        hp: Int,
-        stress: Int,
-        attackModifier: String,
-        attackName: String,
-        attackRange: AttackRange,
-        damage: String,
-        experience: String? = nil,
-        features: [AdversaryFeature] = []
-    ) {
-        self.id = id
-        self.name = name
-        self.source = source
-        self.tier = tier
-        self.type = type
-        self.description = description
-        self.motivesAndTactics = motivesAndTactics
-        self.difficulty = difficulty
-        self.thresholdMajor = thresholdMajor
-        self.thresholdSevere = thresholdSevere
-        self.hp = hp
-        self.stress = stress
-        self.attackModifier = attackModifier
-        self.attackName = attackName
-        self.attackRange = attackRange
-        self.damage = damage
-        self.experience = experience
-        self.features = features
-    }
+  public init(
+    id: String,
+    name: String,
+    source: String = "srd",
+    tier: Int,
+    type: AdversaryType,
+    description: String,
+    motivesAndTactics: String? = nil,
+    difficulty: Int,
+    thresholdMajor: Int,
+    thresholdSevere: Int,
+    hp: Int,
+    stress: Int,
+    attackModifier: String,
+    attackName: String,
+    attackRange: AttackRange,
+    damage: String,
+    experience: String? = nil,
+    features: [AdversaryFeature] = []
+  ) {
+    self.id = id
+    self.name = name
+    self.source = source
+    self.tier = tier
+    self.type = type
+    self.description = description
+    self.motivesAndTactics = motivesAndTactics
+    self.difficulty = difficulty
+    self.thresholdMajor = thresholdMajor
+    self.thresholdSevere = thresholdSevere
+    self.hp = hp
+    self.stress = stress
+    self.attackModifier = attackModifier
+    self.attackName = attackName
+    self.attackRange = attackRange
+    self.damage = damage
+    self.experience = experience
+    self.features = features
+  }
 }

--- a/Encounter/Models/Compendium.swift
+++ b/Encounter/Models/Compendium.swift
@@ -14,24 +14,24 @@
 //
 
 import Foundation
-import Observation
 import OSLog
+import Observation
 
 // MARK: - CompendiumError
 
 /// Errors that can occur while loading compendium data.
 nonisolated public enum CompendiumError: Error, LocalizedError {
-    case fileNotFound(String)
-    case decodingFailed(String, Error)
+  case fileNotFound(String)
+  case decodingFailed(String, Error)
 
-    public var errorDescription: String? {
-        switch self {
-        case .fileNotFound(let name):
-            return "Compendium resource '\(name)' not found in app bundle."
-        case .decodingFailed(let name, let underlying):
-            return "Failed to decode '\(name)': \(underlying.localizedDescription)"
-        }
+  public var errorDescription: String? {
+    switch self {
+    case .fileNotFound(let name):
+      return "Compendium resource '\(name)' not found in app bundle."
+    case .decodingFailed(let name, let underlying):
+      return "Failed to decode '\(name)': \(underlying.localizedDescription)"
     }
+  }
 }
 
 // MARK: - Compendium
@@ -66,252 +66,262 @@ nonisolated public enum CompendiumError: Error, LocalizedError {
 @Observable
 public final class Compendium {
 
-    private let logger = Logger(subsystem: "gwillish.Encounter", category: "Compendium")
+  private let logger = Logger(subsystem: "gwillish.Encounter", category: "Compendium")
 
-    // MARK: Published State
+  // MARK: Published State
 
-    /// SRD adversaries loaded from the bundle, keyed by slug.
-    private var srdAdversariesByID: [String: Adversary] = [:]
+  /// SRD adversaries loaded from the bundle, keyed by slug.
+  private var srdAdversariesByID: [String: Adversary] = [:]
 
-    /// Community source packs, keyed by source ID then by adversary slug.
-    /// Allows packs to be added and removed independently without a full rebuild.
-    private var sourcesAdversariesByID: [String: [String: Adversary]] = [:]
+  /// Community source packs, keyed by source ID then by adversary slug.
+  /// Allows packs to be added and removed independently without a full rebuild.
+  private var sourcesAdversariesByID: [String: [String: Adversary]] = [:]
 
-    /// Homebrew adversaries added at runtime, keyed by slug.
-    /// Homebrew entries with the same `id` as any source or SRD entry take priority.
-    private var homebrewAdversariesByID: [String: Adversary] = [:]
+  /// Homebrew adversaries added at runtime, keyed by slug.
+  /// Homebrew entries with the same `id` as any source or SRD entry take priority.
+  private var homebrewAdversariesByID: [String: Adversary] = [:]
 
-    /// SRD environments loaded from the bundle, keyed by slug.
-    private var srdEnvironmentsByID: [String: DaggerheartEnvironment] = [:]
+  /// SRD environments loaded from the bundle, keyed by slug.
+  private var srdEnvironmentsByID: [String: DaggerheartEnvironment] = [:]
 
-    /// Community source pack environments, keyed by source ID then by environment slug.
-    private var sourcesEnvironmentsByID: [String: [String: DaggerheartEnvironment]] = [:]
+  /// Community source pack environments, keyed by source ID then by environment slug.
+  private var sourcesEnvironmentsByID: [String: [String: DaggerheartEnvironment]] = [:]
 
-    /// Homebrew environments added at runtime, keyed by slug.
-    private var homebrewEnvironmentsByID: [String: DaggerheartEnvironment] = [:]
+  /// Homebrew environments added at runtime, keyed by slug.
+  private var homebrewEnvironmentsByID: [String: DaggerheartEnvironment] = [:]
 
-    /// Cached result of the last adversary merge. `nil` when the cache is dirty.
-    private var _cachedAdversariesByID: [String: Adversary]?
+  /// Cached result of the last adversary merge. `nil` when the cache is dirty.
+  private var _cachedAdversariesByID: [String: Adversary]?
 
-    /// Cached result of the last environment merge. `nil` when the cache is dirty.
-    private var _cachedEnvironmentsByID: [String: DaggerheartEnvironment]?
+  /// Cached result of the last environment merge. `nil` when the cache is dirty.
+  private var _cachedEnvironmentsByID: [String: DaggerheartEnvironment]?
 
-    /// All adversaries merged in priority order: homebrew → sources → srd.
-    /// Within sources, higher-priority packs should be inserted last to win conflicts.
-    /// Result is cached; invalidated whenever any source bucket changes.
-    public var adversariesByID: [String: Adversary] {
-        if let cached = _cachedAdversariesByID { return cached }
-        var merged = srdAdversariesByID
-        for packAdversaries in sourcesAdversariesByID.values {
-            merged.merge(packAdversaries) { _, source in source }
-        }
-        merged.merge(homebrewAdversariesByID) { _, homebrew in homebrew }
-        _cachedAdversariesByID = merged
-        return merged
+  /// All adversaries merged in priority order: homebrew → sources → srd.
+  /// Within sources, higher-priority packs should be inserted last to win conflicts.
+  /// Result is cached; invalidated whenever any source bucket changes.
+  public var adversariesByID: [String: Adversary] {
+    if let cached = _cachedAdversariesByID { return cached }
+    var merged = srdAdversariesByID
+    for packAdversaries in sourcesAdversariesByID.values {
+      merged.merge(packAdversaries) { _, source in source }
     }
+    merged.merge(homebrewAdversariesByID) { _, homebrew in homebrew }
+    _cachedAdversariesByID = merged
+    return merged
+  }
 
-    /// All environments merged in priority order: homebrew → sources → srd.
-    /// Result is cached; invalidated whenever any source bucket changes.
-    public var environmentsByID: [String: DaggerheartEnvironment] {
-        if let cached = _cachedEnvironmentsByID { return cached }
-        var merged = srdEnvironmentsByID
-        for packEnvironments in sourcesEnvironmentsByID.values {
-            merged.merge(packEnvironments) { _, source in source }
-        }
-        merged.merge(homebrewEnvironmentsByID) { _, homebrew in homebrew }
-        _cachedEnvironmentsByID = merged
-        return merged
+  /// All environments merged in priority order: homebrew → sources → srd.
+  /// Result is cached; invalidated whenever any source bucket changes.
+  public var environmentsByID: [String: DaggerheartEnvironment] {
+    if let cached = _cachedEnvironmentsByID { return cached }
+    var merged = srdEnvironmentsByID
+    for packEnvironments in sourcesEnvironmentsByID.values {
+      merged.merge(packEnvironments) { _, source in source }
     }
+    merged.merge(homebrewEnvironmentsByID) { _, homebrew in homebrew }
+    _cachedEnvironmentsByID = merged
+    return merged
+  }
 
-    /// Sorted array of all adversaries (for list views).
-    public var adversaries: [Adversary] {
-        adversariesByID.values.sorted { $0.name < $1.name }
+  /// Sorted array of all adversaries (for list views).
+  public var adversaries: [Adversary] {
+    adversariesByID.values.sorted { $0.name < $1.name }
+  }
+
+  /// Sorted array of all environments.
+  public var environments: [DaggerheartEnvironment] {
+    environmentsByID.values.sorted { $0.name < $1.name }
+  }
+
+  /// Sorted array of homebrew-only adversaries.
+  public var homebrewAdversaries: [Adversary] {
+    homebrewAdversariesByID.values.sorted { $0.name < $1.name }
+  }
+
+  /// Sorted array of homebrew-only environments.
+  public var homebrewEnvironments: [DaggerheartEnvironment] {
+    homebrewEnvironmentsByID.values.sorted { $0.name < $1.name }
+  }
+
+  /// `true` while JSON loading is in progress.
+  public private(set) var isLoading: Bool = false
+
+  /// Non-nil if the last load attempt failed.
+  public private(set) var loadError: CompendiumError?
+
+  // MARK: - Init
+
+  public init() {}
+
+  // MARK: - Loading
+
+  /// Load the SRD data from bundle resources.
+  ///
+  /// JSON decoding is performed on a background task; results are published
+  /// back on the main actor. Safe to call multiple times — concurrent calls
+  /// while a load is already in progress are ignored.
+  ///
+  /// Throws a ``CompendiumError`` if a resource is missing or malformed.
+  /// The error is also stored in ``loadError`` for SwiftUI observation.
+  public func load() async throws {
+    guard !isLoading else {
+      logger.debug("load() called while already loading — skipped")
+      return
     }
+    isLoading = true
+    loadError = nil
+    logger.info("Compendium load started")
 
-    /// Sorted array of all environments.
-    public var environments: [DaggerheartEnvironment] {
-        environmentsByID.values.sorted { $0.name < $1.name }
+    defer { isLoading = false }
+
+    do {
+      async let adversaries = Self.decodeArray(Adversary.self, fromResource: "adversaries")
+      async let environments = Self.decodeArray(
+        DaggerheartEnvironment.self, fromResource: "environments")
+      let (loadedAdversaries, loadedEnvironments) = try await (adversaries, environments)
+
+      srdAdversariesByID = Dictionary(uniqueKeysWithValues: loadedAdversaries.map { ($0.id, $0) })
+      srdEnvironmentsByID = Dictionary(uniqueKeysWithValues: loadedEnvironments.map { ($0.id, $0) })
+      _cachedAdversariesByID = nil
+      _cachedEnvironmentsByID = nil
+      logger.info(
+        "Compendium loaded \(loadedAdversaries.count) adversaries, \(loadedEnvironments.count) environments"
+      )
+    } catch let error as CompendiumError {
+      loadError = error
+      logger.error("Compendium load failed: \(error.localizedDescription)")
+      throw error
+    } catch {
+      let wrapped = CompendiumError.decodingFailed("unknown", error)
+      loadError = wrapped
+      logger.error("Compendium load failed (unexpected): \(error)")
+      throw wrapped
     }
+  }
 
-    /// Sorted array of homebrew-only adversaries.
-    public var homebrewAdversaries: [Adversary] {
-        homebrewAdversariesByID.values.sorted { $0.name < $1.name }
+  // MARK: - Lookup
+
+  /// Look up an adversary by slug, respecting the full priority order:
+  /// homebrew → sources → srd.
+  public func adversary(id: String) -> Adversary? {
+    adversariesByID[id]
+  }
+
+  /// Look up an environment by slug, respecting the full priority order:
+  /// homebrew → sources → srd.
+  public func environment(id: String) -> DaggerheartEnvironment? {
+    environmentsByID[id]
+  }
+
+  /// Return all adversaries for a given tier.
+  public func adversaries(tier: Int) -> [Adversary] {
+    adversaries.filter { $0.tier == tier }
+  }
+
+  /// Return all adversaries of a given type.
+  public func adversaries(type: AdversaryType) -> [Adversary] {
+    adversaries.filter { $0.type == type }
+  }
+
+  /// Full-text search across adversary names and descriptions.
+  /// Uses `localizedStandardContains` for diacritic- and case-insensitive matching.
+  public func searchAdversaries(query: String) -> [Adversary] {
+    guard !query.isEmpty else { return adversaries }
+    return adversaries.filter {
+      $0.name.localizedStandardContains(query) || $0.description.localizedStandardContains(query)
     }
+  }
 
-    /// Sorted array of homebrew-only environments.
-    public var homebrewEnvironments: [DaggerheartEnvironment] {
-        homebrewEnvironmentsByID.values.sorted { $0.name < $1.name }
+  // MARK: - SRD Reload
+
+  /// Replace the SRD adversary and environment dictionaries.
+  ///
+  /// Called by `ContentStore` after downloading a new SRD content pack.
+  /// The swap is atomic from the observation system's perspective.
+  public func replaceSRDContent(adversaries: [Adversary], environments: [DaggerheartEnvironment]) {
+    srdAdversariesByID = Dictionary(uniqueKeysWithValues: adversaries.map { ($0.id, $0) })
+    srdEnvironmentsByID = Dictionary(uniqueKeysWithValues: environments.map { ($0.id, $0) })
+    _cachedAdversariesByID = nil
+    _cachedEnvironmentsByID = nil
+    logger.info(
+      "Compendium SRD content replaced: \(adversaries.count) adversaries, \(environments.count) environments"
+    )
+  }
+
+  // MARK: - Source Pack Management
+
+  /// Install or replace a community source pack.
+  ///
+  /// The `sourceID` is the stable identifier for the pack (e.g. `"expanded-adversary-compendium"`).
+  /// Calling this again with the same `sourceID` replaces the previous pack entirely.
+  public func replaceSourceContent(
+    sourceID: String,
+    adversaries: [Adversary],
+    environments: [DaggerheartEnvironment]
+  ) {
+    sourcesAdversariesByID[sourceID] = Dictionary(
+      uniqueKeysWithValues: adversaries.map { ($0.id, $0) })
+    sourcesEnvironmentsByID[sourceID] = Dictionary(
+      uniqueKeysWithValues: environments.map { ($0.id, $0) })
+    _cachedAdversariesByID = nil
+    _cachedEnvironmentsByID = nil
+    logger.info(
+      "Compendium source '\(sourceID)' replaced: \(adversaries.count) adversaries, \(environments.count) environments"
+    )
+  }
+
+  /// Remove a community source pack entirely.
+  /// No-op if the `sourceID` is not present.
+  public func removeSourceContent(sourceID: String) {
+    sourcesAdversariesByID.removeValue(forKey: sourceID)
+    sourcesEnvironmentsByID.removeValue(forKey: sourceID)
+    _cachedAdversariesByID = nil
+    _cachedEnvironmentsByID = nil
+    logger.info("Compendium source '\(sourceID)' removed")
+  }
+
+  // MARK: - Homebrew
+
+  /// Add or replace a homebrew adversary.
+  /// Homebrew entries shadow SRD and source pack entries with the same `id`.
+  public func addAdversary(_ adversary: Adversary) {
+    homebrewAdversariesByID[adversary.id] = adversary
+    _cachedAdversariesByID = nil
+  }
+
+  /// Remove a homebrew adversary by slug. No-op if not present.
+  public func removeHomebrewAdversary(id: String) {
+    homebrewAdversariesByID.removeValue(forKey: id)
+    _cachedAdversariesByID = nil
+  }
+
+  /// Add or replace a homebrew environment.
+  public func addEnvironment(_ environment: DaggerheartEnvironment) {
+    homebrewEnvironmentsByID[environment.id] = environment
+    _cachedEnvironmentsByID = nil
+  }
+
+  /// Remove a homebrew environment by slug. No-op if not present.
+  public func removeHomebrewEnvironment(id: String) {
+    homebrewEnvironmentsByID.removeValue(forKey: id)
+    _cachedEnvironmentsByID = nil
+  }
+
+  // MARK: - Private Helpers
+
+  nonisolated private static func decodeArray<T: Decodable>(
+    _ type: T.Type, fromResource name: String
+  ) async throws -> [T] {
+    guard let url = Bundle.main.url(forResource: name, withExtension: "json") else {
+      throw CompendiumError.fileNotFound("\(name).json")
     }
-
-    /// `true` while JSON loading is in progress.
-    public private(set) var isLoading: Bool = false
-
-    /// Non-nil if the last load attempt failed.
-    public private(set) var loadError: CompendiumError?
-
-    // MARK: - Init
-
-    public init() {}
-
-    // MARK: - Loading
-
-    /// Load the SRD data from bundle resources.
-    ///
-    /// JSON decoding is performed on a background task; results are published
-    /// back on the main actor. Safe to call multiple times — concurrent calls
-    /// while a load is already in progress are ignored.
-    ///
-    /// Throws a ``CompendiumError`` if a resource is missing or malformed.
-    /// The error is also stored in ``loadError`` for SwiftUI observation.
-    public func load() async throws {
-        guard !isLoading else {
-            logger.debug("load() called while already loading — skipped")
-            return
-        }
-        isLoading = true
-        loadError = nil
-        logger.info("Compendium load started")
-
-        defer { isLoading = false }
-
-        do {
-            async let adversaries = Self.decodeArray(Adversary.self, fromResource: "adversaries")
-            async let environments = Self.decodeArray(DaggerheartEnvironment.self, fromResource: "environments")
-            let (loadedAdversaries, loadedEnvironments) = try await (adversaries, environments)
-
-            srdAdversariesByID  = Dictionary(uniqueKeysWithValues: loadedAdversaries.map  { ($0.id, $0) })
-            srdEnvironmentsByID = Dictionary(uniqueKeysWithValues: loadedEnvironments.map { ($0.id, $0) })
-            _cachedAdversariesByID = nil
-            _cachedEnvironmentsByID = nil
-            logger.info("Compendium loaded \(loadedAdversaries.count) adversaries, \(loadedEnvironments.count) environments")
-        } catch let error as CompendiumError {
-            loadError = error
-            logger.error("Compendium load failed: \(error.localizedDescription)")
-            throw error
-        } catch {
-            let wrapped = CompendiumError.decodingFailed("unknown", error)
-            loadError = wrapped
-            logger.error("Compendium load failed (unexpected): \(error)")
-            throw wrapped
-        }
+    do {
+      let data = try Data(contentsOf: url)
+      return try JSONDecoder().decode([T].self, from: data)
+    } catch let error as CompendiumError {
+      throw error
+    } catch {
+      throw CompendiumError.decodingFailed("\(name).json", error)
     }
-
-    // MARK: - Lookup
-
-    /// Look up an adversary by slug, respecting the full priority order:
-    /// homebrew → sources → srd.
-    public func adversary(id: String) -> Adversary? {
-        adversariesByID[id]
-    }
-
-    /// Look up an environment by slug, respecting the full priority order:
-    /// homebrew → sources → srd.
-    public func environment(id: String) -> DaggerheartEnvironment? {
-        environmentsByID[id]
-    }
-
-    /// Return all adversaries for a given tier.
-    public func adversaries(tier: Int) -> [Adversary] {
-        adversaries.filter { $0.tier == tier }
-    }
-
-    /// Return all adversaries of a given type.
-    public func adversaries(type: AdversaryType) -> [Adversary] {
-        adversaries.filter { $0.type == type }
-    }
-
-    /// Full-text search across adversary names and descriptions.
-    /// Uses `localizedStandardContains` for diacritic- and case-insensitive matching.
-    public func searchAdversaries(query: String) -> [Adversary] {
-        guard !query.isEmpty else { return adversaries }
-        return adversaries.filter {
-            $0.name.localizedStandardContains(query) ||
-            $0.description.localizedStandardContains(query)
-        }
-    }
-
-    // MARK: - SRD Reload
-
-    /// Replace the SRD adversary and environment dictionaries.
-    ///
-    /// Called by `ContentStore` after downloading a new SRD content pack.
-    /// The swap is atomic from the observation system's perspective.
-    public func replaceSRDContent(adversaries: [Adversary], environments: [DaggerheartEnvironment]) {
-        srdAdversariesByID  = Dictionary(uniqueKeysWithValues: adversaries.map  { ($0.id, $0) })
-        srdEnvironmentsByID = Dictionary(uniqueKeysWithValues: environments.map { ($0.id, $0) })
-        _cachedAdversariesByID = nil
-        _cachedEnvironmentsByID = nil
-        logger.info("Compendium SRD content replaced: \(adversaries.count) adversaries, \(environments.count) environments")
-    }
-
-    // MARK: - Source Pack Management
-
-    /// Install or replace a community source pack.
-    ///
-    /// The `sourceID` is the stable identifier for the pack (e.g. `"expanded-adversary-compendium"`).
-    /// Calling this again with the same `sourceID` replaces the previous pack entirely.
-    public func replaceSourceContent(
-        sourceID: String,
-        adversaries: [Adversary],
-        environments: [DaggerheartEnvironment]
-    ) {
-        sourcesAdversariesByID[sourceID]  = Dictionary(uniqueKeysWithValues: adversaries.map  { ($0.id, $0) })
-        sourcesEnvironmentsByID[sourceID] = Dictionary(uniqueKeysWithValues: environments.map { ($0.id, $0) })
-        _cachedAdversariesByID = nil
-        _cachedEnvironmentsByID = nil
-        logger.info("Compendium source '\(sourceID)' replaced: \(adversaries.count) adversaries, \(environments.count) environments")
-    }
-
-    /// Remove a community source pack entirely.
-    /// No-op if the `sourceID` is not present.
-    public func removeSourceContent(sourceID: String) {
-        sourcesAdversariesByID.removeValue(forKey: sourceID)
-        sourcesEnvironmentsByID.removeValue(forKey: sourceID)
-        _cachedAdversariesByID = nil
-        _cachedEnvironmentsByID = nil
-        logger.info("Compendium source '\(sourceID)' removed")
-    }
-
-    // MARK: - Homebrew
-
-    /// Add or replace a homebrew adversary.
-    /// Homebrew entries shadow SRD and source pack entries with the same `id`.
-    public func addAdversary(_ adversary: Adversary) {
-        homebrewAdversariesByID[adversary.id] = adversary
-        _cachedAdversariesByID = nil
-    }
-
-    /// Remove a homebrew adversary by slug. No-op if not present.
-    public func removeHomebrewAdversary(id: String) {
-        homebrewAdversariesByID.removeValue(forKey: id)
-        _cachedAdversariesByID = nil
-    }
-
-    /// Add or replace a homebrew environment.
-    public func addEnvironment(_ environment: DaggerheartEnvironment) {
-        homebrewEnvironmentsByID[environment.id] = environment
-        _cachedEnvironmentsByID = nil
-    }
-
-    /// Remove a homebrew environment by slug. No-op if not present.
-    public func removeHomebrewEnvironment(id: String) {
-        homebrewEnvironmentsByID.removeValue(forKey: id)
-        _cachedEnvironmentsByID = nil
-    }
-
-    // MARK: - Private Helpers
-
-    nonisolated private static func decodeArray<T: Decodable>(_ type: T.Type, fromResource name: String) async throws -> [T] {
-        guard let url = Bundle.main.url(forResource: name, withExtension: "json") else {
-            throw CompendiumError.fileNotFound("\(name).json")
-        }
-        do {
-            let data = try Data(contentsOf: url)
-            return try JSONDecoder().decode([T].self, from: data)
-        } catch let error as CompendiumError {
-            throw error
-        } catch {
-            throw CompendiumError.decodingFailed("\(name).json", error)
-        }
-    }
+  }
 }

--- a/Encounter/Models/Condition.swift
+++ b/Encounter/Models/Condition.swift
@@ -21,68 +21,68 @@ import Foundation
 /// additional conditions via `.custom(String)`. The same condition cannot
 /// stack on a single target — use `Set<Condition>` to enforce this.
 nonisolated public enum Condition: Hashable, Sendable, Codable {
-    /// Rolls against this creature have disadvantage.
-    /// Removed when an adversary moves to see you, you move into sight, or you attack.
-    case hidden
-    /// Cannot move, but can take actions from current position.
-    /// Cleared with a successful action roll (PCs) or GM spending spotlight (adversaries).
-    case restrained
-    /// All rolls targeting this creature have advantage.
-    /// Applied when a PC marks all Stress. Cleared with a move.
-    case vulnerable
-    /// A feature-imposed condition with a custom name.
-    case custom(String)
+  /// Rolls against this creature have disadvantage.
+  /// Removed when an adversary moves to see you, you move into sight, or you attack.
+  case hidden
+  /// Cannot move, but can take actions from current position.
+  /// Cleared with a successful action roll (PCs) or GM spending spotlight (adversaries).
+  case restrained
+  /// All rolls targeting this creature have advantage.
+  /// Applied when a PC marks all Stress. Cleared with a move.
+  case vulnerable
+  /// A feature-imposed condition with a custom name.
+  case custom(String)
 
-    /// The three standard SRD conditions available for toggle in encounter UI.
-    /// `.custom` is omitted because it requires a name parameter.
-    public static let standardConditions: [Condition] = [.hidden, .restrained, .vulnerable]
+  /// The three standard SRD conditions available for toggle in encounter UI.
+  /// `.custom` is omitted because it requires a name parameter.
+  public static let standardConditions: [Condition] = [.hidden, .restrained, .vulnerable]
 
-    /// Human-readable display name for UI rendering.
-    public var displayName: String {
-        switch self {
-        case .hidden:            return "Hidden"
-        case .restrained:        return "Restrained"
-        case .vulnerable:        return "Vulnerable"
-        case .custom(let name):  return name
-        }
+  /// Human-readable display name for UI rendering.
+  public var displayName: String {
+    switch self {
+    case .hidden: return "Hidden"
+    case .restrained: return "Restrained"
+    case .vulnerable: return "Vulnerable"
+    case .custom(let name): return name
     }
+  }
 
-    // MARK: - Codable
+  // MARK: - Codable
 
-    private enum CodingKeys: String, CodingKey {
-        case type, name
+  private enum CodingKeys: String, CodingKey {
+    case type, name
+  }
+
+  public func encode(to encoder: Encoder) throws {
+    var container = encoder.container(keyedBy: CodingKeys.self)
+    switch self {
+    case .hidden:
+      try container.encode("hidden", forKey: .type)
+    case .restrained:
+      try container.encode("restrained", forKey: .type)
+    case .vulnerable:
+      try container.encode("vulnerable", forKey: .type)
+    case .custom(let name):
+      try container.encode("custom", forKey: .type)
+      try container.encode(name, forKey: .name)
     }
+  }
 
-    public func encode(to encoder: Encoder) throws {
-        var container = encoder.container(keyedBy: CodingKeys.self)
-        switch self {
-        case .hidden:
-            try container.encode("hidden", forKey: .type)
-        case .restrained:
-            try container.encode("restrained", forKey: .type)
-        case .vulnerable:
-            try container.encode("vulnerable", forKey: .type)
-        case .custom(let name):
-            try container.encode("custom", forKey: .type)
-            try container.encode(name, forKey: .name)
-        }
+  public init(from decoder: Decoder) throws {
+    let container = try decoder.container(keyedBy: CodingKeys.self)
+    let type = try container.decode(String.self, forKey: .type)
+    switch type {
+    case "hidden": self = .hidden
+    case "restrained": self = .restrained
+    case "vulnerable": self = .vulnerable
+    case "custom":
+      let name = try container.decode(String.self, forKey: .name)
+      self = .custom(name)
+    default:
+      throw DecodingError.dataCorruptedError(
+        forKey: .type, in: container,
+        debugDescription: "Unknown condition type: '\(type)'"
+      )
     }
-
-    public init(from decoder: Decoder) throws {
-        let container = try decoder.container(keyedBy: CodingKeys.self)
-        let type = try container.decode(String.self, forKey: .type)
-        switch type {
-        case "hidden":     self = .hidden
-        case "restrained": self = .restrained
-        case "vulnerable": self = .vulnerable
-        case "custom":
-            let name = try container.decode(String.self, forKey: .name)
-            self = .custom(name)
-        default:
-            throw DecodingError.dataCorruptedError(
-                forKey: .type, in: container,
-                debugDescription: "Unknown condition type: '\(type)'"
-            )
-        }
-    }
+  }
 }

--- a/Encounter/Models/ContentFingerprint.swift
+++ b/Encounter/Models/ContentFingerprint.swift
@@ -17,13 +17,13 @@ import Foundation
 /// Both fields are computed from the HTTP response at fetch time and persisted
 /// as part of ``ContentSource``.
 nonisolated public struct ContentFingerprint: Codable, Equatable, Hashable, Sendable {
-    /// SHA-256 hex digest of the downloaded bytes.
-    public let sha256: String
-    /// HTTP ETag from the last successful response, if the server provided one.
-    public let etag: String?
+  /// SHA-256 hex digest of the downloaded bytes.
+  public let sha256: String
+  /// HTTP ETag from the last successful response, if the server provided one.
+  public let etag: String?
 
-    public init(sha256: String, etag: String? = nil) {
-        self.sha256 = sha256
-        self.etag = etag
-    }
+  public init(sha256: String, etag: String? = nil) {
+    self.sha256 = sha256
+    self.etag = etag
+  }
 }

--- a/Encounter/Models/ContentSource.swift
+++ b/Encounter/Models/ContentSource.swift
@@ -30,113 +30,115 @@ import Foundation
 /// All `Date` properties are stored as ISO8601 Zulu strings per ADR-0013.
 nonisolated public struct ContentSource: Codable, Identifiable, Equatable, Hashable, Sendable {
 
-    /// Stable, lowercase slug identifying this source, e.g. `"expanded-adversary-compendium"`.
-    /// Used as a directory name and as the key in ``Compendium``'s sources tier.
-    public let id: String
+  /// Stable, lowercase slug identifying this source, e.g. `"expanded-adversary-compendium"`.
+  /// Used as a directory name and as the key in ``Compendium``'s sources tier.
+  public let id: String
 
-    /// Display name shown in the source management UI.
-    public var name: String
+  /// Display name shown in the source management UI.
+  public var name: String
 
-    /// Remote URL of the `.dhpack` file, or `nil` for locally imported packs.
-    ///
-    /// When `nil`, `ContentStore.fetchSource(id:)` is a no-op for this source.
-    /// Must be version-pinned when set (see ADR-0017).
-    public var url: URL?
+  /// Remote URL of the `.dhpack` file, or `nil` for locally imported packs.
+  ///
+  /// When `nil`, `ContentStore.fetchSource(id:)` is a no-op for this source.
+  /// Must be version-pinned when set (see ADR-0017).
+  public var url: URL?
 
-    /// ISO8601 Zulu date of the last successful fetch or import.
-    /// Nil if this source has never been successfully loaded.
-    /// Always stored and compared in UTC per ADR-0013.
-    public var lastFetched: Date?
+  /// ISO8601 Zulu date of the last successful fetch or import.
+  /// Nil if this source has never been successfully loaded.
+  /// Always stored and compared in UTC per ADR-0013.
+  public var lastFetched: Date?
 
-    /// Content fingerprint from the last successful fetch.
-    /// Nil for locally imported packs (no HTTP response to fingerprint).
-    public var fingerprint: ContentFingerprint?
+  /// Content fingerprint from the last successful fetch.
+  /// Nil for locally imported packs (no HTTP response to fingerprint).
+  public var fingerprint: ContentFingerprint?
 
-    /// Number of consecutive fetch failures since the last successful fetch.
-    /// Always 0 for local imports (they are never re-fetched automatically).
-    public private(set) var consecutiveFailures: Int
+  /// Number of consecutive fetch failures since the last successful fetch.
+  /// Always 0 for local imports (they are never re-fetched automatically).
+  public private(set) var consecutiveFailures: Int
 
-    /// The earliest date at which the next fetch attempt is permitted.
-    /// Nil means fetching is allowed immediately, or the source is a local import.
-    /// Set by exponential backoff whenever a remote fetch fails.
-    public private(set) var nextAllowedFetch: Date?
+  /// The earliest date at which the next fetch attempt is permitted.
+  /// Nil means fetching is allowed immediately, or the source is a local import.
+  /// Set by exponential backoff whenever a remote fetch fails.
+  public private(set) var nextAllowedFetch: Date?
 
-    // MARK: - Init
+  // MARK: - Init
 
-    /// Create a remote source (with a URL to fetch from).
-    public init(
-        id: String,
-        name: String,
-        url: URL,
-        lastFetched: Date? = nil,
-        fingerprint: ContentFingerprint? = nil,
-        consecutiveFailures: Int = 0,
-        nextAllowedFetch: Date? = nil
-    ) {
-        self.id = id
-        self.name = name
-        self.url = url
-        self.lastFetched = lastFetched
-        self.fingerprint = fingerprint
-        self.consecutiveFailures = consecutiveFailures
-        self.nextAllowedFetch = nextAllowedFetch
-    }
+  /// Create a remote source (with a URL to fetch from).
+  public init(
+    id: String,
+    name: String,
+    url: URL,
+    lastFetched: Date? = nil,
+    fingerprint: ContentFingerprint? = nil,
+    consecutiveFailures: Int = 0,
+    nextAllowedFetch: Date? = nil
+  ) {
+    self.id = id
+    self.name = name
+    self.url = url
+    self.lastFetched = lastFetched
+    self.fingerprint = fingerprint
+    self.consecutiveFailures = consecutiveFailures
+    self.nextAllowedFetch = nextAllowedFetch
+  }
 
-    /// Create a local import source (no remote URL).
-    public init(id: String, name: String, importedAt date: Date = .now) {
-        self.id = id
-        self.name = name
-        self.url = nil
-        self.lastFetched = date
-        self.fingerprint = nil
-        self.consecutiveFailures = 0
-        self.nextAllowedFetch = nil
-    }
+  /// Create a local import source (no remote URL).
+  public init(id: String, name: String, importedAt date: Date = .now) {
+    self.id = id
+    self.name = name
+    self.url = nil
+    self.lastFetched = date
+    self.fingerprint = nil
+    self.consecutiveFailures = 0
+    self.nextAllowedFetch = nil
+  }
 
-    // MARK: - Convenience
+  // MARK: - Convenience
 
-    /// `true` if this source was locally imported rather than fetched from a URL.
-    public var isLocalImport: Bool { url == nil }
+  /// `true` if this source was locally imported rather than fetched from a URL.
+  public var isLocalImport: Bool { url == nil }
 
-    // MARK: - Throttle check
+  // MARK: - Throttle check
 
-    /// Returns `true` if backoff is currently active for this source.
-    /// Always `false` for local imports.
-    public func isThrottled(at date: Date = .now) -> Bool {
-        guard let next = nextAllowedFetch else { return false }
-        return date < next
-    }
+  /// Returns `true` if backoff is currently active for this source.
+  /// Always `false` for local imports.
+  public func isThrottled(at date: Date = .now) -> Bool {
+    guard let next = nextAllowedFetch else { return false }
+    return date < next
+  }
 
-    // MARK: - Backoff mutations
-    //
-    // These return new values rather than mutating in place, keeping ContentSource
-    // a pure value type and making the state transitions easy to test.
+  // MARK: - Backoff mutations
+  //
+  // These return new values rather than mutating in place, keeping ContentSource
+  // a pure value type and making the state transitions easy to test.
 
-    /// Returns a copy with exponential backoff applied for one additional failure.
-    ///
-    /// Delay formula: `min(1h × 2^consecutiveFailures, 7 days)`
-    /// - 1st failure  → 1 hour
-    /// - 2nd failure  → 2 hours
-    /// - 3rd failure  → 4 hours
-    /// - …
-    /// - 10th failure → capped at 7 days
-    public func recordingFailure(at date: Date = .now) -> ContentSource {
-        var updated = self
-        let exponent = Double(consecutiveFailures)          // starts at 0 on first failure
-        let hours    = pow(2.0, exponent)                   // 1, 2, 4, 8, …
-        let delay    = min(hours * 3_600, 7 * 24 * 3_600)  // cap at 7 days
-        updated.consecutiveFailures += 1
-        updated.nextAllowedFetch = date.addingTimeInterval(delay)
-        return updated
-    }
+  /// Returns a copy with exponential backoff applied for one additional failure.
+  ///
+  /// Delay formula: `min(1h × 2^consecutiveFailures, 7 days)`
+  /// - 1st failure  → 1 hour
+  /// - 2nd failure  → 2 hours
+  /// - 3rd failure  → 4 hours
+  /// - …
+  /// - 10th failure → capped at 7 days
+  public func recordingFailure(at date: Date = .now) -> ContentSource {
+    var updated = self
+    let exponent = Double(consecutiveFailures)  // starts at 0 on first failure
+    let hours = pow(2.0, exponent)  // 1, 2, 4, 8, …
+    let delay = min(hours * 3_600, 7 * 24 * 3_600)  // cap at 7 days
+    updated.consecutiveFailures += 1
+    updated.nextAllowedFetch = date.addingTimeInterval(delay)
+    return updated
+  }
 
-    /// Returns a copy recording a successful remote fetch, resetting all backoff state.
-    public func recordingSuccess(fingerprint: ContentFingerprint, at date: Date = .now) -> ContentSource {
-        var updated = self
-        updated.lastFetched = date
-        updated.fingerprint = fingerprint
-        updated.consecutiveFailures = 0
-        updated.nextAllowedFetch = nil
-        return updated
-    }
+  /// Returns a copy recording a successful remote fetch, resetting all backoff state.
+  public func recordingSuccess(fingerprint: ContentFingerprint, at date: Date = .now)
+    -> ContentSource
+  {
+    var updated = self
+    updated.lastFetched = date
+    updated.fingerprint = fingerprint
+    updated.consecutiveFailures = 0
+    updated.nextAllowedFetch = nil
+    return updated
+  }
 }

--- a/Encounter/Models/ContentStoreError.swift
+++ b/Encounter/Models/ContentStoreError.swift
@@ -9,33 +9,33 @@ import Foundation
 
 /// Errors produced by the content loading and update pipeline.
 nonisolated public enum ContentStoreError: Error, LocalizedError, Sendable {
-    /// The source is currently throttled by exponential backoff.
-    case fetchThrottled(sourceID: String, until: Date)
-    /// A network or URLSession error occurred during fetch.
-    case networkError(sourceID: String, underlying: Error)
-    /// The downloaded data could not be decoded as valid content.
-    case decodingFailed(sourceID: String, underlying: Error)
-    /// The atomic file write failed.
-    case writeFailed(sourceID: String, underlying: Error)
-    /// Reading a content file from disk failed.
-    case readFailed(sourceID: String, underlying: Error)
-    /// The content is structurally invalid (e.g. empty adversary ID).
-    case invalidContent(sourceID: String, reason: String)
+  /// The source is currently throttled by exponential backoff.
+  case fetchThrottled(sourceID: String, until: Date)
+  /// A network or URLSession error occurred during fetch.
+  case networkError(sourceID: String, underlying: Error)
+  /// The downloaded data could not be decoded as valid content.
+  case decodingFailed(sourceID: String, underlying: Error)
+  /// The atomic file write failed.
+  case writeFailed(sourceID: String, underlying: Error)
+  /// Reading a content file from disk failed.
+  case readFailed(sourceID: String, underlying: Error)
+  /// The content is structurally invalid (e.g. empty adversary ID).
+  case invalidContent(sourceID: String, reason: String)
 
-    public var errorDescription: String? {
-        switch self {
-        case .fetchThrottled(let id, let until):
-            return "Source '\(id)' is throttled until \(until.formatted(.dateTime))."
-        case .networkError(let id, let error):
-            return "Network error for '\(id)': \(error.localizedDescription)"
-        case .decodingFailed(let id, let error):
-            return "Decode failed for '\(id)': \(error.localizedDescription)"
-        case .writeFailed(let id, let error):
-            return "Write failed for '\(id)': \(error.localizedDescription)"
-        case .readFailed(let id, let error):
-            return "Read failed for '\(id)': \(error.localizedDescription)"
-        case .invalidContent(let id, let reason):
-            return "Invalid content from '\(id)': \(reason)"
-        }
+  public var errorDescription: String? {
+    switch self {
+    case .fetchThrottled(let id, let until):
+      return "Source '\(id)' is throttled until \(until.formatted(.dateTime))."
+    case .networkError(let id, let error):
+      return "Network error for '\(id)': \(error.localizedDescription)"
+    case .decodingFailed(let id, let error):
+      return "Decode failed for '\(id)': \(error.localizedDescription)"
+    case .writeFailed(let id, let error):
+      return "Write failed for '\(id)': \(error.localizedDescription)"
+    case .readFailed(let id, let error):
+      return "Read failed for '\(id)': \(error.localizedDescription)"
+    case .invalidContent(let id, let reason):
+      return "Invalid content from '\(id)': \(reason)"
     }
+  }
 }

--- a/Encounter/Models/DHPackContent.swift
+++ b/Encounter/Models/DHPackContent.swift
@@ -13,17 +13,18 @@ import UniformTypeIdentifiers
 // MARK: - UTType
 
 extension UTType {
-    /// The `.dhpack` file type: a JSON content pack for Encounter.
-    ///
-    /// Declared in `Info.plist` as `gwillish.Encounter.dhpack`, conforming to
-    /// `public.json → public.text → public.data`. The `public.json` conformance
-    /// allows text editors and Quick Look to preview the file, and lets the OS
-    /// route AirDrop and Files-app opens to Encounter (see ADR-0016).
-    ///
-    /// Use `static let` (not `var`) because the type is exported by this app's
-    /// bundle and is stable for the app's lifetime.
-    public static let dhpack: UTType = UTType(exportedAs: "gwillish.Encounter.dhpack",
-                                              conformingTo: .json)
+  /// The `.dhpack` file type: a JSON content pack for Encounter.
+  ///
+  /// Declared in `Info.plist` as `gwillish.Encounter.dhpack`, conforming to
+  /// `public.json → public.text → public.data`. The `public.json` conformance
+  /// allows text editors and Quick Look to preview the file, and lets the OS
+  /// route AirDrop and Files-app opens to Encounter (see ADR-0016).
+  ///
+  /// Use `static let` (not `var`) because the type is exported by this app's
+  /// bundle and is stable for the app's lifetime.
+  public static let dhpack: UTType = UTType(
+    exportedAs: "gwillish.Encounter.dhpack",
+    conformingTo: .json)
 }
 
 /// The decoded contents of a `.dhpack` file.
@@ -41,29 +42,29 @@ extension UTType {
 /// A root-level array of adversaries (bare seansbox export format) is also
 /// accepted and treated as a pack with environments omitted.
 nonisolated public struct DHPackContent: Sendable {
-    public let adversaries: [Adversary]
-    public let environments: [DaggerheartEnvironment]
+  public let adversaries: [Adversary]
+  public let environments: [DaggerheartEnvironment]
 
-    public init(adversaries: [Adversary], environments: [DaggerheartEnvironment]) {
-        self.adversaries = adversaries
-        self.environments = environments
-    }
+  public init(adversaries: [Adversary], environments: [DaggerheartEnvironment]) {
+    self.adversaries = adversaries
+    self.environments = environments
+  }
 }
 
 nonisolated extension DHPackContent: Decodable {
-    private enum CodingKeys: String, CodingKey {
-        case adversaries, environments
-    }
+  private enum CodingKeys: String, CodingKey {
+    case adversaries, environments
+  }
 
-    public init(from decoder: Decoder) throws {
-        // Try the keyed object format first {"adversaries":[…], "environments":[…]}.
-        // Fall back to a bare adversary array (direct seansbox export).
-        if let keyed = try? decoder.container(keyedBy: CodingKeys.self) {
-            adversaries  = (try? keyed.decode([Adversary].self,               forKey: .adversaries))  ?? []
-            environments = (try? keyed.decode([DaggerheartEnvironment].self,  forKey: .environments)) ?? []
-        } else {
-            adversaries  = try decoder.singleValueContainer().decode([Adversary].self)
-            environments = []
-        }
+  public init(from decoder: Decoder) throws {
+    // Try the keyed object format first {"adversaries":[…], "environments":[…]}.
+    // Fall back to a bare adversary array (direct seansbox export).
+    if let keyed = try? decoder.container(keyedBy: CodingKeys.self) {
+      adversaries = (try? keyed.decode([Adversary].self, forKey: .adversaries)) ?? []
+      environments = (try? keyed.decode([DaggerheartEnvironment].self, forKey: .environments)) ?? []
+    } else {
+      adversaries = try decoder.singleValueContainer().decode([Adversary].self)
+      environments = []
     }
+  }
 }

--- a/Encounter/Models/DaggerheartEnvironment.swift
+++ b/Encounter/Models/DaggerheartEnvironment.swift
@@ -22,74 +22,77 @@ import Foundation
 /// Environments share the same feature schema as adversaries but represent
 /// location hazards, terrain, or interactive elements rather than combatants.
 /// They participate in encounters but are not tracked as HP pools.
-nonisolated public struct DaggerheartEnvironment: Codable, Identifiable, Sendable, Equatable, Hashable {
+nonisolated public struct DaggerheartEnvironment: Codable, Identifiable, Sendable, Equatable,
+  Hashable
+{
 
-    // MARK: Identity
-    /// URL-safe slug, e.g. `"collapsing-cavern"`.
-    public let id: String
-    public let name: String
-    /// Content source tag, always lowercased: `"srd"`, `"homebrew"`, a book name, etc.
-    public let source: String
-    /// `true` if this environment comes from a non-SRD source (homebrew or a named book).
-    public var isHomebrew: Bool { source != "srd" }
+  // MARK: Identity
+  /// URL-safe slug, e.g. `"collapsing-cavern"`.
+  public let id: String
+  public let name: String
+  /// Content source tag, always lowercased: `"srd"`, `"homebrew"`, a book name, etc.
+  public let source: String
+  /// `true` if this environment comes from a non-SRD source (homebrew or a named book).
+  public var isHomebrew: Bool { source != "srd" }
 
-    // MARK: Description
-    public let description: String
+  // MARK: Description
+  public let description: String
 
-    // MARK: Features
-    /// Passives, reactions, and actions this environment contributes to the scene.
-    public let features: [AdversaryFeature]
+  // MARK: Features
+  /// Passives, reactions, and actions this environment contributes to the scene.
+  public let features: [AdversaryFeature]
 
-    // MARK: - CodingKeys
+  // MARK: - CodingKeys
 
-    enum CodingKeys: String, CodingKey {
-        case id, name, source, description
-        // SRD JSON uses "feature"; homebrew/export uses "feature" too.
-        case features = "feature"
-    }
+  enum CodingKeys: String, CodingKey {
+    case id, name, source, description
+    // SRD JSON uses "feature"; homebrew/export uses "feature" too.
+    case features = "feature"
+  }
 
-    // MARK: - Decodable
+  // MARK: - Decodable
 
-    public init(from decoder: Decoder) throws {
-        let c = try decoder.container(keyedBy: CodingKeys.self)
-        // name decoded first so it can serve as the id fallback.
-        name        = try c.decode(String.self, forKey: .name)
-        // SRD JSON has no id field; derive a slug from the name.
-        id          = try c.decodeIfPresent(String.self, forKey: .id)
-            ?? name.lowercased()
-                .components(separatedBy: CharacterSet.alphanumerics.inverted)
-                .filter { !$0.isEmpty }
-                .joined(separator: "-")
-        // Normalize source to lowercase so "SRD", "srd", "Homebrew", etc. all compare equal.
-        source      = (try c.decodeIfPresent(String.self, forKey: .source) ?? "srd").lowercased()
-        description = try c.decode(String.self, forKey: .description)
-        features    = try c.decodeIfPresent([AdversaryFeature].self, forKey: .features) ?? []
-    }
+  public init(from decoder: Decoder) throws {
+    let c = try decoder.container(keyedBy: CodingKeys.self)
+    // name decoded first so it can serve as the id fallback.
+    name = try c.decode(String.self, forKey: .name)
+    // SRD JSON has no id field; derive a slug from the name.
+    id =
+      try c.decodeIfPresent(String.self, forKey: .id)
+      ?? name.lowercased()
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .filter { !$0.isEmpty }
+      .joined(separator: "-")
+    // Normalize source to lowercase so "SRD", "srd", "Homebrew", etc. all compare equal.
+    source = (try c.decodeIfPresent(String.self, forKey: .source) ?? "srd").lowercased()
+    description = try c.decode(String.self, forKey: .description)
+    features = try c.decodeIfPresent([AdversaryFeature].self, forKey: .features) ?? []
+  }
 
-    // MARK: - Encodable
+  // MARK: - Encodable
 
-    public func encode(to encoder: Encoder) throws {
-        var c = encoder.container(keyedBy: CodingKeys.self)
-        try c.encode(id,          forKey: .id)
-        try c.encode(name,        forKey: .name)
-        try c.encode(source,      forKey: .source)
-        try c.encode(description, forKey: .description)
-        try c.encode(features,    forKey: .features)
-    }
+  public func encode(to encoder: Encoder) throws {
+    var c = encoder.container(keyedBy: CodingKeys.self)
+    try c.encode(id, forKey: .id)
+    try c.encode(name, forKey: .name)
+    try c.encode(source, forKey: .source)
+    try c.encode(description, forKey: .description)
+    try c.encode(features, forKey: .features)
+  }
 
-    // MARK: - Memberwise init (for previews / tests)
+  // MARK: - Memberwise init (for previews / tests)
 
-    public init(
-        id: String,
-        name: String,
-        source: String = "srd",
-        description: String,
-        features: [AdversaryFeature] = []
-    ) {
-        self.id = id
-        self.name = name
-        self.source = source
-        self.description = description
-        self.features = features
-    }
+  public init(
+    id: String,
+    name: String,
+    source: String = "srd",
+    description: String,
+    features: [AdversaryFeature] = []
+  ) {
+    self.id = id
+    self.name = name
+    self.source = source
+    self.description = description
+    self.features = features
+  }
 }

--- a/Encounter/Models/DifficultyBudget.swift
+++ b/Encounter/Models/DifficultyBudget.swift
@@ -22,137 +22,137 @@ import Foundation
 /// No state, no dependencies on ``EncounterSession`` or UI.
 nonisolated public enum DifficultyBudget {
 
-    // MARK: - Battle Point Cost per Type
+  // MARK: - Battle Point Cost per Type
 
-    /// The Battle Point cost for a single adversary of the given type.
-    ///
-    /// Per SRD "Building Balanced Encounters":
-    /// - Minion group, Social, Support: 1 point
-    /// - Horde, Ranged, Skulk, Standard: 2 points
-    /// - Leader: 3 points
-    /// - Bruiser: 4 points
-    /// - Solo: 5 points
-    public static func cost(for type: AdversaryType) -> Int {
-        switch type {
-        case .minion, .social, .support:         return 1
-        case .horde, .ranged, .skulk, .standard: return 2
-        case .leader:                            return 3
-        case .bruiser:                           return 4
-        case .solo:                              return 5
-        }
+  /// The Battle Point cost for a single adversary of the given type.
+  ///
+  /// Per SRD "Building Balanced Encounters":
+  /// - Minion group, Social, Support: 1 point
+  /// - Horde, Ranged, Skulk, Standard: 2 points
+  /// - Leader: 3 points
+  /// - Bruiser: 4 points
+  /// - Solo: 5 points
+  public static func cost(for type: AdversaryType) -> Int {
+    switch type {
+    case .minion, .social, .support: return 1
+    case .horde, .ranged, .skulk, .standard: return 2
+    case .leader: return 3
+    case .bruiser: return 4
+    case .solo: return 5
+    }
+  }
+
+  // MARK: - Base Budget
+
+  /// The starting Battle Point budget before adjustments.
+  ///
+  /// Formula: `(3 × playerCount) + 2`
+  public static func baseBudget(playerCount: Int) -> Int {
+    (3 * playerCount) + 2
+  }
+
+  // MARK: - Total Cost
+
+  /// Sum of Battle Point costs for a list of adversary types.
+  public static func totalCost(for types: [AdversaryType]) -> Int {
+    types.reduce(0) { $0 + cost(for: $1) }
+  }
+
+  // MARK: - Rating
+
+  /// A snapshot of the encounter's difficulty budget analysis.
+  nonisolated public struct Rating: Sendable, Equatable, Hashable {
+    /// Total Battle Points available (base budget + adjustment).
+    public let budget: Int
+    /// Total Battle Points spent on the adversary roster.
+    public let totalCost: Int
+    /// Budget minus cost. Negative means over-budget.
+    public let remaining: Int
+  }
+
+  /// Compute the difficulty rating for an adversary roster against a player count.
+  ///
+  /// - Parameters:
+  ///   - adversaryTypes: The types of all adversaries in the encounter.
+  ///   - playerCount: Number of player characters.
+  ///   - budgetAdjustment: Manual adjustment to the base budget (from ``Adjustment`` point values).
+  /// - Returns: A ``Rating`` with budget, cost, and remaining points.
+  public static func rating(
+    adversaryTypes: [AdversaryType],
+    playerCount: Int,
+    budgetAdjustment: Int = 0
+  ) -> Rating {
+    let budget = baseBudget(playerCount: playerCount) + budgetAdjustment
+    let cost = totalCost(for: adversaryTypes)
+    return Rating(budget: budget, totalCost: cost, remaining: budget - cost)
+  }
+
+  // MARK: - Adjustment Suggestions
+
+  /// Predefined budget adjustments from the SRD.
+  nonisolated public enum Adjustment: Sendable, Equatable, Hashable, CaseIterable {
+    /// -1 for an easier or shorter fight.
+    case easierFight
+    /// -2 if using 2+ Solo adversaries.
+    case multipleSolos
+    /// -2 if adding +1d4 (or static +2) to all adversary damage.
+    case boostedDamage
+    /// +1 if choosing an adversary from a lower tier.
+    case lowerTierAdversary
+    /// +1 if no Bruisers, Hordes, Leaders, or Solos in the roster.
+    case noBigThreats
+    /// +2 for a harder or longer fight.
+    case harderFight
+
+    /// The Battle Point adjustment this represents.
+    public var pointValue: Int {
+      switch self {
+      case .easierFight: return -1
+      case .multipleSolos: return -2
+      case .boostedDamage: return -2
+      case .lowerTierAdversary: return 1
+      case .noBigThreats: return 1
+      case .harderFight: return 2
+      }
     }
 
-    // MARK: - Base Budget
+    /// Human-readable description for UI display.
+    public var label: String {
+      switch self {
+      case .easierFight: return "Easier/shorter fight"
+      case .multipleSolos: return "Using 2+ Solo adversaries"
+      case .boostedDamage: return "Boosted adversary damage (+1d4 or +2)"
+      case .lowerTierAdversary: return "Adversary from a lower tier"
+      case .noBigThreats: return "No Bruisers, Hordes, Leaders, or Solos"
+      case .harderFight: return "Harder/longer fight"
+      }
+    }
+  }
 
-    /// The starting Battle Point budget before adjustments.
-    ///
-    /// Formula: `(3 × playerCount) + 2`
-    public static func baseBudget(playerCount: Int) -> Int {
-        (3 * playerCount) + 2
+  /// Determine which SRD adjustments apply automatically based on the roster.
+  ///
+  /// Only returns adjustments that can be mechanically detected:
+  /// - `.multipleSolos` if 2+ Solo types
+  /// - `.noBigThreats` if no Bruiser, Horde, Leader, or Solo types
+  ///
+  /// GM-discretionary adjustments (easier/harder fight, boosted damage,
+  /// lower tier) must be toggled manually in the UI.
+  public static func suggestedAdjustments(
+    adversaryTypes: [AdversaryType]
+  ) -> Set<Adjustment> {
+    var result: Set<Adjustment> = []
+
+    let soloCount = adversaryTypes.count(where: { $0 == .solo })
+    if soloCount >= 2 {
+      result.insert(.multipleSolos)
     }
 
-    // MARK: - Total Cost
-
-    /// Sum of Battle Point costs for a list of adversary types.
-    public static func totalCost(for types: [AdversaryType]) -> Int {
-        types.reduce(0) { $0 + cost(for: $1) }
+    let bigThreatTypes: Set<AdversaryType> = [.bruiser, .horde, .leader, .solo]
+    let hasBigThreat = adversaryTypes.contains { bigThreatTypes.contains($0) }
+    if !hasBigThreat && !adversaryTypes.isEmpty {
+      result.insert(.noBigThreats)
     }
 
-    // MARK: - Rating
-
-    /// A snapshot of the encounter's difficulty budget analysis.
-    nonisolated public struct Rating: Sendable, Equatable, Hashable {
-        /// Total Battle Points available (base budget + adjustment).
-        public let budget: Int
-        /// Total Battle Points spent on the adversary roster.
-        public let totalCost: Int
-        /// Budget minus cost. Negative means over-budget.
-        public let remaining: Int
-    }
-
-    /// Compute the difficulty rating for an adversary roster against a player count.
-    ///
-    /// - Parameters:
-    ///   - adversaryTypes: The types of all adversaries in the encounter.
-    ///   - playerCount: Number of player characters.
-    ///   - budgetAdjustment: Manual adjustment to the base budget (from ``Adjustment`` point values).
-    /// - Returns: A ``Rating`` with budget, cost, and remaining points.
-    public static func rating(
-        adversaryTypes: [AdversaryType],
-        playerCount: Int,
-        budgetAdjustment: Int = 0
-    ) -> Rating {
-        let budget = baseBudget(playerCount: playerCount) + budgetAdjustment
-        let cost = totalCost(for: adversaryTypes)
-        return Rating(budget: budget, totalCost: cost, remaining: budget - cost)
-    }
-
-    // MARK: - Adjustment Suggestions
-
-    /// Predefined budget adjustments from the SRD.
-    nonisolated public enum Adjustment: Sendable, Equatable, Hashable, CaseIterable {
-        /// -1 for an easier or shorter fight.
-        case easierFight
-        /// -2 if using 2+ Solo adversaries.
-        case multipleSolos
-        /// -2 if adding +1d4 (or static +2) to all adversary damage.
-        case boostedDamage
-        /// +1 if choosing an adversary from a lower tier.
-        case lowerTierAdversary
-        /// +1 if no Bruisers, Hordes, Leaders, or Solos in the roster.
-        case noBigThreats
-        /// +2 for a harder or longer fight.
-        case harderFight
-
-        /// The Battle Point adjustment this represents.
-        public var pointValue: Int {
-            switch self {
-            case .easierFight:        return -1
-            case .multipleSolos:      return -2
-            case .boostedDamage:      return -2
-            case .lowerTierAdversary: return  1
-            case .noBigThreats:       return  1
-            case .harderFight:        return  2
-            }
-        }
-
-        /// Human-readable description for UI display.
-        public var label: String {
-            switch self {
-            case .easierFight:        return "Easier/shorter fight"
-            case .multipleSolos:      return "Using 2+ Solo adversaries"
-            case .boostedDamage:      return "Boosted adversary damage (+1d4 or +2)"
-            case .lowerTierAdversary: return "Adversary from a lower tier"
-            case .noBigThreats:       return "No Bruisers, Hordes, Leaders, or Solos"
-            case .harderFight:        return "Harder/longer fight"
-            }
-        }
-    }
-
-    /// Determine which SRD adjustments apply automatically based on the roster.
-    ///
-    /// Only returns adjustments that can be mechanically detected:
-    /// - `.multipleSolos` if 2+ Solo types
-    /// - `.noBigThreats` if no Bruiser, Horde, Leader, or Solo types
-    ///
-    /// GM-discretionary adjustments (easier/harder fight, boosted damage,
-    /// lower tier) must be toggled manually in the UI.
-    public static func suggestedAdjustments(
-        adversaryTypes: [AdversaryType]
-    ) -> Set<Adjustment> {
-        var result: Set<Adjustment> = []
-
-        let soloCount = adversaryTypes.count(where: { $0 == .solo })
-        if soloCount >= 2 {
-            result.insert(.multipleSolos)
-        }
-
-        let bigThreatTypes: Set<AdversaryType> = [.bruiser, .horde, .leader, .solo]
-        let hasBigThreat = adversaryTypes.contains { bigThreatTypes.contains($0) }
-        if !hasBigThreat && !adversaryTypes.isEmpty {
-            result.insert(.noBigThreats)
-        }
-
-        return result
-    }
+    return result
+  }
 }

--- a/Encounter/Models/EncounterDefinition.swift
+++ b/Encounter/Models/EncounterDefinition.swift
@@ -25,34 +25,34 @@ import Foundation
 /// When an ``EncounterSession`` is started from a definition, each
 /// `PlayerConfig` becomes a ``PlayerSlot`` with fresh runtime state.
 nonisolated public struct PlayerConfig: Codable, Sendable, Equatable, Hashable, Identifiable {
-    public let id: UUID
-    public let name: String
-    public let maxHP: Int
-    public let maxStress: Int
-    public let evasion: Int
-    public let thresholdMajor: Int
-    public let thresholdSevere: Int
-    public let armorSlots: Int
+  public let id: UUID
+  public let name: String
+  public let maxHP: Int
+  public let maxStress: Int
+  public let evasion: Int
+  public let thresholdMajor: Int
+  public let thresholdSevere: Int
+  public let armorSlots: Int
 
-    public init(
-        id: UUID = UUID(),
-        name: String,
-        maxHP: Int,
-        maxStress: Int,
-        evasion: Int,
-        thresholdMajor: Int,
-        thresholdSevere: Int,
-        armorSlots: Int
-    ) {
-        self.id = id
-        self.name = name
-        self.maxHP = maxHP
-        self.maxStress = maxStress
-        self.evasion = evasion
-        self.thresholdMajor = thresholdMajor
-        self.thresholdSevere = thresholdSevere
-        self.armorSlots = armorSlots
-    }
+  public init(
+    id: UUID = UUID(),
+    name: String,
+    maxHP: Int,
+    maxStress: Int,
+    evasion: Int,
+    thresholdMajor: Int,
+    thresholdSevere: Int,
+    armorSlots: Int
+  ) {
+    self.id = id
+    self.name = name
+    self.maxHP = maxHP
+    self.maxStress = maxStress
+    self.evasion = evasion
+    self.thresholdMajor = thresholdMajor
+    self.thresholdSevere = thresholdSevere
+    self.armorSlots = armorSlots
+  }
 }
 
 // MARK: - EncounterDefinition
@@ -66,47 +66,48 @@ nonisolated public struct PlayerConfig: Codable, Sendable, Equatable, Hashable, 
 ///
 /// To run an encounter, create an ``EncounterSession`` from a definition
 /// using ``EncounterSession/start(from:using:)``.
-nonisolated public struct EncounterDefinition: Codable, Sendable, Equatable, Hashable, Identifiable {
-    public let id: UUID
-    public var name: String
+nonisolated public struct EncounterDefinition: Codable, Sendable, Equatable, Hashable, Identifiable
+{
+  public let id: UUID
+  public var name: String
 
-    /// Adversary catalog IDs. Duplicates represent multiple copies of the same adversary.
-    public var adversaryIDs: [String]
+  /// Adversary catalog IDs. Duplicates represent multiple copies of the same adversary.
+  public var adversaryIDs: [String]
 
-    /// Environment catalog IDs.
-    public var environmentIDs: [String]
+  /// Environment catalog IDs.
+  public var environmentIDs: [String]
 
-    /// Player character configurations for this encounter.
-    public var playerConfigs: [PlayerConfig]
+  /// Player character configurations for this encounter.
+  public var playerConfigs: [PlayerConfig]
 
-    /// Freeform GM notes for encounter prep.
-    public var gmNotes: String
+  /// Freeform GM notes for encounter prep.
+  public var gmNotes: String
 
-    // MARK: Timestamps
+  // MARK: Timestamps
 
-    /// When this definition was first created.
-    public let createdAt: Date
+  /// When this definition was first created.
+  public let createdAt: Date
 
-    /// Stamped by ``EncounterStore/save(_:)`` — do not set directly.
-    public var modifiedAt: Date
+  /// Stamped by ``EncounterStore/save(_:)`` — do not set directly.
+  public var modifiedAt: Date
 
-    public init(
-        id: UUID = UUID(),
-        name: String,
-        adversaryIDs: [String] = [],
-        environmentIDs: [String] = [],
-        playerConfigs: [PlayerConfig] = [],
-        gmNotes: String = "",
-        createdAt: Date = .now,
-        modifiedAt: Date = .now
-    ) {
-        self.id = id
-        self.name = name
-        self.adversaryIDs = adversaryIDs
-        self.environmentIDs = environmentIDs
-        self.playerConfigs = playerConfigs
-        self.gmNotes = gmNotes
-        self.createdAt = createdAt
-        self.modifiedAt = modifiedAt
-    }
+  public init(
+    id: UUID = UUID(),
+    name: String,
+    adversaryIDs: [String] = [],
+    environmentIDs: [String] = [],
+    playerConfigs: [PlayerConfig] = [],
+    gmNotes: String = "",
+    createdAt: Date = .now,
+    modifiedAt: Date = .now
+  ) {
+    self.id = id
+    self.name = name
+    self.adversaryIDs = adversaryIDs
+    self.environmentIDs = environmentIDs
+    self.playerConfigs = playerConfigs
+    self.gmNotes = gmNotes
+    self.createdAt = createdAt
+    self.modifiedAt = modifiedAt
+  }
 }

--- a/Encounter/Models/EncounterSession.swift
+++ b/Encounter/Models/EncounterSession.swift
@@ -16,8 +16,8 @@
 //
 
 import Foundation
-import Observation
 import OSLog
+import Observation
 
 // MARK: - AdversarySlot
 
@@ -31,56 +31,56 @@ import OSLog
 /// time so that HP/stress clamping works correctly even if the source adversary
 /// is later edited or removed from the ``Compendium`` (homebrew orphan safety).
 nonisolated public struct AdversarySlot: Identifiable, Sendable, Equatable, Hashable {
-    public let id: UUID
-    /// The slug that identifies this adversary in the ``Compendium``.
-    public let adversaryID: String
-    /// Display name override (e.g. "Grimfang" for a named bandit leader).
-    /// Falls back to the catalog name when `nil`.
-    public var customName: String?
+  public let id: UUID
+  /// The slug that identifies this adversary in the ``Compendium``.
+  public let adversaryID: String
+  /// Display name override (e.g. "Grimfang" for a named bandit leader).
+  /// Falls back to the catalog name when `nil`.
+  public var customName: String?
 
-    // MARK: Stat Snapshot (from catalog at creation time)
-    public let maxHP: Int
-    public let maxStress: Int
+  // MARK: Stat Snapshot (from catalog at creation time)
+  public let maxHP: Int
+  public let maxStress: Int
 
-    // MARK: Tracked Stats
-    public var currentHP: Int
-    public var currentStress: Int
-    public var isDefeated: Bool
-    public var conditions: Set<Condition>
+  // MARK: Tracked Stats
+  public var currentHP: Int
+  public var currentStress: Int
+  public var isDefeated: Bool
+  public var conditions: Set<Condition>
 
-    // MARK: - Init
+  // MARK: - Init
 
-    public init(
-        id: UUID = UUID(),
-        adversaryID: String,
-        customName: String? = nil,
-        maxHP: Int,
-        maxStress: Int,
-        currentHP: Int? = nil,
-        currentStress: Int = 0,
-        isDefeated: Bool = false,
-        conditions: Set<Condition> = []
-    ) {
-        self.id = id
-        self.adversaryID = adversaryID
-        self.customName = customName
-        self.maxHP = maxHP
-        self.maxStress = maxStress
-        self.currentHP = currentHP ?? maxHP
-        self.currentStress = currentStress
-        self.isDefeated = isDefeated
-        self.conditions = conditions
-    }
+  public init(
+    id: UUID = UUID(),
+    adversaryID: String,
+    customName: String? = nil,
+    maxHP: Int,
+    maxStress: Int,
+    currentHP: Int? = nil,
+    currentStress: Int = 0,
+    isDefeated: Bool = false,
+    conditions: Set<Condition> = []
+  ) {
+    self.id = id
+    self.adversaryID = adversaryID
+    self.customName = customName
+    self.maxHP = maxHP
+    self.maxStress = maxStress
+    self.currentHP = currentHP ?? maxHP
+    self.currentStress = currentStress
+    self.isDefeated = isDefeated
+    self.conditions = conditions
+  }
 
-    /// Convenience factory: create a slot pre-populated from a catalog entry.
-    public static func from(_ adversary: Adversary, customName: String? = nil) -> AdversarySlot {
-        AdversarySlot(
-            adversaryID: adversary.id,
-            customName: customName,
-            maxHP: adversary.hp,
-            maxStress: adversary.stress
-        )
-    }
+  /// Convenience factory: create a slot pre-populated from a catalog entry.
+  public static func from(_ adversary: Adversary, customName: String? = nil) -> AdversarySlot {
+    AdversarySlot(
+      adversaryID: adversary.id,
+      customName: customName,
+      maxHP: adversary.hp,
+      maxStress: adversary.stress
+    )
+  }
 }
 
 // MARK: - EnvironmentSlot
@@ -90,21 +90,21 @@ nonisolated public struct AdversarySlot: Identifiable, Sendable, Equatable, Hash
 /// Environments have no HP or Stress — they are tracked only for
 /// their features and activation state.
 nonisolated public struct EnvironmentSlot: Identifiable, Sendable, Equatable, Hashable {
-    public let id: UUID
-    /// The slug identifying this environment in the ``Compendium``.
-    public let environmentID: String
-    /// Whether this environment element is currently active/visible to players.
-    public var isActive: Bool
+  public let id: UUID
+  /// The slug identifying this environment in the ``Compendium``.
+  public let environmentID: String
+  /// Whether this environment element is currently active/visible to players.
+  public var isActive: Bool
 
-    public init(
-        id: UUID = UUID(),
-        environmentID: String,
-        isActive: Bool = true
-    ) {
-        self.id = id
-        self.environmentID = environmentID
-        self.isActive = isActive
-    }
+  public init(
+    id: UUID = UUID(),
+    environmentID: String,
+    isActive: Bool = true
+  ) {
+    self.id = id
+    self.environmentID = environmentID
+    self.isActive = isActive
+  }
 }
 
 // MARK: - EncounterSession
@@ -132,338 +132,355 @@ nonisolated public struct EnvironmentSlot: Identifiable, Sendable, Equatable, Ha
 @MainActor
 @Observable
 public final class EncounterSession: Identifiable, Hashable {
-    public nonisolated static func == (lhs: EncounterSession, rhs: EncounterSession) -> Bool { lhs.id == rhs.id }
-    public nonisolated func hash(into hasher: inout Hasher) { hasher.combine(id) }
+  public nonisolated static func == (lhs: EncounterSession, rhs: EncounterSession) -> Bool {
+    lhs.id == rhs.id
+  }
+  public nonisolated func hash(into hasher: inout Hasher) { hasher.combine(id) }
 
-    private let logger = Logger(subsystem: "gwillish.Encounter", category: "EncounterSession")
+  private let logger = Logger(subsystem: "gwillish.Encounter", category: "EncounterSession")
 
-    // MARK: Identity
-    public let id: UUID
-    public var name: String
+  // MARK: Identity
+  public let id: UUID
+  public var name: String
 
-    // MARK: Participants
-    public var adversarySlots: [AdversarySlot]
-    public var playerSlots: [PlayerSlot]
-    public var environmentSlots: [EnvironmentSlot]
+  // MARK: Participants
+  public var adversarySlots: [AdversarySlot]
+  public var playerSlots: [PlayerSlot]
+  public var environmentSlots: [EnvironmentSlot]
 
-    // MARK: Fear & Hope
-    /// The GM's Fear pool. Increases when players roll with Fear,
-    /// decreases when the GM spends Fear on adversary actions.
-    public var fearPool: Int
+  // MARK: Fear & Hope
+  /// The GM's Fear pool. Increases when players roll with Fear,
+  /// decreases when the GM spends Fear on adversary actions.
+  public var fearPool: Int
 
-    /// The party's Hope pool (total across all PCs). Tracked here for
-    /// quick reference; primary source of truth is player character sheets.
-    public var hopePool: Int
+  /// The party's Hope pool (total across all PCs). Tracked here for
+  /// quick reference; primary source of truth is player character sheets.
+  public var hopePool: Int
 
-    // MARK: Spotlight
-    /// The ID of the adversary slot (or environment slot) currently taking
-    /// its turn. `nil` when it is the players' action phase.
-    public var activeSlotID: UUID?
+  // MARK: Spotlight
+  /// The ID of the adversary slot (or environment slot) currently taking
+  /// its turn. `nil` when it is the players' action phase.
+  public var activeSlotID: UUID?
 
-    // MARK: Round Tracking
-    public var currentRound: Int
-    public var turnOrder: [UUID]   // ordered slot IDs for this round
+  // MARK: Round Tracking
+  public var currentRound: Int
+  public var turnOrder: [UUID]  // ordered slot IDs for this round
 
-    // MARK: Notes
-    public var gmNotes: String
+  // MARK: Notes
+  public var gmNotes: String
 
-    // MARK: - Init
+  // MARK: - Init
 
-    public init(
-        id: UUID = UUID(),
-        name: String,
-        adversarySlots: [AdversarySlot] = [],
-        playerSlots: [PlayerSlot] = [],
-        environmentSlots: [EnvironmentSlot] = [],
-        fearPool: Int = 0,
-        hopePool: Int = 0,
-        currentRound: Int = 1,
-        gmNotes: String = ""
-    ) {
-        self.id = id
-        self.name = name
-        self.adversarySlots = adversarySlots
-        self.playerSlots = playerSlots
-        self.environmentSlots = environmentSlots
-        self.fearPool = fearPool
-        self.hopePool = hopePool
-        self.activeSlotID = nil
-        self.currentRound = currentRound
-        self.turnOrder = adversarySlots.map(\.id) + playerSlots.map(\.id)
-        self.gmNotes = gmNotes
+  public init(
+    id: UUID = UUID(),
+    name: String,
+    adversarySlots: [AdversarySlot] = [],
+    playerSlots: [PlayerSlot] = [],
+    environmentSlots: [EnvironmentSlot] = [],
+    fearPool: Int = 0,
+    hopePool: Int = 0,
+    currentRound: Int = 1,
+    gmNotes: String = ""
+  ) {
+    self.id = id
+    self.name = name
+    self.adversarySlots = adversarySlots
+    self.playerSlots = playerSlots
+    self.environmentSlots = environmentSlots
+    self.fearPool = fearPool
+    self.hopePool = hopePool
+    self.activeSlotID = nil
+    self.currentRound = currentRound
+    self.turnOrder = adversarySlots.map(\.id) + playerSlots.map(\.id)
+    self.gmNotes = gmNotes
+  }
+
+  // MARK: - Roster Management
+
+  /// Add a new adversary slot populated from a catalog entry.
+  public func add(adversary: Adversary, customName: String? = nil) {
+    let slot = AdversarySlot.from(adversary, customName: customName)
+    adversarySlots.append(slot)
+    turnOrder.append(slot.id)
+  }
+
+  /// Add an environment slot.
+  public func add(environment: DaggerheartEnvironment) {
+    environmentSlots.append(EnvironmentSlot(environmentID: environment.id))
+  }
+
+  /// Remove an adversary slot by ID.
+  public func removeAdversary(id: UUID) {
+    adversarySlots.removeAll { $0.id == id }
+    turnOrder.removeAll { $0 == id }
+    if activeSlotID == id { activeSlotID = nil }
+  }
+
+  // MARK: - Player Management
+
+  /// Add a player slot to the encounter.
+  public func addPlayer(_ player: PlayerSlot) {
+    playerSlots.append(player)
+    turnOrder.append(player.id)
+  }
+
+  /// Remove a player slot by ID.
+  public func removePlayer(id: UUID) {
+    playerSlots.removeAll { $0.id == id }
+    turnOrder.removeAll { $0 == id }
+    if activeSlotID == id { activeSlotID = nil }
+  }
+
+  // MARK: - HP & Stress Mutations
+
+  /// Apply damage to an adversary slot, clamping HP to 0.
+  public func applyDamage(_ amount: Int, to slotID: UUID) {
+    guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
+      logger.warning("applyDamage: slot \(slotID) not found")
+      return
+    }
+    adversarySlots[index].currentHP = max(0, adversarySlots[index].currentHP - amount)
+    if adversarySlots[index].currentHP == 0 {
+      adversarySlots[index].isDefeated = true
+      logger.info("Slot \(slotID) defeated")
+    } else {
+      logger.debug(
+        "Slot \(slotID) took \(amount) damage, HP now \(self.adversarySlots[index].currentHP)")
+    }
+  }
+
+  /// Apply stress to an adversary slot, clamping to the slot's snapshotted maximum.
+  public func applyStress(_ amount: Int, to slotID: UUID) {
+    guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
+      logger.warning("applyStress: slot \(slotID) not found")
+      return
+    }
+    adversarySlots[index].currentStress = min(
+      adversarySlots[index].maxStress,
+      adversarySlots[index].currentStress + amount
+    )
+    logger.debug(
+      "Slot \(slotID) stress now \(self.adversarySlots[index].currentStress)/\(self.adversarySlots[index].maxStress)"
+    )
+  }
+
+  /// Heal an adversary slot, clamping HP to the slot's snapshotted maximum.
+  public func heal(_ amount: Int, slotID: UUID) {
+    guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
+      logger.warning("heal: slot \(slotID) not found")
+      return
+    }
+    adversarySlots[index].currentHP = min(
+      adversarySlots[index].maxHP,
+      adversarySlots[index].currentHP + amount
+    )
+    if adversarySlots[index].currentHP > 0 {
+      adversarySlots[index].isDefeated = false
+    }
+    logger.debug(
+      "Slot \(slotID) healed \(amount), HP now \(self.adversarySlots[index].currentHP)/\(self.adversarySlots[index].maxHP)"
+    )
+  }
+
+  // MARK: - Adversary Condition Management
+
+  /// Apply a condition to an adversary slot.
+  /// Per the SRD, the same condition does not stack (Set enforces this).
+  /// `.custom` conditions with an empty or whitespace-only name are silently ignored.
+  public func applyCondition(_ condition: Condition, to slotID: UUID) {
+    if case .custom(let name) = condition,
+      name.trimmingCharacters(in: .whitespaces).isEmpty
+    {
+      return
+    }
+    guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else { return }
+    adversarySlots[index].conditions.insert(condition)
+  }
+
+  /// Remove a condition from an adversary slot.
+  public func removeCondition(_ condition: Condition, from slotID: UUID) {
+    guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else { return }
+    adversarySlots[index].conditions.remove(condition)
+  }
+
+  // MARK: - Player HP & Stress Mutations
+
+  /// Apply damage to a player slot, clamping HP to 0.
+  public func applyPlayerDamage(_ amount: Int, to slotID: UUID) {
+    guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+    playerSlots[index].currentHP = max(0, playerSlots[index].currentHP - amount)
+  }
+
+  /// Apply stress to a player slot, clamping to maximum.
+  public func applyPlayerStress(_ amount: Int, to slotID: UUID) {
+    guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+    playerSlots[index].currentStress = min(
+      playerSlots[index].maxStress,
+      playerSlots[index].currentStress + amount
+    )
+  }
+
+  /// Heal a player slot, clamping HP to maximum.
+  public func healPlayer(_ amount: Int, slotID: UUID) {
+    guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+    playerSlots[index].currentHP = min(
+      playerSlots[index].maxHP,
+      playerSlots[index].currentHP + amount
+    )
+  }
+
+  /// Clear stress from a player slot, clamping to 0.
+  public func clearPlayerStress(_ amount: Int, slotID: UUID) {
+    guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+    playerSlots[index].currentStress = max(0, playerSlots[index].currentStress - amount)
+  }
+
+  /// Mark one Armor Slot on a player (used to reduce damage severity).
+  public func markPlayerArmorSlot(_ slotID: UUID) {
+    guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+    guard playerSlots[index].currentArmorSlots > 0 else { return }
+    playerSlots[index].currentArmorSlots -= 1
+  }
+
+  /// Restore one Armor Slot on a player (undo a mark, or recover via a rest ability).
+  public func restorePlayerArmorSlot(_ slotID: UUID) {
+    guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+    playerSlots[index].currentArmorSlots = min(
+      playerSlots[index].armorSlots,
+      playerSlots[index].currentArmorSlots + 1
+    )
+  }
+
+  // MARK: - Player Condition Management
+
+  /// Apply a condition to a player slot.
+  /// `.custom` conditions with an empty or whitespace-only name are silently ignored.
+  public func applyPlayerCondition(_ condition: Condition, to slotID: UUID) {
+    if case .custom(let name) = condition,
+      name.trimmingCharacters(in: .whitespaces).isEmpty
+    {
+      return
+    }
+    guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+    playerSlots[index].conditions.insert(condition)
+  }
+
+  /// Remove a condition from a player slot.
+  public func removePlayerCondition(_ condition: Condition, from slotID: UUID) {
+    guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
+    playerSlots[index].conditions.remove(condition)
+  }
+
+  // MARK: - Fear & Hope
+
+  public func incrementFear(by amount: Int = 1) {
+    fearPool += amount
+  }
+
+  public func spendFear(_ amount: Int = 1) {
+    fearPool = max(0, fearPool - amount)
+  }
+
+  public func incrementHope(by amount: Int = 1) {
+    hopePool += amount
+  }
+
+  public func spendHope(_ amount: Int = 1) {
+    hopePool = max(0, hopePool - amount)
+  }
+
+  // MARK: - Round Management
+
+  /// Advance to the next round, resetting the turn position.
+  public func advanceRound() {
+    currentRound += 1
+    activeSlotID = nil
+    // Defeated adversaries are removed from the turn order for the new round.
+    let defeatedIDs = Set(adversarySlots.filter(\.isDefeated).map(\.id))
+    turnOrder = turnOrder.filter { !defeatedIDs.contains($0) }
+    logger.info("Advanced to round \(self.currentRound), \(self.turnOrder.count) slots in order")
+  }
+
+  /// Turn order filtered to non-defeated participants.
+  /// Defeated adversaries are excluded so `advanceTurn` never lands on them mid-round.
+  private var activeTurnOrder: [UUID] {
+    let defeatedIDs = Set(adversarySlots.filter(\.isDefeated).map(\.id))
+    return turnOrder.filter { !defeatedIDs.contains($0) }
+  }
+
+  /// Set the active spotlight to the next slot in turn order, skipping defeated adversaries.
+  public func advanceTurn() {
+    let active = activeTurnOrder
+    guard !active.isEmpty else {
+      activeSlotID = nil
+      return
+    }
+    if let current = activeSlotID,
+      let currentIndex = active.firstIndex(of: current),
+      currentIndex + 1 < active.count
+    {
+      activeSlotID = active[currentIndex + 1]
+    } else {
+      activeSlotID = active.first
+    }
+  }
+
+  // MARK: - Computed Helpers
+
+  /// All adversary slots still in the fight.
+  public var activeAdversaries: [AdversarySlot] {
+    adversarySlots.filter { !$0.isDefeated }
+  }
+
+  /// `true` when all adversary slots are defeated.
+  public var isOver: Bool {
+    !adversarySlots.isEmpty && adversarySlots.allSatisfy(\.isDefeated)
+  }
+
+  // MARK: - Factory
+
+  /// Create a live encounter session from a saved definition.
+  ///
+  /// Resolves adversary and environment IDs through the compendium.
+  /// IDs that do not resolve to a catalog entry are silently skipped
+  /// (this handles orphaned homebrew references gracefully).
+  ///
+  /// - Parameters:
+  ///   - definition: The encounter template to instantiate.
+  ///   - compendium: The catalog used to resolve adversary/environment IDs.
+  /// - Returns: A fresh `EncounterSession` ready for play.
+  public static func start(
+    from definition: EncounterDefinition,
+    using compendium: Compendium
+  ) -> EncounterSession {
+    let adversarySlots: [AdversarySlot] = definition.adversaryIDs.compactMap { id in
+      guard let adversary = compendium.adversary(id: id) else { return nil }
+      return AdversarySlot.from(adversary)
     }
 
-    // MARK: - Roster Management
-
-    /// Add a new adversary slot populated from a catalog entry.
-    public func add(adversary: Adversary, customName: String? = nil) {
-        let slot = AdversarySlot.from(adversary, customName: customName)
-        adversarySlots.append(slot)
-        turnOrder.append(slot.id)
+    let environmentSlots: [EnvironmentSlot] = definition.environmentIDs.compactMap { id in
+      guard compendium.environment(id: id) != nil else { return nil }
+      return EnvironmentSlot(environmentID: id)
     }
 
-    /// Add an environment slot.
-    public func add(environment: DaggerheartEnvironment) {
-        environmentSlots.append(EnvironmentSlot(environmentID: environment.id))
+    let playerSlots: [PlayerSlot] = definition.playerConfigs.map { config in
+      PlayerSlot(
+        name: config.name,
+        maxHP: config.maxHP,
+        maxStress: config.maxStress,
+        evasion: config.evasion,
+        thresholdMajor: config.thresholdMajor,
+        thresholdSevere: config.thresholdSevere,
+        armorSlots: config.armorSlots
+      )
     }
 
-    /// Remove an adversary slot by ID.
-    public func removeAdversary(id: UUID) {
-        adversarySlots.removeAll { $0.id == id }
-        turnOrder.removeAll { $0 == id }
-        if activeSlotID == id { activeSlotID = nil }
-    }
-
-    // MARK: - Player Management
-
-    /// Add a player slot to the encounter.
-    public func addPlayer(_ player: PlayerSlot) {
-        playerSlots.append(player)
-        turnOrder.append(player.id)
-    }
-
-    /// Remove a player slot by ID.
-    public func removePlayer(id: UUID) {
-        playerSlots.removeAll { $0.id == id }
-        turnOrder.removeAll { $0 == id }
-        if activeSlotID == id { activeSlotID = nil }
-    }
-
-    // MARK: - HP & Stress Mutations
-
-    /// Apply damage to an adversary slot, clamping HP to 0.
-    public func applyDamage(_ amount: Int, to slotID: UUID) {
-        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
-            logger.warning("applyDamage: slot \(slotID) not found")
-            return
-        }
-        adversarySlots[index].currentHP = max(0, adversarySlots[index].currentHP - amount)
-        if adversarySlots[index].currentHP == 0 {
-            adversarySlots[index].isDefeated = true
-            logger.info("Slot \(slotID) defeated")
-        } else {
-            logger.debug("Slot \(slotID) took \(amount) damage, HP now \(self.adversarySlots[index].currentHP)")
-        }
-    }
-
-    /// Apply stress to an adversary slot, clamping to the slot's snapshotted maximum.
-    public func applyStress(_ amount: Int, to slotID: UUID) {
-        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
-            logger.warning("applyStress: slot \(slotID) not found")
-            return
-        }
-        adversarySlots[index].currentStress = min(
-            adversarySlots[index].maxStress,
-            adversarySlots[index].currentStress + amount
-        )
-        logger.debug("Slot \(slotID) stress now \(self.adversarySlots[index].currentStress)/\(self.adversarySlots[index].maxStress)")
-    }
-
-    /// Heal an adversary slot, clamping HP to the slot's snapshotted maximum.
-    public func heal(_ amount: Int, slotID: UUID) {
-        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else {
-            logger.warning("heal: slot \(slotID) not found")
-            return
-        }
-        adversarySlots[index].currentHP = min(
-            adversarySlots[index].maxHP,
-            adversarySlots[index].currentHP + amount
-        )
-        if adversarySlots[index].currentHP > 0 {
-            adversarySlots[index].isDefeated = false
-        }
-        logger.debug("Slot \(slotID) healed \(amount), HP now \(self.adversarySlots[index].currentHP)/\(self.adversarySlots[index].maxHP)")
-    }
-
-    // MARK: - Adversary Condition Management
-
-    /// Apply a condition to an adversary slot.
-    /// Per the SRD, the same condition does not stack (Set enforces this).
-    /// `.custom` conditions with an empty or whitespace-only name are silently ignored.
-    public func applyCondition(_ condition: Condition, to slotID: UUID) {
-        if case .custom(let name) = condition,
-           name.trimmingCharacters(in: .whitespaces).isEmpty { return }
-        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else { return }
-        adversarySlots[index].conditions.insert(condition)
-    }
-
-    /// Remove a condition from an adversary slot.
-    public func removeCondition(_ condition: Condition, from slotID: UUID) {
-        guard let index = adversarySlots.firstIndex(where: { $0.id == slotID }) else { return }
-        adversarySlots[index].conditions.remove(condition)
-    }
-
-    // MARK: - Player HP & Stress Mutations
-
-    /// Apply damage to a player slot, clamping HP to 0.
-    public func applyPlayerDamage(_ amount: Int, to slotID: UUID) {
-        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
-        playerSlots[index].currentHP = max(0, playerSlots[index].currentHP - amount)
-    }
-
-    /// Apply stress to a player slot, clamping to maximum.
-    public func applyPlayerStress(_ amount: Int, to slotID: UUID) {
-        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
-        playerSlots[index].currentStress = min(
-            playerSlots[index].maxStress,
-            playerSlots[index].currentStress + amount
-        )
-    }
-
-    /// Heal a player slot, clamping HP to maximum.
-    public func healPlayer(_ amount: Int, slotID: UUID) {
-        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
-        playerSlots[index].currentHP = min(
-            playerSlots[index].maxHP,
-            playerSlots[index].currentHP + amount
-        )
-    }
-
-    /// Clear stress from a player slot, clamping to 0.
-    public func clearPlayerStress(_ amount: Int, slotID: UUID) {
-        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
-        playerSlots[index].currentStress = max(0, playerSlots[index].currentStress - amount)
-    }
-
-    /// Mark one Armor Slot on a player (used to reduce damage severity).
-    public func markPlayerArmorSlot(_ slotID: UUID) {
-        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
-        guard playerSlots[index].currentArmorSlots > 0 else { return }
-        playerSlots[index].currentArmorSlots -= 1
-    }
-
-    /// Restore one Armor Slot on a player (undo a mark, or recover via a rest ability).
-    public func restorePlayerArmorSlot(_ slotID: UUID) {
-        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
-        playerSlots[index].currentArmorSlots = min(
-            playerSlots[index].armorSlots,
-            playerSlots[index].currentArmorSlots + 1
-        )
-    }
-
-    // MARK: - Player Condition Management
-
-    /// Apply a condition to a player slot.
-    /// `.custom` conditions with an empty or whitespace-only name are silently ignored.
-    public func applyPlayerCondition(_ condition: Condition, to slotID: UUID) {
-        if case .custom(let name) = condition,
-           name.trimmingCharacters(in: .whitespaces).isEmpty { return }
-        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
-        playerSlots[index].conditions.insert(condition)
-    }
-
-    /// Remove a condition from a player slot.
-    public func removePlayerCondition(_ condition: Condition, from slotID: UUID) {
-        guard let index = playerSlots.firstIndex(where: { $0.id == slotID }) else { return }
-        playerSlots[index].conditions.remove(condition)
-    }
-
-    // MARK: - Fear & Hope
-
-    public func incrementFear(by amount: Int = 1) {
-        fearPool += amount
-    }
-
-    public func spendFear(_ amount: Int = 1) {
-        fearPool = max(0, fearPool - amount)
-    }
-
-    public func incrementHope(by amount: Int = 1) {
-        hopePool += amount
-    }
-
-    public func spendHope(_ amount: Int = 1) {
-        hopePool = max(0, hopePool - amount)
-    }
-
-    // MARK: - Round Management
-
-    /// Advance to the next round, resetting the turn position.
-    public func advanceRound() {
-        currentRound += 1
-        activeSlotID = nil
-        // Defeated adversaries are removed from the turn order for the new round.
-        let defeatedIDs = Set(adversarySlots.filter(\.isDefeated).map(\.id))
-        turnOrder = turnOrder.filter { !defeatedIDs.contains($0) }
-        logger.info("Advanced to round \(self.currentRound), \(self.turnOrder.count) slots in order")
-    }
-
-    /// Turn order filtered to non-defeated participants.
-    /// Defeated adversaries are excluded so `advanceTurn` never lands on them mid-round.
-    private var activeTurnOrder: [UUID] {
-        let defeatedIDs = Set(adversarySlots.filter(\.isDefeated).map(\.id))
-        return turnOrder.filter { !defeatedIDs.contains($0) }
-    }
-
-    /// Set the active spotlight to the next slot in turn order, skipping defeated adversaries.
-    public func advanceTurn() {
-        let active = activeTurnOrder
-        guard !active.isEmpty else { activeSlotID = nil; return }
-        if let current = activeSlotID,
-           let currentIndex = active.firstIndex(of: current),
-           currentIndex + 1 < active.count {
-            activeSlotID = active[currentIndex + 1]
-        } else {
-            activeSlotID = active.first
-        }
-    }
-
-    // MARK: - Computed Helpers
-
-    /// All adversary slots still in the fight.
-    public var activeAdversaries: [AdversarySlot] {
-        adversarySlots.filter { !$0.isDefeated }
-    }
-
-    /// `true` when all adversary slots are defeated.
-    public var isOver: Bool {
-        !adversarySlots.isEmpty && adversarySlots.allSatisfy(\.isDefeated)
-    }
-
-    // MARK: - Factory
-
-    /// Create a live encounter session from a saved definition.
-    ///
-    /// Resolves adversary and environment IDs through the compendium.
-    /// IDs that do not resolve to a catalog entry are silently skipped
-    /// (this handles orphaned homebrew references gracefully).
-    ///
-    /// - Parameters:
-    ///   - definition: The encounter template to instantiate.
-    ///   - compendium: The catalog used to resolve adversary/environment IDs.
-    /// - Returns: A fresh `EncounterSession` ready for play.
-    public static func start(
-        from definition: EncounterDefinition,
-        using compendium: Compendium
-    ) -> EncounterSession {
-        let adversarySlots: [AdversarySlot] = definition.adversaryIDs.compactMap { id in
-            guard let adversary = compendium.adversary(id: id) else { return nil }
-            return AdversarySlot.from(adversary)
-        }
-
-        let environmentSlots: [EnvironmentSlot] = definition.environmentIDs.compactMap { id in
-            guard compendium.environment(id: id) != nil else { return nil }
-            return EnvironmentSlot(environmentID: id)
-        }
-
-        let playerSlots: [PlayerSlot] = definition.playerConfigs.map { config in
-            PlayerSlot(
-                name: config.name,
-                maxHP: config.maxHP,
-                maxStress: config.maxStress,
-                evasion: config.evasion,
-                thresholdMajor: config.thresholdMajor,
-                thresholdSevere: config.thresholdSevere,
-                armorSlots: config.armorSlots
-            )
-        }
-
-        return EncounterSession(
-            name: definition.name,
-            adversarySlots: adversarySlots,
-            playerSlots: playerSlots,
-            environmentSlots: environmentSlots,
-            gmNotes: definition.gmNotes
-        )
-    }
+    return EncounterSession(
+      name: definition.name,
+      adversarySlots: adversarySlots,
+      playerSlots: playerSlots,
+      environmentSlots: environmentSlots,
+      gmNotes: definition.gmNotes
+    )
+  }
 }

--- a/Encounter/Models/EncounterStore.swift
+++ b/Encounter/Models/EncounterStore.swift
@@ -22,20 +22,20 @@ import Observation
 
 /// Errors thrown by ``EncounterStore`` operations.
 public enum EncounterStoreError: Error, LocalizedError {
-    case notFound(UUID)
-    case saveFailed(UUID, Error)
-    case deleteFailed(UUID, Error)
+  case notFound(UUID)
+  case saveFailed(UUID, Error)
+  case deleteFailed(UUID, Error)
 
-    public var errorDescription: String? {
-        switch self {
-        case .notFound(let id):
-            return "No encounter definition found with ID \(id)."
-        case .saveFailed(let id, let underlying):
-            return "Failed to save encounter \(id): \(underlying.localizedDescription)"
-        case .deleteFailed(let id, let underlying):
-            return "Failed to delete encounter \(id): \(underlying.localizedDescription)"
-        }
+  public var errorDescription: String? {
+    switch self {
+    case .notFound(let id):
+      return "No encounter definition found with ID \(id)."
+    case .saveFailed(let id, let underlying):
+      return "Failed to save encounter \(id): \(underlying.localizedDescription)"
+    case .deleteFailed(let id, let underlying):
+      return "Failed to delete encounter \(id): \(underlying.localizedDescription)"
     }
+  }
 }
 
 // MARK: - EncounterStore
@@ -66,229 +66,235 @@ public enum EncounterStoreError: Error, LocalizedError {
 @Observable @MainActor
 public final class EncounterStore {
 
-    // MARK: Public State
+  // MARK: Public State
 
-    /// All loaded encounter definitions, sorted by `modifiedAt` descending.
-    public private(set) var definitions: [EncounterDefinition] = []
+  /// All loaded encounter definitions, sorted by `modifiedAt` descending.
+  public private(set) var definitions: [EncounterDefinition] = []
 
-    /// The directory where `.encounter.json` files are stored.
-    public private(set) var directory: URL
+  /// The directory where `.encounter.json` files are stored.
+  public private(set) var directory: URL
 
-    /// `true` while a `load()` is in progress.
-    public private(set) var isLoading = false
+  /// `true` while a `load()` is in progress.
+  public private(set) var isLoading = false
 
-    /// Non-nil if the last `load()` failed at the directory level.
-    public private(set) var loadError: (any Error)?
+  /// Non-nil if the last `load()` failed at the directory level.
+  public private(set) var loadError: (any Error)?
 
-    // MARK: - Init
+  // MARK: - Init
 
-    public init(directory: URL) {
-        self.directory = directory
+  public init(directory: URL) {
+    self.directory = directory
+  }
+
+  // MARK: - Directory Resolution
+
+  /// Returns the preferred storage directory, using iCloud when available.
+  ///
+  /// `url(forUbiquityContainerIdentifier:)` may perform file-system operations.
+  /// Marked `@concurrent` so the body runs on the cooperative thread pool even
+  /// when called from a `@MainActor` context (required in Swift 6.2+).
+  @concurrent
+  nonisolated public static func defaultDirectory() async -> URL {
+    await resolveDefaultDirectory()
+  }
+
+  @concurrent
+  nonisolated private static func resolveDefaultDirectory() async -> URL {
+    let fm = FileManager.default
+    if let ubiquity = fm.url(forUbiquityContainerIdentifier: nil) {
+      let dir =
+        ubiquity
+        .appending(path: "Documents")
+        .appending(path: "Encounters")
+      try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
+      return dir
     }
+    return Self.localDirectory
+  }
 
-    // MARK: - Directory Resolution
+  @concurrent
+  nonisolated private static func readAllEncounters(from dir: URL) async throws
+    -> [EncounterDefinition]
+  {
+    let fm = FileManager.default
+    try fm.createDirectory(at: dir, withIntermediateDirectories: true)
+    let contents = try fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: [])
+    let decoder = JSONDecoder()
+    return
+      contents
+      .filter { $0.lastPathComponent.hasSuffix(".encounter.json") }
+      .compactMap { url -> EncounterDefinition? in
+        guard let data = try? Data(contentsOf: url),
+          let def = try? decoder.decode(EncounterDefinition.self, from: data)
+        else { return nil }
+        return def
+      }
+  }
 
-    /// Returns the preferred storage directory, using iCloud when available.
-    ///
-    /// `url(forUbiquityContainerIdentifier:)` may perform file-system operations.
-    /// Marked `@concurrent` so the body runs on the cooperative thread pool even
-    /// when called from a `@MainActor` context (required in Swift 6.2+).
-    @concurrent
-    nonisolated public static func defaultDirectory() async -> URL {
-        await resolveDefaultDirectory()
+  @concurrent
+  nonisolated private static func writeEncounter(_ definition: EncounterDefinition, to url: URL)
+    async throws
+  {
+    // Create directory defensively so persist() works even if
+    // called before load() has had a chance to create it.
+    try FileManager.default.createDirectory(
+      at: url.deletingLastPathComponent(),
+      withIntermediateDirectories: true
+    )
+    // JSONEncoder is allocated per-call because JSONEncoder is not
+    // Sendable in Swift 6 and cannot be safely shared across tasks.
+    let data = try JSONEncoder().encode(definition)
+    try data.write(to: url, options: .atomic)
+  }
+
+  @concurrent
+  nonisolated private static func deleteEncounter(at url: URL) async throws {
+    try FileManager.default.removeItem(at: url)
+  }
+
+  /// Local Application Support directory. A pure URL — no file I/O performed.
+  nonisolated public static var localDirectory: URL {
+    URL.applicationSupportDirectory.appending(path: "Encounters")
+  }
+
+  /// Switches the storage directory and clears `definitions`.
+  /// Call `load()` afterwards to populate from the new location.
+  public func relocate(to newDirectory: URL) {
+    directory = newDirectory
+    definitions = []
+  }
+
+  // MARK: - Load
+
+  /// Reads all `.encounter.json` files from `directory`.
+  ///
+  /// If a load is already in progress, this call returns immediately without
+  /// waiting for the existing load to complete and without triggering a second
+  /// load. Callers that need fresh data should await the first load before calling again.
+  ///
+  /// Corrupt or unreadable individual files are skipped silently.
+  /// Valid definitions are published via ``definitions``, sorted by
+  /// `modifiedAt` descending. Directory-level errors are stored in ``loadError``.
+  public func load() async {
+    guard !isLoading else { return }
+    isLoading = true
+    loadError = nil
+    defer { isLoading = false }
+
+    let dir = directory
+    do {
+      let loaded = try await Self.readAllEncounters(from: dir)
+      definitions = loaded.sorted { $0.modifiedAt > $1.modifiedAt }
+    } catch {
+      loadError = error
     }
+  }
 
-    @concurrent
-    nonisolated private static func resolveDefaultDirectory() async -> URL {
-        let fm = FileManager.default
-        if let ubiquity = fm.url(forUbiquityContainerIdentifier: nil) {
-            let dir = ubiquity
-                .appending(path: "Documents")
-                .appending(path: "Encounters")
-            try? fm.createDirectory(at: dir, withIntermediateDirectories: true)
-            return dir
-        }
-        return Self.localDirectory
+  // MARK: - Create
+
+  /// Creates a new ``EncounterDefinition``, persists it, and inserts it
+  /// into ``definitions``.
+  public func create(name: String) async throws {
+    let def = EncounterDefinition(name: name)
+    try await persist(def)
+    insertSorted(def)
+  }
+
+  // MARK: - Save
+
+  /// Persists an updated definition to disk and refreshes ``definitions``.
+  ///
+  /// The store stamps `modifiedAt = .now` before writing, so the sort order
+  /// invariant is maintained regardless of whether the caller has updated
+  /// individual properties through their `didSet` observers.
+  ///
+  /// - Throws: ``EncounterStoreError/notFound(_:)`` if the ID is not in
+  ///   the current ``definitions``.
+  public func save(_ definition: EncounterDefinition) async throws {
+    guard definitions.contains(where: { $0.id == definition.id }) else {
+      throw EncounterStoreError.notFound(definition.id)
     }
+    var stamped = definition
+    stamped.modifiedAt = .now
+    try await persist(stamped)
+    updateInPlace(stamped)
+  }
 
-    @concurrent
-    nonisolated private static func readAllEncounters(from dir: URL) async throws -> [EncounterDefinition] {
-        let fm = FileManager.default
-        try fm.createDirectory(at: dir, withIntermediateDirectories: true)
-        let contents = try fm.contentsOfDirectory(at: dir, includingPropertiesForKeys: [])
-        let decoder = JSONDecoder()
-        return contents
-            .filter { $0.lastPathComponent.hasSuffix(".encounter.json") }
-            .compactMap { url -> EncounterDefinition? in
-                guard let data = try? Data(contentsOf: url),
-                      let def = try? decoder.decode(EncounterDefinition.self, from: data)
-                else { return nil }
-                return def
-            }
+  // MARK: - Delete
+
+  /// Removes a definition from memory and deletes its backing file.
+  ///
+  /// - Throws: ``EncounterStoreError/notFound(_:)`` if the ID is unknown.
+  public func delete(id: UUID) async throws {
+    guard definitions.contains(where: { $0.id == id }) else {
+      throw EncounterStoreError.notFound(id)
     }
-
-    @concurrent
-    nonisolated private static func writeEncounter(_ definition: EncounterDefinition, to url: URL) async throws {
-        // Create directory defensively so persist() works even if
-        // called before load() has had a chance to create it.
-        try FileManager.default.createDirectory(
-            at: url.deletingLastPathComponent(),
-            withIntermediateDirectories: true
-        )
-        // JSONEncoder is allocated per-call because JSONEncoder is not
-        // Sendable in Swift 6 and cannot be safely shared across tasks.
-        let data = try JSONEncoder().encode(definition)
-        try data.write(to: url, options: .atomic)
+    let url = fileURL(for: id)
+    do {
+      try await Self.deleteEncounter(at: url)
+    } catch {
+      throw EncounterStoreError.deleteFailed(id, error)
     }
+    definitions.removeAll { $0.id == id }
+  }
 
-    @concurrent
-    nonisolated private static func deleteEncounter(at url: URL) async throws {
-        try FileManager.default.removeItem(at: url)
+  // MARK: - Duplicate
+
+  /// Creates an independent copy of an existing definition with a new UUID,
+  /// `createdAt`, and a `" (Copy)"` suffix on the name. Persists it and
+  /// adds it to ``definitions``.
+  ///
+  /// The copy is inserted with `createdAt = modifiedAt = .now`, so it sorts
+  /// to the top of ``definitions``.
+  ///
+  /// - Note: All content fields of ``EncounterDefinition`` must be listed
+  ///   explicitly here. When adding new fields to `EncounterDefinition`,
+  ///   update this method to include them.
+  ///
+  /// - Throws: ``EncounterStoreError/notFound(_:)`` if the source ID is unknown.
+  public func duplicate(id: UUID) async throws {
+    guard let original = definitions.first(where: { $0.id == id }) else {
+      throw EncounterStoreError.notFound(id)
     }
+    let copy = EncounterDefinition(
+      name: "\(original.name) (Copy)",
+      adversaryIDs: original.adversaryIDs,
+      environmentIDs: original.environmentIDs,
+      playerConfigs: original.playerConfigs,
+      gmNotes: original.gmNotes
+    )
+    try await persist(copy)
+    insertSorted(copy)
+  }
 
-    /// Local Application Support directory. A pure URL — no file I/O performed.
-    nonisolated public static var localDirectory: URL {
-        URL.applicationSupportDirectory.appending(path: "Encounters")
+  // MARK: - Private Helpers
+
+  private func fileURL(for id: UUID) -> URL {
+    directory.appending(path: "\(id.uuidString).encounter.json")
+  }
+
+  private func persist(_ definition: EncounterDefinition) async throws {
+    let url = fileURL(for: definition.id)
+    do {
+      try await Self.writeEncounter(definition, to: url)
+    } catch {
+      throw EncounterStoreError.saveFailed(definition.id, error)
     }
+  }
 
-    /// Switches the storage directory and clears `definitions`.
-    /// Call `load()` afterwards to populate from the new location.
-    public func relocate(to newDirectory: URL) {
-        directory = newDirectory
-        definitions = []
+  // Appends then re-sorts the full array. O(n log n), appropriate for
+  // GM-scale encounter lists (tens to low hundreds of items).
+  private func insertSorted(_ definition: EncounterDefinition) {
+    definitions.append(definition)
+    definitions.sort { $0.modifiedAt > $1.modifiedAt }
+  }
+
+  private func updateInPlace(_ definition: EncounterDefinition) {
+    guard let idx = definitions.firstIndex(where: { $0.id == definition.id }) else {
+      assertionFailure("updateInPlace called for unknown id \(definition.id)")
+      return
     }
-
-    // MARK: - Load
-
-    /// Reads all `.encounter.json` files from `directory`.
-    ///
-    /// If a load is already in progress, this call returns immediately without
-    /// waiting for the existing load to complete and without triggering a second
-    /// load. Callers that need fresh data should await the first load before calling again.
-    ///
-    /// Corrupt or unreadable individual files are skipped silently.
-    /// Valid definitions are published via ``definitions``, sorted by
-    /// `modifiedAt` descending. Directory-level errors are stored in ``loadError``.
-    public func load() async {
-        guard !isLoading else { return }
-        isLoading = true
-        loadError = nil
-        defer { isLoading = false }
-
-        let dir = directory
-        do {
-            let loaded = try await Self.readAllEncounters(from: dir)
-            definitions = loaded.sorted { $0.modifiedAt > $1.modifiedAt }
-        } catch {
-            loadError = error
-        }
-    }
-
-    // MARK: - Create
-
-    /// Creates a new ``EncounterDefinition``, persists it, and inserts it
-    /// into ``definitions``.
-    public func create(name: String) async throws {
-        let def = EncounterDefinition(name: name)
-        try await persist(def)
-        insertSorted(def)
-    }
-
-    // MARK: - Save
-
-    /// Persists an updated definition to disk and refreshes ``definitions``.
-    ///
-    /// The store stamps `modifiedAt = .now` before writing, so the sort order
-    /// invariant is maintained regardless of whether the caller has updated
-    /// individual properties through their `didSet` observers.
-    ///
-    /// - Throws: ``EncounterStoreError/notFound(_:)`` if the ID is not in
-    ///   the current ``definitions``.
-    public func save(_ definition: EncounterDefinition) async throws {
-        guard definitions.contains(where: { $0.id == definition.id }) else {
-            throw EncounterStoreError.notFound(definition.id)
-        }
-        var stamped = definition
-        stamped.modifiedAt = .now
-        try await persist(stamped)
-        updateInPlace(stamped)
-    }
-
-    // MARK: - Delete
-
-    /// Removes a definition from memory and deletes its backing file.
-    ///
-    /// - Throws: ``EncounterStoreError/notFound(_:)`` if the ID is unknown.
-    public func delete(id: UUID) async throws {
-        guard definitions.contains(where: { $0.id == id }) else {
-            throw EncounterStoreError.notFound(id)
-        }
-        let url = fileURL(for: id)
-        do {
-            try await Self.deleteEncounter(at: url)
-        } catch {
-            throw EncounterStoreError.deleteFailed(id, error)
-        }
-        definitions.removeAll { $0.id == id }
-    }
-
-    // MARK: - Duplicate
-
-    /// Creates an independent copy of an existing definition with a new UUID,
-    /// `createdAt`, and a `" (Copy)"` suffix on the name. Persists it and
-    /// adds it to ``definitions``.
-    ///
-    /// The copy is inserted with `createdAt = modifiedAt = .now`, so it sorts
-    /// to the top of ``definitions``.
-    ///
-    /// - Note: All content fields of ``EncounterDefinition`` must be listed
-    ///   explicitly here. When adding new fields to `EncounterDefinition`,
-    ///   update this method to include them.
-    ///
-    /// - Throws: ``EncounterStoreError/notFound(_:)`` if the source ID is unknown.
-    public func duplicate(id: UUID) async throws {
-        guard let original = definitions.first(where: { $0.id == id }) else {
-            throw EncounterStoreError.notFound(id)
-        }
-        let copy = EncounterDefinition(
-            name: "\(original.name) (Copy)",
-            adversaryIDs: original.adversaryIDs,
-            environmentIDs: original.environmentIDs,
-            playerConfigs: original.playerConfigs,
-            gmNotes: original.gmNotes
-        )
-        try await persist(copy)
-        insertSorted(copy)
-    }
-
-    // MARK: - Private Helpers
-
-    private func fileURL(for id: UUID) -> URL {
-        directory.appending(path: "\(id.uuidString).encounter.json")
-    }
-
-    private func persist(_ definition: EncounterDefinition) async throws {
-        let url = fileURL(for: definition.id)
-        do {
-            try await Self.writeEncounter(definition, to: url)
-        } catch {
-            throw EncounterStoreError.saveFailed(definition.id, error)
-        }
-    }
-
-    // Appends then re-sorts the full array. O(n log n), appropriate for
-    // GM-scale encounter lists (tens to low hundreds of items).
-    private func insertSorted(_ definition: EncounterDefinition) {
-        definitions.append(definition)
-        definitions.sort { $0.modifiedAt > $1.modifiedAt }
-    }
-
-    private func updateInPlace(_ definition: EncounterDefinition) {
-        guard let idx = definitions.firstIndex(where: { $0.id == definition.id }) else {
-            assertionFailure("updateInPlace called for unknown id \(definition.id)")
-            return
-        }
-        definitions[idx] = definition
-        definitions.sort { $0.modifiedAt > $1.modifiedAt }
-    }
+    definitions[idx] = definition
+    definitions.sort { $0.modifiedAt > $1.modifiedAt }
+  }
 }

--- a/Encounter/Models/PlayerSlot.swift
+++ b/Encounter/Models/PlayerSlot.swift
@@ -20,61 +20,61 @@ import Foundation
 /// Tracks combat-relevant PC stats the GM needs to resolve hits and
 /// track health during play. The full character sheet remains with the player.
 nonisolated public struct PlayerSlot: Identifiable, Sendable, Equatable, Hashable {
-    public let id: UUID
-    public var name: String
+  public let id: UUID
+  public var name: String
 
-    // MARK: Hit Points
-    public let maxHP: Int
-    public var currentHP: Int
+  // MARK: Hit Points
+  public let maxHP: Int
+  public var currentHP: Int
 
-    // MARK: Stress
-    public let maxStress: Int
-    public var currentStress: Int
+  // MARK: Stress
+  public let maxStress: Int
+  public var currentStress: Int
 
-    // MARK: Defense
-    /// The DC for all rolls made against this PC.
-    public let evasion: Int
-    /// Damage at or above this triggers a Major hit (mark 2 HP).
-    public let thresholdMajor: Int
-    /// Damage at or above this triggers a Severe hit (mark 3 HP).
-    public let thresholdSevere: Int
+  // MARK: Defense
+  /// The DC for all rolls made against this PC.
+  public let evasion: Int
+  /// Damage at or above this triggers a Major hit (mark 2 HP).
+  public let thresholdMajor: Int
+  /// Damage at or above this triggers a Severe hit (mark 3 HP).
+  public let thresholdSevere: Int
 
-    // MARK: Armor
-    /// Total Armor Score (number of Armor Slots available).
-    public let armorSlots: Int
-    /// Remaining unused Armor Slots.
-    public var currentArmorSlots: Int
+  // MARK: Armor
+  /// Total Armor Score (number of Armor Slots available).
+  public let armorSlots: Int
+  /// Remaining unused Armor Slots.
+  public var currentArmorSlots: Int
 
-    // MARK: Conditions
-    public var conditions: Set<Condition>
+  // MARK: Conditions
+  public var conditions: Set<Condition>
 
-    // MARK: - Init
+  // MARK: - Init
 
-    public init(
-        id: UUID = UUID(),
-        name: String,
-        maxHP: Int,
-        currentHP: Int? = nil,
-        maxStress: Int,
-        currentStress: Int = 0,
-        evasion: Int,
-        thresholdMajor: Int,
-        thresholdSevere: Int,
-        armorSlots: Int,
-        currentArmorSlots: Int? = nil,
-        conditions: Set<Condition> = []
-    ) {
-        self.id = id
-        self.name = name
-        self.maxHP = maxHP
-        self.currentHP = currentHP ?? maxHP
-        self.maxStress = maxStress
-        self.currentStress = currentStress
-        self.evasion = evasion
-        self.thresholdMajor = thresholdMajor
-        self.thresholdSevere = thresholdSevere
-        self.armorSlots = armorSlots
-        self.currentArmorSlots = currentArmorSlots ?? armorSlots
-        self.conditions = conditions
-    }
+  public init(
+    id: UUID = UUID(),
+    name: String,
+    maxHP: Int,
+    currentHP: Int? = nil,
+    maxStress: Int,
+    currentStress: Int = 0,
+    evasion: Int,
+    thresholdMajor: Int,
+    thresholdSevere: Int,
+    armorSlots: Int,
+    currentArmorSlots: Int? = nil,
+    conditions: Set<Condition> = []
+  ) {
+    self.id = id
+    self.name = name
+    self.maxHP = maxHP
+    self.currentHP = currentHP ?? maxHP
+    self.maxStress = maxStress
+    self.currentStress = currentStress
+    self.evasion = evasion
+    self.thresholdMajor = thresholdMajor
+    self.thresholdSevere = thresholdSevere
+    self.armorSlots = armorSlots
+    self.currentArmorSlots = currentArmorSlots ?? armorSlots
+    self.conditions = conditions
+  }
 }

--- a/Encounter/Models/SessionRegistry.swift
+++ b/Encounter/Models/SessionRegistry.swift
@@ -29,39 +29,39 @@ import Observation
 @MainActor
 @Observable
 public final class SessionRegistry {
-    public private(set) var sessions: [UUID: EncounterSession] = [:]
+  public private(set) var sessions: [UUID: EncounterSession] = [:]
 
-    public init() {}
+  public init() {}
 
-    /// Return the existing session for `definitionID`, or create and store a new one.
-    public func session(
-        for definitionID: UUID,
-        definition: EncounterDefinition,
-        compendium: Compendium
-    ) -> EncounterSession {
-        if let existing = sessions[definitionID] { return existing }
-        let newSession = EncounterSession.start(from: definition, using: compendium)
-        sessions[definitionID] = newSession
-        return newSession
-    }
+  /// Return the existing session for `definitionID`, or create and store a new one.
+  public func session(
+    for definitionID: UUID,
+    definition: EncounterDefinition,
+    compendium: Compendium
+  ) -> EncounterSession {
+    if let existing = sessions[definitionID] { return existing }
+    let newSession = EncounterSession.start(from: definition, using: compendium)
+    sessions[definitionID] = newSession
+    return newSession
+  }
 
-    /// Remove the stored session so the next call to ``session(for:definition:compendium:)``
-    /// starts a fresh session.
-    public func clearSession(for definitionID: UUID) {
-        sessions.removeValue(forKey: definitionID)
-    }
+  /// Remove the stored session so the next call to ``session(for:definition:compendium:)``
+  /// starts a fresh session.
+  public func clearSession(for definitionID: UUID) {
+    sessions.removeValue(forKey: definitionID)
+  }
 
-    /// Discard the existing session and immediately create a fresh one from the given definition.
-    ///
-    /// Use this when the GM wants to restart an encounter from scratch without navigating away.
-    @discardableResult
-    public func resetSession(
-        for definitionID: UUID,
-        definition: EncounterDefinition,
-        compendium: Compendium
-    ) -> EncounterSession {
-        let newSession = EncounterSession.start(from: definition, using: compendium)
-        sessions[definitionID] = newSession
-        return newSession
-    }
+  /// Discard the existing session and immediately create a fresh one from the given definition.
+  ///
+  /// Use this when the GM wants to restart an encounter from scratch without navigating away.
+  @discardableResult
+  public func resetSession(
+    for definitionID: UUID,
+    definition: EncounterDefinition,
+    compendium: Compendium
+  ) -> EncounterSession {
+    let newSession = EncounterSession.start(from: definition, using: compendium)
+    sessions[definitionID] = newSession
+    return newSession
+  }
 }

--- a/Encounter/Services/ContentFetcher.swift
+++ b/Encounter/Services/ContentFetcher.swift
@@ -28,89 +28,91 @@ import OSLog
 /// content size.
 public struct ContentFetcher: Sendable {
 
-    nonisolated private static let logger = Logger(subsystem: "gwillish.Encounter", category: "ContentFetcher")
+  nonisolated private static let logger = Logger(
+    subsystem: "gwillish.Encounter", category: "ContentFetcher")
 
-    public init() {}
+  public init() {}
 
-    // MARK: - Fetch outcome
+  // MARK: - Fetch outcome
 
-    /// The result of a fetch attempt.
-    public enum Outcome: Sendable {
-        /// New content was downloaded. `data` is the raw bytes; `fingerprint` is ready to persist.
-        case fetched(data: Data, fingerprint: ContentFingerprint)
-        /// The server returned HTTP 304 Not Modified. The cached content is still current.
-        case notModified
+  /// The result of a fetch attempt.
+  public enum Outcome: Sendable {
+    /// New content was downloaded. `data` is the raw bytes; `fingerprint` is ready to persist.
+    case fetched(data: Data, fingerprint: ContentFingerprint)
+    /// The server returned HTTP 304 Not Modified. The cached content is still current.
+    case notModified
+  }
+
+  // MARK: - Public API
+
+  /// Fetch the content pack for `source`.
+  ///
+  /// Sends a conditional GET using the stored ETag if available. Returns
+  /// `.notModified` when the server confirms the cached copy is current.
+  ///
+  /// - Throws: ``ContentStoreError/networkError(sourceID:underlying:)`` on transport failure.
+  @concurrent
+  nonisolated public func fetch(source: ContentSource) async throws -> Outcome {
+    guard let remoteURL = source.url else {
+      // Local imports have no URL — callers should guard on isLocalImport before calling.
+      throw ContentStoreError.networkError(
+        sourceID: source.id, underlying: URLError(.unsupportedURL))
+    }
+    var request = URLRequest(url: remoteURL)
+    request.cachePolicy = .reloadIgnoringLocalCacheData
+    if let etag = source.fingerprint?.etag {
+      request.setValue(etag, forHTTPHeaderField: "If-None-Match")
     }
 
-    // MARK: - Public API
-
-    /// Fetch the content pack for `source`.
-    ///
-    /// Sends a conditional GET using the stored ETag if available. Returns
-    /// `.notModified` when the server confirms the cached copy is current.
-    ///
-    /// - Throws: ``ContentStoreError/networkError(sourceID:underlying:)`` on transport failure.
-    @concurrent
-    nonisolated public func fetch(source: ContentSource) async throws -> Outcome {
-        guard let remoteURL = source.url else {
-            // Local imports have no URL — callers should guard on isLocalImport before calling.
-            throw ContentStoreError.networkError(sourceID: source.id, underlying: URLError(.unsupportedURL))
-        }
-        var request = URLRequest(url: remoteURL)
-        request.cachePolicy = .reloadIgnoringLocalCacheData
-        if let etag = source.fingerprint?.etag {
-            request.setValue(etag, forHTTPHeaderField: "If-None-Match")
-        }
-
-        let (data, response): (Data, URLResponse)
-        do {
-            (data, response) = try await URLSession.shared.data(for: request)
-        } catch {
-            throw ContentStoreError.networkError(sourceID: source.id, underlying: error)
-        }
-
-        if let http = response as? HTTPURLResponse, http.statusCode == 304 {
-            Self.logger.info("Source '\(source.id)' not modified (304)")
-            return .notModified
-        }
-
-        let sha256 = computeSHA256(data)
-        let etag   = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "ETag")
-        let fingerprint = ContentFingerprint(sha256: sha256, etag: etag)
-
-        Self.logger.info("ContentFetcher: \(data.count) bytes from '\(source.id)'")
-        return .fetched(data: data, fingerprint: fingerprint)
+    let (data, response): (Data, URLResponse)
+    do {
+      (data, response) = try await URLSession.shared.data(for: request)
+    } catch {
+      throw ContentStoreError.networkError(sourceID: source.id, underlying: error)
     }
 
-    /// Decode raw `.dhpack` bytes into adversaries and environments.
-    ///
-    /// - Throws: ``ContentStoreError/decodingFailed(sourceID:underlying:)`` on decode error.
-    @concurrent
-    nonisolated public func decode(data: Data, sourceID: String) async throws -> DHPackContent {
-        do {
-            return try JSONDecoder().decode(DHPackContent.self, from: data)
-        } catch {
-            throw ContentStoreError.decodingFailed(sourceID: sourceID, underlying: error)
-        }
+    if let http = response as? HTTPURLResponse, http.statusCode == 304 {
+      Self.logger.info("Source '\(source.id)' not modified (304)")
+      return .notModified
     }
 
-    /// Read raw bytes from a local file URL.
-    ///
-    /// Used by `ContentStore.importPack(from:)` to read a security-scoped file
-    /// off the cooperative thread pool rather than blocking the main actor.
-    @concurrent
-    nonisolated public static func readData(from url: URL) async throws -> Data {
-        try Data(contentsOf: url)
-    }
+    let sha256 = computeSHA256(data)
+    let etag = (response as? HTTPURLResponse)?.value(forHTTPHeaderField: "ETag")
+    let fingerprint = ContentFingerprint(sha256: sha256, etag: etag)
 
-    // MARK: - Fingerprinting
+    Self.logger.info("ContentFetcher: \(data.count) bytes from '\(source.id)'")
+    return .fetched(data: data, fingerprint: fingerprint)
+  }
 
-    /// Computes a SHA-256 hex string for the given data.
-    ///
-    /// Intentionally `nonisolated` — must only be called off the main actor.
-    nonisolated public func computeSHA256(_ data: Data) -> String {
-        SHA256.hash(data: data)
-            .map { String(format: "%02x", $0) }
-            .joined()
+  /// Decode raw `.dhpack` bytes into adversaries and environments.
+  ///
+  /// - Throws: ``ContentStoreError/decodingFailed(sourceID:underlying:)`` on decode error.
+  @concurrent
+  nonisolated public func decode(data: Data, sourceID: String) async throws -> DHPackContent {
+    do {
+      return try JSONDecoder().decode(DHPackContent.self, from: data)
+    } catch {
+      throw ContentStoreError.decodingFailed(sourceID: sourceID, underlying: error)
     }
+  }
+
+  /// Read raw bytes from a local file URL.
+  ///
+  /// Used by `ContentStore.importPack(from:)` to read a security-scoped file
+  /// off the cooperative thread pool rather than blocking the main actor.
+  @concurrent
+  nonisolated public static func readData(from url: URL) async throws -> Data {
+    try Data(contentsOf: url)
+  }
+
+  // MARK: - Fingerprinting
+
+  /// Computes a SHA-256 hex string for the given data.
+  ///
+  /// Intentionally `nonisolated` — must only be called off the main actor.
+  nonisolated public func computeSHA256(_ data: Data) -> String {
+    SHA256.hash(data: data)
+      .map { String(format: "%02x", $0) }
+      .joined()
+  }
 }

--- a/Encounter/Services/ContentStore.swift
+++ b/Encounter/Services/ContentStore.swift
@@ -9,8 +9,8 @@
 //
 
 import Foundation
-import Observation
 import OSLog
+import Observation
 
 // MARK: - ContentStore
 
@@ -31,332 +31,340 @@ import OSLog
 @Observable
 public final class ContentStore {
 
-    private let logger = Logger(subsystem: "gwillish.Encounter", category: "ContentStore")
+  private let logger = Logger(subsystem: "gwillish.Encounter", category: "ContentStore")
 
-    // MARK: - Dependencies
+  // MARK: - Dependencies
 
-    // fetcher is an immutable Sendable value type; nonisolated so awaiting its
-    // methods from a @MainActor context runs them on the cooperative thread pool.
-    nonisolated private let fetcher: ContentFetcher
+  // fetcher is an immutable Sendable value type; nonisolated so awaiting its
+  // methods from a @MainActor context runs them on the cooperative thread pool.
+  nonisolated private let fetcher: ContentFetcher
 
-    // writer is a var so relocate(to:) can swap it when the real content
-    // directory is known. Callers capture the current writer value via await,
-    // so in-flight tasks are unaffected by a reassignment.
-    private var writer: ContentWriter
+  // writer is a var so relocate(to:) can swap it when the real content
+  // directory is known. Callers capture the current writer value via await,
+  // so in-flight tasks are unaffected by a reassignment.
+  private var writer: ContentWriter
 
-    private var compendium: Compendium
+  private var compendium: Compendium
 
-    /// The current content root directory. Read-only outside this type.
-    public private(set) var contentDirectory: URL
+  /// The current content root directory. Read-only outside this type.
+  public private(set) var contentDirectory: URL
 
-    // MARK: - Published state
+  // MARK: - Published state
 
-    /// Registered remote content sources, keyed by source ID.
-    public private(set) var sources: [String: ContentSource] = [:]
+  /// Registered remote content sources, keyed by source ID.
+  public private(set) var sources: [String: ContentSource] = [:]
 
-    /// Source IDs currently being fetched.
-    public private(set) var fetchingSourceIDs: Set<String> = []
+  /// Source IDs currently being fetched.
+  public private(set) var fetchingSourceIDs: Set<String> = []
 
-    /// `true` while startup seeding/loading is in progress.
-    public private(set) var isLoading: Bool = false
+  /// `true` while startup seeding/loading is in progress.
+  public private(set) var isLoading: Bool = false
 
-    /// Non-nil if the most recent operation produced an error.
-    public private(set) var lastError: ContentStoreError?
+  /// Non-nil if the most recent operation produced an error.
+  public private(set) var lastError: ContentStoreError?
 
-    // MARK: - Init / directory resolution
+  // MARK: - Init / directory resolution
 
-    /// Placeholder content directory used until `relocate(to:)` is called.
-    /// Always local Application Support — no file I/O performed.
-    nonisolated public static var localContentDirectory: URL {
-        URL.applicationSupportDirectory
-            .appending(path: "gwillish.Encounter", directoryHint: .isDirectory)
-            .appending(path: "Content",            directoryHint: .isDirectory)
+  /// Placeholder content directory used until `relocate(to:)` is called.
+  /// Always local Application Support — no file I/O performed.
+  nonisolated public static var localContentDirectory: URL {
+    URL.applicationSupportDirectory
+      .appending(path: "gwillish.Encounter", directoryHint: .isDirectory)
+      .appending(path: "Content", directoryHint: .isDirectory)
+  }
+
+  public init(contentDirectory: URL, compendium: Compendium) {
+    self.contentDirectory = contentDirectory
+    self.fetcher = ContentFetcher()
+    self.writer = ContentWriter(contentDirectory: contentDirectory)
+    self.compendium = compendium
+  }
+
+  /// Wire in the real ``Compendium`` instance after construction.
+  ///
+  /// Call this in `EncounterApp.task` before ``loadOnStartup()`` to replace
+  /// the placeholder `Compendium` passed to `init`. This avoids recreating
+  /// the entire `ContentStore` just to swap the compendium reference.
+  public func configure(compendium: Compendium) {
+    self.compendium = compendium
+  }
+
+  /// Switches to a new content directory with safety checks.
+  ///
+  /// Call this once in `EncounterApp.task` before ``loadOnStartup()``,
+  /// passing the resolved real directory (which may differ from the
+  /// placeholder when iCloud or a custom path is in use).
+  ///
+  /// Safety rules (all comparisons use standardized paths):
+  /// 1. **Same path** — no-op; logs and returns immediately.
+  /// 2. **New path already has content** — switches without touching existing
+  ///    files; logs a warning so the situation is visible.
+  /// 3. **Old path has content, new path is empty** — migrates subdirectories
+  ///    one at a time. Never overwrites a subdirectory that already exists at
+  ///    the destination. Falls back to a switch-only if migration fails.
+  /// 4. **Old path is empty** — switches silently.
+  public func relocate(to newDirectory: URL) async {
+    let oldStd = contentDirectory.standardized
+    let newStd = newDirectory.standardized
+    guard oldStd != newStd else {
+      logger.debug("ContentStore.relocate: already at target '\(newStd.path)' — no-op")
+      return
     }
 
-    public init(contentDirectory: URL, compendium: Compendium) {
-        self.contentDirectory = contentDirectory
-        self.fetcher          = ContentFetcher()
-        self.writer           = ContentWriter(contentDirectory: contentDirectory)
-        self.compendium       = compendium
+    let oldHasContent = await ContentWriter.checkSubdirectoryExists(oldStd)
+    let newHasContent = await ContentWriter.checkSubdirectoryExists(newStd)
+
+    if newHasContent {
+      // The target already has data — switch without touching anything.
+      if oldHasContent {
+        logger.warning(
+          "ContentStore.relocate: both '\(oldStd.path)' and '\(newStd.path)' have content. Switching to new path; old content left in place."
+        )
+      } else {
+        logger.info("ContentStore.relocate: switching to existing content at '\(newStd.path)'")
+      }
+    } else if oldHasContent {
+      // Old has data, new is empty — attempt migration.
+      logger.info(
+        "ContentStore.relocate: migrating content from '\(oldStd.path)' to '\(newStd.path)'"
+      )
+      await ContentWriter.migrateSubdirectories(
+        from: oldStd,
+        to: newStd,
+        names: ["srd", "sources", "homebrew"],
+        logger: logger
+      )
+      logger.info("ContentStore.relocate: migration complete")
     }
 
-    /// Wire in the real ``Compendium`` instance after construction.
-    ///
-    /// Call this in `EncounterApp.task` before ``loadOnStartup()`` to replace
-    /// the placeholder `Compendium` passed to `init`. This avoids recreating
-    /// the entire `ContentStore` just to swap the compendium reference.
-    public func configure(compendium: Compendium) {
-        self.compendium = compendium
-    }
+    contentDirectory = newDirectory
+    writer = ContentWriter(contentDirectory: newDirectory)
+    logger.info(
+      "ContentStore.relocate: active directory is now '\(newDirectory.standardized.path)'")
+  }
 
-    /// Switches to a new content directory with safety checks.
-    ///
-    /// Call this once in `EncounterApp.task` before ``loadOnStartup()``,
-    /// passing the resolved real directory (which may differ from the
-    /// placeholder when iCloud or a custom path is in use).
-    ///
-    /// Safety rules (all comparisons use standardized paths):
-    /// 1. **Same path** — no-op; logs and returns immediately.
-    /// 2. **New path already has content** — switches without touching existing
-    ///    files; logs a warning so the situation is visible.
-    /// 3. **Old path has content, new path is empty** — migrates subdirectories
-    ///    one at a time. Never overwrites a subdirectory that already exists at
-    ///    the destination. Falls back to a switch-only if migration fails.
-    /// 4. **Old path is empty** — switches silently.
-    public func relocate(to newDirectory: URL) async {
-        let oldStd = contentDirectory.standardized
-        let newStd = newDirectory.standardized
-        guard oldStd != newStd else {
-            logger.debug("ContentStore.relocate: already at target '\(newStd.path)' — no-op")
-            return
+  // MARK: - Startup
+
+  /// Seed SRD content and load the source index. Call once at app launch.
+  ///
+  /// 1. Seeds writable SRD from bundle (no-op if already seeded for this version).
+  /// 2. Loads the source index from disk.
+  /// 3. Hydrates ``Compendium`` with any previously fetched source packs.
+  public func loadOnStartup() async {
+    guard !isLoading else { return }
+    isLoading = true
+    defer { isLoading = false }
+
+    let bundleVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
+
+    do {
+      // Seed SRD — nonisolated, runs on cooperative thread pool when awaited
+      let seeded = try await writer.seedSRDIfNeeded(bundleVersion: bundleVersion)
+      if seeded { logger.info("ContentStore: SRD seeded from bundle") }
+
+      // Load source index
+      let savedSources = try await writer.readSourceIndex()
+      sources = Dictionary(uniqueKeysWithValues: savedSources.map { ($0.id, $0) })
+
+      // Hydrate Compendium with previously fetched source packs (all in parallel)
+      await withTaskGroup(of: Void.self) { group in
+        for (sourceID, _) in sources {
+          group.addTask { await self.loadSourcePackIntoCompendium(sourceID: sourceID) }
         }
-
-        let oldHasContent = await ContentWriter.checkSubdirectoryExists(oldStd)
-        let newHasContent = await ContentWriter.checkSubdirectoryExists(newStd)
-
-        if newHasContent {
-            // The target already has data — switch without touching anything.
-            if oldHasContent {
-                logger.warning("ContentStore.relocate: both '\(oldStd.path)' and '\(newStd.path)' have content. Switching to new path; old content left in place.")
-            } else {
-                logger.info("ContentStore.relocate: switching to existing content at '\(newStd.path)'")
-            }
-        } else if oldHasContent {
-            // Old has data, new is empty — attempt migration.
-            logger.info(
-                "ContentStore.relocate: migrating content from '\(oldStd.path)' to '\(newStd.path)'"
-            )
-            await ContentWriter.migrateSubdirectories(
-                from: oldStd,
-                to: newStd,
-                names: ["srd", "sources", "homebrew"],
-                logger: logger
-            )
-            logger.info("ContentStore.relocate: migration complete")
-        }
-
-        contentDirectory = newDirectory
-        writer = ContentWriter(contentDirectory: newDirectory)
-        logger.info("ContentStore.relocate: active directory is now '\(newDirectory.standardized.path)'")
+      }
+      logger.info("ContentStore: startup complete, \(self.sources.count) sources loaded")
+    } catch {
+      lastError =
+        error as? ContentStoreError
+        ?? ContentStoreError.readFailed(sourceID: "startup", underlying: error)
+      logger.error("ContentStore: startup failed: \(error)")
     }
+  }
 
-    // MARK: - Startup
+  // MARK: - Source management
 
-    /// Seed SRD content and load the source index. Call once at app launch.
-    ///
-    /// 1. Seeds writable SRD from bundle (no-op if already seeded for this version).
-    /// 2. Loads the source index from disk.
-    /// 3. Hydrates ``Compendium`` with any previously fetched source packs.
-    public func loadOnStartup() async {
-        guard !isLoading else { return }
-        isLoading = true
-        defer { isLoading = false }
+  /// Register a new content source. Does not fetch immediately.
+  public func addSource(_ source: ContentSource) async {
+    sources[source.id] = source
+    await persistSourceIndex()
+  }
 
-        let bundleVersion = Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "1"
-
-        do {
-            // Seed SRD — nonisolated, runs on cooperative thread pool when awaited
-            let seeded = try await writer.seedSRDIfNeeded(bundleVersion: bundleVersion)
-            if seeded { logger.info("ContentStore: SRD seeded from bundle") }
-
-            // Load source index
-            let savedSources = try await writer.readSourceIndex()
-            sources = Dictionary(uniqueKeysWithValues: savedSources.map { ($0.id, $0) })
-
-            // Hydrate Compendium with previously fetched source packs (all in parallel)
-            await withTaskGroup(of: Void.self) { group in
-                for (sourceID, _) in sources {
-                    group.addTask { await self.loadSourcePackIntoCompendium(sourceID: sourceID) }
-                }
-            }
-            logger.info("ContentStore: startup complete, \(self.sources.count) sources loaded")
-        } catch {
-            lastError = error as? ContentStoreError
-                ?? ContentStoreError.readFailed(sourceID: "startup", underlying: error)
-            logger.error("ContentStore: startup failed: \(error)")
-        }
+  /// Remove a source and its content from the Compendium and disk.
+  public func removeSource(id: String) async {
+    sources.removeValue(forKey: id)
+    compendium.removeSourceContent(sourceID: id)
+    do {
+      try await writer.removeSourcePack(sourceID: id)
+    } catch {
+      logger.error("ContentStore: failed to remove pack '\(id)' from disk: \(error)")
     }
+    await persistSourceIndex()
+    logger.info("ContentStore: source '\(id)' removed")
+  }
 
-    // MARK: - Source management
+  // MARK: - Remote fetch
 
-    /// Register a new content source. Does not fetch immediately.
-    public func addSource(_ source: ContentSource) async {
-        sources[source.id] = source
+  /// Fetch and install a remote source pack. User-initiated only.
+  ///
+  /// Respects exponential backoff. No-ops if already fetching this source
+  /// or if the source is currently throttled.
+  public func fetchSource(id: String) async {
+    guard var source = sources[id] else { return }
+    guard !source.isLocalImport else {
+      logger.debug("ContentStore: source '\(id)' is a local import — no URL to fetch")
+      return
+    }
+    guard !source.isThrottled() else {
+      logger.info("ContentStore: source '\(id)' throttled, skipping")
+      return
+    }
+    guard !fetchingSourceIDs.contains(id) else { return }
+
+    fetchingSourceIDs.insert(id)
+    defer { fetchingSourceIDs.remove(id) }
+
+    do {
+      // fetcher.fetch is nonisolated — suspends the main actor and runs on
+      // the cooperative thread pool. Resumes on the main actor with the outcome.
+      let outcome = try await fetcher.fetch(source: source)
+
+      switch outcome {
+      case .notModified:
+        // HTTP 304: server confirmed cached content is current. This is a
+        // success — update lastFetched and clear any prior error state.
+        // The Compendium already has this source's content from loadOnStartup.
+        guard sources[id] != nil else {
+          logger.info(
+            "ContentStore: source '\(id)' removed mid-fetch — discarding notModified result")
+          return
+        }
+        let existing = source.fingerprint ?? ContentFingerprint(sha256: "", etag: nil)
+        source = source.recordingSuccess(fingerprint: existing)
+        sources[id] = source
         await persistSourceIndex()
-    }
+        logger.info("ContentStore: source '\(id)' not modified — still current")
 
-    /// Remove a source and its content from the Compendium and disk.
-    public func removeSource(id: String) async {
-        sources.removeValue(forKey: id)
-        compendium.removeSourceContent(sourceID: id)
-        do {
-            try await writer.removeSourcePack(sourceID: id)
-        } catch {
-            logger.error("ContentStore: failed to remove pack '\(id)' from disk: \(error)")
+      case .fetched(let data, let fingerprint):
+        // Decode and write — @concurrent, runs on cooperative thread pool when awaited.
+        let pack = try await fetcher.decode(data: data, sourceID: id)
+
+        try await writer.writeSourcePack(
+          adversaries: pack.adversaries,
+          environments: pack.environments,
+          sourceID: id
+        )
+
+        // Back on main actor: update state and Compendium.
+        // Guard against source being removed while the fetch was in-flight.
+        guard sources[id] != nil else {
+          logger.info("ContentStore: source '\(id)' removed mid-fetch — discarding fetched result")
+          return
         }
+        source = source.recordingSuccess(fingerprint: fingerprint)
+        sources[id] = source
+        compendium.replaceSourceContent(
+          sourceID: id,
+          adversaries: pack.adversaries,
+          environments: pack.environments
+        )
         await persistSourceIndex()
-        logger.info("ContentStore: source '\(id)' removed")
+        logger.info("ContentStore: source '\(id)' fetched: \(pack.adversaries.count) adversaries")
+      }
+    } catch let error as ContentStoreError {
+      guard sources[id] != nil else { return }
+      source = source.recordingFailure()
+      sources[id] = source
+      lastError = error
+      await persistSourceIndex()
+      logger.error("ContentStore: source '\(id)' fetch failed: \(error.localizedDescription)")
+    } catch {
+      guard sources[id] != nil else { return }
+      source = source.recordingFailure()
+      sources[id] = source
+      lastError = ContentStoreError.networkError(sourceID: id, underlying: error)
+      await persistSourceIndex()
+      logger.error("ContentStore: source '\(id)' fetch failed (unexpected): \(error)")
     }
+  }
 
-    // MARK: - Remote fetch
+  // MARK: - .dhpack import
 
-    /// Fetch and install a remote source pack. User-initiated only.
-    ///
-    /// Respects exponential backoff. No-ops if already fetching this source
-    /// or if the source is currently throttled.
-    public func fetchSource(id: String) async {
-        guard var source = sources[id] else { return }
-        guard !source.isLocalImport else {
-            logger.debug("ContentStore: source '\(id)' is a local import — no URL to fetch")
-            return
-        }
-        guard !source.isThrottled() else {
-            logger.info("ContentStore: source '\(id)' throttled, skipping")
-            return
-        }
-        guard !fetchingSourceIDs.contains(id) else { return }
+  /// Import a locally opened `.dhpack` file and persist it across launches.
+  ///
+  /// The pack is decoded, written to the writable content directory, registered
+  /// as a local `ContentSource` (no URL), and loaded into `Compendium`. It will
+  /// reload automatically on every subsequent launch via `loadOnStartup`.
+  ///
+  /// If a source with the same derived ID already exists, it is replaced.
+  ///
+  /// Removal requires explicit user action via ``removeSource(id:)``.
+  /// A UI for this is tracked separately.
+  ///
+  /// The file at `url` is a security-scoped resource; the caller must start
+  /// access before calling this method and stop it after it returns.
+  public func importPack(from url: URL) async {
+    let displayName = url.deletingPathExtension().lastPathComponent
+    let sourceID =
+      displayName
+      .lowercased()
+      .components(separatedBy: CharacterSet.alphanumerics.inverted)
+      .filter { !$0.isEmpty }
+      .joined(separator: "-")
 
-        fetchingSourceIDs.insert(id)
-        defer { fetchingSourceIDs.remove(id) }
+    do {
+      // Read, decode, and write — nonisolated, runs on cooperative thread pool when awaited.
+      let data = try await ContentFetcher.readData(from: url)
+      let pack = try await fetcher.decode(data: data, sourceID: sourceID)
 
-        do {
-            // fetcher.fetch is nonisolated — suspends the main actor and runs on
-            // the cooperative thread pool. Resumes on the main actor with the outcome.
-            let outcome = try await fetcher.fetch(source: source)
+      try await writer.writeSourcePack(
+        adversaries: pack.adversaries,
+        environments: pack.environments,
+        sourceID: sourceID
+      )
 
-            switch outcome {
-            case .notModified:
-                // HTTP 304: server confirmed cached content is current. This is a
-                // success — update lastFetched and clear any prior error state.
-                // The Compendium already has this source's content from loadOnStartup.
-                guard sources[id] != nil else {
-                    logger.info("ContentStore: source '\(id)' removed mid-fetch — discarding notModified result")
-                    return
-                }
-                let existing = source.fingerprint ?? ContentFingerprint(sha256: "", etag: nil)
-                source = source.recordingSuccess(fingerprint: existing)
-                sources[id] = source
-                await persistSourceIndex()
-                logger.info("ContentStore: source '\(id)' not modified — still current")
-
-            case .fetched(let data, let fingerprint):
-                // Decode and write — @concurrent, runs on cooperative thread pool when awaited.
-                let pack = try await fetcher.decode(data: data, sourceID: id)
-
-                try await writer.writeSourcePack(
-                    adversaries: pack.adversaries,
-                    environments: pack.environments,
-                    sourceID: id
-                )
-
-                // Back on main actor: update state and Compendium.
-                // Guard against source being removed while the fetch was in-flight.
-                guard sources[id] != nil else {
-                    logger.info("ContentStore: source '\(id)' removed mid-fetch — discarding fetched result")
-                    return
-                }
-                source = source.recordingSuccess(fingerprint: fingerprint)
-                sources[id] = source
-                compendium.replaceSourceContent(
-                    sourceID: id,
-                    adversaries: pack.adversaries,
-                    environments: pack.environments
-                )
-                await persistSourceIndex()
-                logger.info("ContentStore: source '\(id)' fetched: \(pack.adversaries.count) adversaries")
-            }
-        } catch let error as ContentStoreError {
-            guard sources[id] != nil else { return }
-            source = source.recordingFailure()
-            sources[id] = source
-            lastError = error
-            await persistSourceIndex()
-            logger.error("ContentStore: source '\(id)' fetch failed: \(error.localizedDescription)")
-        } catch {
-            guard sources[id] != nil else { return }
-            source = source.recordingFailure()
-            sources[id] = source
-            lastError = ContentStoreError.networkError(sourceID: id, underlying: error)
-            await persistSourceIndex()
-            logger.error("ContentStore: source '\(id)' fetch failed (unexpected): \(error)")
-        }
+      // Register as a local ContentSource and update Compendium on the main actor.
+      let source = ContentSource(id: sourceID, name: displayName, importedAt: .now)
+      sources[sourceID] = source
+      compendium.replaceSourceContent(
+        sourceID: sourceID,
+        adversaries: pack.adversaries,
+        environments: pack.environments
+      )
+      await persistSourceIndex()
+      logger.info(
+        "ContentStore: imported '\(sourceID)': \(pack.adversaries.count) adversaries, persisted")
+    } catch {
+      lastError =
+        error as? ContentStoreError
+        ?? ContentStoreError.decodingFailed(sourceID: sourceID, underlying: error)
+      logger.error("ContentStore: pack import failed for '\(sourceID)': \(error)")
     }
+  }
 
-    // MARK: - .dhpack import
+  // MARK: - Private helpers
 
-    /// Import a locally opened `.dhpack` file and persist it across launches.
-    ///
-    /// The pack is decoded, written to the writable content directory, registered
-    /// as a local `ContentSource` (no URL), and loaded into `Compendium`. It will
-    /// reload automatically on every subsequent launch via `loadOnStartup`.
-    ///
-    /// If a source with the same derived ID already exists, it is replaced.
-    ///
-    /// Removal requires explicit user action via ``removeSource(id:)``.
-    /// A UI for this is tracked separately.
-    ///
-    /// The file at `url` is a security-scoped resource; the caller must start
-    /// access before calling this method and stop it after it returns.
-    public func importPack(from url: URL) async {
-        let displayName = url.deletingPathExtension().lastPathComponent
-        let sourceID = displayName
-            .lowercased()
-            .components(separatedBy: CharacterSet.alphanumerics.inverted)
-            .filter { !$0.isEmpty }
-            .joined(separator: "-")
-
-        do {
-            // Read, decode, and write — nonisolated, runs on cooperative thread pool when awaited.
-            let data = try await ContentFetcher.readData(from: url)
-            let pack = try await fetcher.decode(data: data, sourceID: sourceID)
-
-            try await writer.writeSourcePack(
-                adversaries: pack.adversaries,
-                environments: pack.environments,
-                sourceID: sourceID
-            )
-
-            // Register as a local ContentSource and update Compendium on the main actor.
-            let source = ContentSource(id: sourceID, name: displayName, importedAt: .now)
-            sources[sourceID] = source
-            compendium.replaceSourceContent(
-                sourceID: sourceID,
-                adversaries: pack.adversaries,
-                environments: pack.environments
-            )
-            await persistSourceIndex()
-            logger.info("ContentStore: imported '\(sourceID)': \(pack.adversaries.count) adversaries, persisted")
-        } catch {
-            lastError = error as? ContentStoreError
-                ?? ContentStoreError.decodingFailed(sourceID: sourceID, underlying: error)
-            logger.error("ContentStore: pack import failed for '\(sourceID)': \(error)")
-        }
+  private func loadSourcePackIntoCompendium(sourceID: String) async {
+    do {
+      let adversaries = try await writer.readAdversaries(sourceID: sourceID)
+      let environments = try await writer.readEnvironments(sourceID: sourceID)
+      guard !adversaries.isEmpty || !environments.isEmpty else { return }
+      compendium.replaceSourceContent(
+        sourceID: sourceID,
+        adversaries: adversaries,
+        environments: environments
+      )
+    } catch {
+      logger.warning("ContentStore: could not load cached pack '\(sourceID)': \(error)")
     }
+  }
 
-    // MARK: - Private helpers
-
-    private func loadSourcePackIntoCompendium(sourceID: String) async {
-        do {
-            let adversaries = try await writer.readAdversaries(sourceID: sourceID)
-            let environments = try await writer.readEnvironments(sourceID: sourceID)
-            guard !adversaries.isEmpty || !environments.isEmpty else { return }
-            compendium.replaceSourceContent(
-                sourceID: sourceID,
-                adversaries: adversaries,
-                environments: environments
-            )
-        } catch {
-            logger.warning("ContentStore: could not load cached pack '\(sourceID)': \(error)")
-        }
+  private func persistSourceIndex() async {
+    let snapshot = Array(sources.values)
+    do {
+      try await writer.writeSourceIndex(snapshot)
+    } catch {
+      lastError = ContentStoreError.writeFailed(sourceID: "source-index", underlying: error)
+      logger.error("ContentStore: failed to persist source index: \(error)")
     }
-
-    private func persistSourceIndex() async {
-        let snapshot = Array(sources.values)
-        do {
-            try await writer.writeSourceIndex(snapshot)
-        } catch {
-            lastError = ContentStoreError.writeFailed(sourceID: "source-index", underlying: error)
-            logger.error("ContentStore: failed to persist source index: \(error)")
-        }
-    }
+  }
 }

--- a/Encounter/Services/ContentWriter.swift
+++ b/Encounter/Services/ContentWriter.swift
@@ -45,196 +45,210 @@ import OSLog
 /// All methods are `nonisolated`. Call from a `@MainActor` context via `await`.
 public struct ContentWriter: Sendable {
 
-    nonisolated private static let logger = Logger(subsystem: "gwillish.Encounter", category: "ContentWriter")
+  nonisolated private static let logger = Logger(
+    subsystem: "gwillish.Encounter", category: "ContentWriter")
 
-    /// Root of the writable content directory
-    /// (e.g. `Application Support/gwillish.Encounter/`).
-    public let contentDirectory: URL
+  /// Root of the writable content directory
+  /// (e.g. `Application Support/gwillish.Encounter/`).
+  public let contentDirectory: URL
 
-    public init(contentDirectory: URL) {
-        self.contentDirectory = contentDirectory
+  public init(contentDirectory: URL) {
+    self.contentDirectory = contentDirectory
+  }
+
+  // MARK: - SRD seeding
+
+  /// Seeds the writable `srd/` directory from bundle resources if the bundle
+  /// has changed since the last seed.
+  ///
+  /// Uses a `srd/bundle_version` stamp file to detect whether seeding is needed.
+  /// The stamp contains the bundle's `CFBundleVersion` string.
+  ///
+  /// - Parameter bundleVersion: Current `CFBundleVersion` from `Bundle.main`.
+  /// - Returns: `true` if seeding was performed.
+  @concurrent
+  nonisolated public func seedSRDIfNeeded(bundleVersion: String) async throws -> Bool {
+    let srdDir = contentDirectory.appending(path: "srd", directoryHint: .isDirectory)
+    let stampURL = srdDir.appending(path: "bundle_version")
+
+    let existingStamp = try? String(contentsOf: stampURL, encoding: .utf8)
+    guard existingStamp != bundleVersion else {
+      return false  // Already seeded this bundle version
     }
 
-    // MARK: - SRD seeding
-
-    /// Seeds the writable `srd/` directory from bundle resources if the bundle
-    /// has changed since the last seed.
-    ///
-    /// Uses a `srd/bundle_version` stamp file to detect whether seeding is needed.
-    /// The stamp contains the bundle's `CFBundleVersion` string.
-    ///
-    /// - Parameter bundleVersion: Current `CFBundleVersion` from `Bundle.main`.
-    /// - Returns: `true` if seeding was performed.
-    @concurrent
-    nonisolated public func seedSRDIfNeeded(bundleVersion: String) async throws -> Bool {
-        let srdDir   = contentDirectory.appending(path: "srd",            directoryHint: .isDirectory)
-        let stampURL = srdDir.appending(path: "bundle_version")
-
-        let existingStamp = try? String(contentsOf: stampURL, encoding: .utf8)
-        guard existingStamp != bundleVersion else {
-            return false  // Already seeded this bundle version
-        }
-
-        guard let advURL = Bundle.main.url(forResource: "adversaries", withExtension: "json"),
-              let envURL = Bundle.main.url(forResource: "environments", withExtension: "json") else {
-            Self.logger.warning("ContentWriter: bundle resources missing — skipping SRD seed")
-            return false
-        }
-
-        try FileManager.default.createDirectory(at: srdDir, withIntermediateDirectories: true)
-        let advData = try Data(contentsOf: advURL)
-        let envData = try Data(contentsOf: envURL)
-
-        try atomicWrite(data: advData, to: srdDir.appending(path: "adversaries.json"),  sourceID: "srd")
-        try atomicWrite(data: envData, to: srdDir.appending(path: "environments.json"), sourceID: "srd")
-        try atomicWrite(data: Data(bundleVersion.utf8), to: stampURL,                   sourceID: "srd")
-
-        Self.logger.info("ContentWriter: SRD seeded from bundle (version \(bundleVersion))")
-        return true
+    guard let advURL = Bundle.main.url(forResource: "adversaries", withExtension: "json"),
+      let envURL = Bundle.main.url(forResource: "environments", withExtension: "json")
+    else {
+      Self.logger.warning("ContentWriter: bundle resources missing — skipping SRD seed")
+      return false
     }
 
-    // MARK: - Source pack read/write
+    try FileManager.default.createDirectory(at: srdDir, withIntermediateDirectories: true)
+    let advData = try Data(contentsOf: advURL)
+    let envData = try Data(contentsOf: envURL)
 
-    /// Write a source pack's adversaries and environments to disk.
-    ///
-    /// Creates `sources/<sourceID>/` if it doesn't exist.
-    @concurrent
-    nonisolated public func writeSourcePack(
-        adversaries: [Adversary],
-        environments: [DaggerheartEnvironment],
-        sourceID: String
-    ) async throws {
-        let dir = sourcesDirectory.appending(path: sourceID, directoryHint: .isDirectory)
-        try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    try atomicWrite(data: advData, to: srdDir.appending(path: "adversaries.json"), sourceID: "srd")
+    try atomicWrite(data: envData, to: srdDir.appending(path: "environments.json"), sourceID: "srd")
+    try atomicWrite(data: Data(bundleVersion.utf8), to: stampURL, sourceID: "srd")
 
-        let encoder = JSONEncoder()
-        encoder.outputFormatting = .prettyPrinted
-        try atomicWrite(data: try encoder.encode(adversaries),  to: dir.appending(path: "adversaries.json"),  sourceID: sourceID)
-        try atomicWrite(data: try encoder.encode(environments), to: dir.appending(path: "environments.json"), sourceID: sourceID)
+    Self.logger.info("ContentWriter: SRD seeded from bundle (version \(bundleVersion))")
+    return true
+  }
 
-        Self.logger.info("ContentWriter: wrote source '\(sourceID)': \(adversaries.count) adversaries, \(environments.count) environments")
+  // MARK: - Source pack read/write
+
+  /// Write a source pack's adversaries and environments to disk.
+  ///
+  /// Creates `sources/<sourceID>/` if it doesn't exist.
+  @concurrent
+  nonisolated public func writeSourcePack(
+    adversaries: [Adversary],
+    environments: [DaggerheartEnvironment],
+    sourceID: String
+  ) async throws {
+    let dir = sourcesDirectory.appending(path: sourceID, directoryHint: .isDirectory)
+    try FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+
+    let encoder = JSONEncoder()
+    encoder.outputFormatting = .prettyPrinted
+    try atomicWrite(
+      data: try encoder.encode(adversaries), to: dir.appending(path: "adversaries.json"),
+      sourceID: sourceID)
+    try atomicWrite(
+      data: try encoder.encode(environments), to: dir.appending(path: "environments.json"),
+      sourceID: sourceID)
+
+    Self.logger.info(
+      "ContentWriter: wrote source '\(sourceID)': \(adversaries.count) adversaries, \(environments.count) environments"
+    )
+  }
+
+  /// Read adversaries for a source pack from disk. Returns `[]` if not yet written.
+  @concurrent
+  nonisolated public func readAdversaries(sourceID: String) async throws -> [Adversary] {
+    let url = sourcesDirectory.appending(path: "\(sourceID)/adversaries.json")
+    guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return [] }
+    do {
+      return try JSONDecoder().decode([Adversary].self, from: Data(contentsOf: url))
+    } catch {
+      throw ContentStoreError.readFailed(sourceID: sourceID, underlying: error)
     }
+  }
 
-    /// Read adversaries for a source pack from disk. Returns `[]` if not yet written.
-    @concurrent
-    nonisolated public func readAdversaries(sourceID: String) async throws -> [Adversary] {
-        let url = sourcesDirectory.appending(path: "\(sourceID)/adversaries.json")
-        guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return [] }
-        do {
-            return try JSONDecoder().decode([Adversary].self, from: Data(contentsOf: url))
-        } catch {
-            throw ContentStoreError.readFailed(sourceID: sourceID, underlying: error)
-        }
+  /// Read environments for a source pack from disk. Returns `[]` if not yet written.
+  @concurrent
+  nonisolated public func readEnvironments(sourceID: String) async throws
+    -> [DaggerheartEnvironment]
+  {
+    let url = sourcesDirectory.appending(path: "\(sourceID)/environments.json")
+    guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return [] }
+    do {
+      return try JSONDecoder().decode([DaggerheartEnvironment].self, from: Data(contentsOf: url))
+    } catch {
+      throw ContentStoreError.readFailed(sourceID: sourceID, underlying: error)
     }
+  }
 
-    /// Read environments for a source pack from disk. Returns `[]` if not yet written.
-    @concurrent
-    nonisolated public func readEnvironments(sourceID: String) async throws -> [DaggerheartEnvironment] {
-        let url = sourcesDirectory.appending(path: "\(sourceID)/environments.json")
-        guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return [] }
-        do {
-            return try JSONDecoder().decode([DaggerheartEnvironment].self, from: Data(contentsOf: url))
-        } catch {
-            throw ContentStoreError.readFailed(sourceID: sourceID, underlying: error)
-        }
+  /// Remove a source pack's directory from disk. No-op if not present.
+  @concurrent
+  nonisolated public func removeSourcePack(sourceID: String) async throws {
+    let dir = sourcesDirectory.appending(path: sourceID, directoryHint: .isDirectory)
+    guard FileManager.default.fileExists(atPath: dir.path(percentEncoded: false)) else { return }
+    try FileManager.default.removeItem(at: dir)
+    Self.logger.info("ContentWriter: removed source pack '\(sourceID)'")
+  }
+
+  // MARK: - Source index (ContentSource metadata)
+
+  /// Persist the source index to `sources/index.json`.
+  @concurrent
+  nonisolated public func writeSourceIndex(_ sources: [ContentSource]) async throws {
+    try FileManager.default.createDirectory(at: sourcesDirectory, withIntermediateDirectories: true)
+    let encoder = JSONEncoder()
+    encoder.dateEncodingStrategy = .iso8601
+    encoder.outputFormatting = .prettyPrinted
+    let data = try encoder.encode(sources)
+    try atomicWrite(
+      data: data, to: sourcesDirectory.appending(path: "index.json"), sourceID: "index")
+  }
+
+  /// Load the source index from `sources/index.json`. Returns `[]` if not present.
+  @concurrent
+  nonisolated public func readSourceIndex() async throws -> [ContentSource] {
+    let url = sourcesDirectory.appending(path: "index.json")
+    guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return [] }
+    let decoder = JSONDecoder()
+    decoder.dateDecodingStrategy = .iso8601
+    do {
+      return try decoder.decode([ContentSource].self, from: Data(contentsOf: url))
+    } catch {
+      throw ContentStoreError.readFailed(sourceID: "index", underlying: error)
     }
+  }
 
-    /// Remove a source pack's directory from disk. No-op if not present.
-    @concurrent
-    nonisolated public func removeSourcePack(sourceID: String) async throws {
-        let dir = sourcesDirectory.appending(path: sourceID, directoryHint: .isDirectory)
-        guard FileManager.default.fileExists(atPath: dir.path(percentEncoded: false)) else { return }
-        try FileManager.default.removeItem(at: dir)
-        Self.logger.info("ContentWriter: removed source pack '\(sourceID)'")
+  // MARK: - Static helpers for relocate
+
+  /// Returns `true` if a subdirectory named `srd` exists under `url`.
+  /// Used by `ContentStore.relocate(to:)` to check whether a directory has content.
+  @concurrent
+  nonisolated public static func checkSubdirectoryExists(_ url: URL) async -> Bool {
+    FileManager.default.fileExists(atPath: url.appending(path: "srd").path(percentEncoded: false))
+  }
+
+  /// Moves `names` subdirectories from `source` to `destination`, skipping any
+  /// that already exist at the destination. Never overwrites.
+  @concurrent
+  nonisolated public static func migrateSubdirectories(
+    from source: URL,
+    to destination: URL,
+    names: [String],
+    logger: Logger
+  ) async {
+    let fm = FileManager.default
+    do {
+      try fm.createDirectory(at: destination, withIntermediateDirectories: true)
+    } catch {
+      logger.error(
+        "ContentWriter.migrateSubdirectories: could not create destination '\(destination.path(percentEncoded: false))': \(error)"
+      )
+      return
     }
-
-    // MARK: - Source index (ContentSource metadata)
-
-    /// Persist the source index to `sources/index.json`.
-    @concurrent
-    nonisolated public func writeSourceIndex(_ sources: [ContentSource]) async throws {
-        try FileManager.default.createDirectory(at: sourcesDirectory, withIntermediateDirectories: true)
-        let encoder = JSONEncoder()
-        encoder.dateEncodingStrategy = .iso8601
-        encoder.outputFormatting = .prettyPrinted
-        let data = try encoder.encode(sources)
-        try atomicWrite(data: data, to: sourcesDirectory.appending(path: "index.json"), sourceID: "index")
+    for name in names {
+      let src = source.appending(path: name)
+      let dst = destination.appending(path: name)
+      guard fm.fileExists(atPath: src.path(percentEncoded: false)) else { continue }
+      guard !fm.fileExists(atPath: dst.path(percentEncoded: false)) else {
+        logger.warning(
+          "ContentWriter.migrateSubdirectories: '\(name)' already exists at destination — skipped")
+        continue
+      }
+      do {
+        try fm.moveItem(at: src, to: dst)
+      } catch {
+        logger.error("ContentWriter.migrateSubdirectories: failed to move '\(name)': \(error)")
+      }
     }
+  }
 
-    /// Load the source index from `sources/index.json`. Returns `[]` if not present.
-    @concurrent
-    nonisolated public func readSourceIndex() async throws -> [ContentSource] {
-        let url = sourcesDirectory.appending(path: "index.json")
-        guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return [] }
-        let decoder = JSONDecoder()
-        decoder.dateDecodingStrategy = .iso8601
-        do {
-            return try decoder.decode([ContentSource].self, from: Data(contentsOf: url))
-        } catch {
-            throw ContentStoreError.readFailed(sourceID: "index", underlying: error)
-        }
+  // MARK: - Private helpers
+
+  nonisolated private var sourcesDirectory: URL {
+    contentDirectory.appending(path: "sources", directoryHint: .isDirectory)
+  }
+
+  nonisolated private func atomicWrite(data: Data, to destination: URL, sourceID: String) throws {
+    let temp = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString)
+    do {
+      try data.write(to: temp, options: .atomic)
+      if FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)) {
+        _ = try FileManager.default.replaceItemAt(destination, withItemAt: temp)
+      } else {
+        try FileManager.default.moveItem(at: temp, to: destination)
+      }
+    } catch {
+      try? FileManager.default.removeItem(at: temp)
+      throw ContentStoreError.writeFailed(sourceID: sourceID, underlying: error)
     }
-
-    // MARK: - Static helpers for relocate
-
-    /// Returns `true` if a subdirectory named `srd` exists under `url`.
-    /// Used by `ContentStore.relocate(to:)` to check whether a directory has content.
-    @concurrent
-    nonisolated public static func checkSubdirectoryExists(_ url: URL) async -> Bool {
-        FileManager.default.fileExists(atPath: url.appending(path: "srd").path(percentEncoded: false))
-    }
-
-    /// Moves `names` subdirectories from `source` to `destination`, skipping any
-    /// that already exist at the destination. Never overwrites.
-    @concurrent
-    nonisolated public static func migrateSubdirectories(
-        from source: URL,
-        to destination: URL,
-        names: [String],
-        logger: Logger
-    ) async {
-        let fm = FileManager.default
-        do {
-            try fm.createDirectory(at: destination, withIntermediateDirectories: true)
-        } catch {
-            logger.error("ContentWriter.migrateSubdirectories: could not create destination '\(destination.path(percentEncoded: false))': \(error)")
-            return
-        }
-        for name in names {
-            let src = source.appending(path: name)
-            let dst = destination.appending(path: name)
-            guard fm.fileExists(atPath: src.path(percentEncoded: false)) else { continue }
-            guard !fm.fileExists(atPath: dst.path(percentEncoded: false)) else {
-                logger.warning("ContentWriter.migrateSubdirectories: '\(name)' already exists at destination — skipped")
-                continue
-            }
-            do {
-                try fm.moveItem(at: src, to: dst)
-            } catch {
-                logger.error("ContentWriter.migrateSubdirectories: failed to move '\(name)': \(error)")
-            }
-        }
-    }
-
-    // MARK: - Private helpers
-
-    nonisolated private var sourcesDirectory: URL {
-        contentDirectory.appending(path: "sources", directoryHint: .isDirectory)
-    }
-
-    nonisolated private func atomicWrite(data: Data, to destination: URL, sourceID: String) throws {
-        let temp = FileManager.default.temporaryDirectory
-            .appending(path: UUID().uuidString)
-        do {
-            try data.write(to: temp, options: .atomic)
-            if FileManager.default.fileExists(atPath: destination.path(percentEncoded: false)) {
-                _ = try FileManager.default.replaceItemAt(destination, withItemAt: temp)
-            } else {
-                try FileManager.default.moveItem(at: temp, to: destination)
-            }
-        } catch {
-            try? FileManager.default.removeItem(at: temp)
-            throw ContentStoreError.writeFailed(sourceID: sourceID, underlying: error)
-        }
-    }
+  }
 }

--- a/Encounter/Views/AddPlayerForm.swift
+++ b/Encounter/Views/AddPlayerForm.swift
@@ -10,102 +10,100 @@
 import SwiftUI
 
 struct AddPlayerForm: View {
-    let onAdd: (PlayerConfig) -> Void
+  let onAdd: (PlayerConfig) -> Void
 
-    @Environment(\.dismiss) private var dismiss
+  @Environment(\.dismiss) private var dismiss
 
-    @State private var name = ""
-    @State private var maxHP = ""
-    @State private var maxStress = ""
-    @State private var evasion = ""
-    @State private var thresholdMajor = ""
-    @State private var thresholdSevere = ""
-    @State private var armorSlots = ""
+  @State private var name = ""
+  @State private var maxHP = ""
+  @State private var maxStress = ""
+  @State private var evasion = ""
+  @State private var thresholdMajor = ""
+  @State private var thresholdSevere = ""
+  @State private var armorSlots = ""
 
-    private var isValid: Bool {
-        !name.trimmingCharacters(in: .whitespaces).isEmpty &&
-        Int(maxHP).map { $0 > 0 } ?? false &&
-        Int(maxStress).map { $0 > 0 } ?? false &&
-        Int(evasion).map { $0 > 0 } ?? false &&
-        Int(thresholdMajor).map { $0 > 0 } ?? false &&
-        Int(thresholdSevere).map { $0 > 0 } ?? false &&
-        Int(armorSlots).map { $0 >= 0 } ?? false
-    }
+  private var isValid: Bool {
+    !name.trimmingCharacters(in: .whitespaces).isEmpty && Int(maxHP).map { $0 > 0 } ?? false
+      && Int(maxStress).map { $0 > 0 } ?? false && Int(evasion).map { $0 > 0 } ?? false
+      && Int(thresholdMajor).map { $0 > 0 } ?? false && Int(thresholdSevere).map { $0 > 0 } ?? false
+      && Int(armorSlots).map { $0 >= 0 } ?? false
+  }
 
-    var body: some View {
-        NavigationStack {
-            Form {
-                Section("Character") {
-                    TextField("Name", text: $name)
-                }
-                Section("Stats") {
-                    TextField("Max HP", text: $maxHP)
-                        #if os(iOS)
-                        .keyboardType(.numberPad)
-                        #endif
-                    TextField("Max Stress", text: $maxStress)
-                        #if os(iOS)
-                        .keyboardType(.numberPad)
-                        #endif
-                    TextField("Evasion", text: $evasion)
-                        #if os(iOS)
-                        .keyboardType(.numberPad)
-                        #endif
-                }
-                Section("Damage Thresholds") {
-                    TextField("Major Threshold", text: $thresholdMajor)
-                        #if os(iOS)
-                        .keyboardType(.numberPad)
-                        #endif
-                    TextField("Severe Threshold", text: $thresholdSevere)
-                        #if os(iOS)
-                        .keyboardType(.numberPad)
-                        #endif
-                }
-                Section("Armor") {
-                    TextField("Armor Slots", text: $armorSlots)
-                        #if os(iOS)
-                        .keyboardType(.numberPad)
-                        #endif
-                }
-            }
-            .navigationTitle("Add Player")
-            #if os(iOS)
-            .navigationBarTitleDisplayMode(.inline)
-            #endif
-            .toolbar {
-                ToolbarItem(placement: .cancellationAction) {
-                    Button("Cancel") { dismiss() }
-                }
-                ToolbarItem(placement: .confirmationAction) {
-                    Button("Add") { commitAdd() }
-                        .disabled(!isValid)
-                }
-            }
+  var body: some View {
+    NavigationStack {
+      Form {
+        Section("Character") {
+          TextField("Name", text: $name)
         }
+        Section("Stats") {
+          TextField("Max HP", text: $maxHP)
+            #if os(iOS)
+              .keyboardType(.numberPad)
+            #endif
+          TextField("Max Stress", text: $maxStress)
+            #if os(iOS)
+              .keyboardType(.numberPad)
+            #endif
+          TextField("Evasion", text: $evasion)
+            #if os(iOS)
+              .keyboardType(.numberPad)
+            #endif
+        }
+        Section("Damage Thresholds") {
+          TextField("Major Threshold", text: $thresholdMajor)
+            #if os(iOS)
+              .keyboardType(.numberPad)
+            #endif
+          TextField("Severe Threshold", text: $thresholdSevere)
+            #if os(iOS)
+              .keyboardType(.numberPad)
+            #endif
+        }
+        Section("Armor") {
+          TextField("Armor Slots", text: $armorSlots)
+            #if os(iOS)
+              .keyboardType(.numberPad)
+            #endif
+        }
+      }
+      .navigationTitle("Add Player")
+      #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Cancel") { dismiss() }
+        }
+        ToolbarItem(placement: .confirmationAction) {
+          Button("Add") { commitAdd() }
+            .disabled(!isValid)
+        }
+      }
     }
+  }
 
-    private func commitAdd() {
-        guard isValid,
-              let hp    = Int(maxHP),
-              let str   = Int(maxStress),
-              let ev    = Int(evasion),
-              let tmaj  = Int(thresholdMajor),
-              let tsev  = Int(thresholdSevere),
-              let armor = Int(armorSlots)
-        else { return }
-        onAdd(PlayerConfig(
-            name: name.trimmingCharacters(in: .whitespaces),
-            maxHP: hp, maxStress: str, evasion: ev,
-            thresholdMajor: tmaj, thresholdSevere: tsev,
-            armorSlots: armor
-        ))
-        dismiss()
-    }
+  private func commitAdd() {
+    guard isValid,
+      let hp = Int(maxHP),
+      let str = Int(maxStress),
+      let ev = Int(evasion),
+      let tmaj = Int(thresholdMajor),
+      let tsev = Int(thresholdSevere),
+      let armor = Int(armorSlots)
+    else { return }
+    onAdd(
+      PlayerConfig(
+        name: name.trimmingCharacters(in: .whitespaces),
+        maxHP: hp, maxStress: str, evasion: ev,
+        thresholdMajor: tmaj, thresholdSevere: tsev,
+        armorSlots: armor
+      ))
+    dismiss()
+  }
 }
 
 #Preview {
-    AddPlayerForm { config in
-        print("Added: \(config.name)")
-    }
+  AddPlayerForm { config in
+    print("Added: \(config.name)")
+  }
 }

--- a/Encounter/Views/AdversaryConditionsSection.swift
+++ b/Encounter/Views/AdversaryConditionsSection.swift
@@ -12,29 +12,29 @@ import SwiftUI
 /// Active conditions are highlighted in orange. Tapping a condition applies
 /// or removes it from the slot via the session.
 struct AdversaryConditionsSection: View {
-    let slot: AdversarySlot
-    let session: EncounterSession
+  let slot: AdversarySlot
+  let session: EncounterSession
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 6) {
-            Text("Conditions")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            HStack(spacing: 6) {
-                ForEach(Condition.standardConditions, id: \.self) { condition in
-                    let active = slot.conditions.contains(condition)
-                    Button(condition.displayName) {
-                        if active {
-                            session.removeCondition(condition, from: slot.id)
-                        } else {
-                            session.applyCondition(condition, to: slot.id)
-                        }
-                    }
-                    .font(.caption)
-                    .buttonStyle(.bordered)
-                    .tint(active ? .orange : nil)
-                }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Conditions")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      HStack(spacing: 6) {
+        ForEach(Condition.standardConditions, id: \.self) { condition in
+          let active = slot.conditions.contains(condition)
+          Button(condition.displayName) {
+            if active {
+              session.removeCondition(condition, from: slot.id)
+            } else {
+              session.applyCondition(condition, to: slot.id)
             }
+          }
+          .font(.caption)
+          .buttonStyle(.bordered)
+          .tint(active ? .orange : nil)
         }
+      }
     }
+  }
 }

--- a/Encounter/Views/AdversaryDetailView.swift
+++ b/Encounter/Views/AdversaryDetailView.swift
@@ -10,120 +10,125 @@
 import SwiftUI
 
 struct AdversaryDetailView: View {
-    let adversary: Adversary
-    let onSelect: ((Adversary) -> Void)?
+  let adversary: Adversary
+  let onSelect: ((Adversary) -> Void)?
 
-    @Environment(\.dismiss) private var dismiss
+  @Environment(\.dismiss) private var dismiss
 
-    init(adversary: Adversary, onSelect: ((Adversary) -> Void)? = nil) {
-        self.adversary = adversary
-        self.onSelect = onSelect
-    }
+  init(adversary: Adversary, onSelect: ((Adversary) -> Void)? = nil) {
+    self.adversary = adversary
+    self.onSelect = onSelect
+  }
 
-    var body: some View {
-        List {
-            // Identity
-            Section {
-                VStack(alignment: .leading, spacing: 6) {
-                    HStack(spacing: 6) {
-                        TypeBadgeView(type: adversary.type)
-                        Text("Tier \(adversary.tier)")
-                            .font(.caption)
-                            .foregroundStyle(.secondary)
-                        if adversary.source != "srd" {
-                            Text(adversary.source)
-                                .font(.caption2)
-                                .foregroundStyle(.white)
-                                .padding(.horizontal, 5)
-                                .padding(.vertical, 2)
-                                .background(.blue)
-                                .clipShape(.capsule)
-                        }
-                    }
-                    Text(adversary.description)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.vertical, 4)
+  var body: some View {
+    List {
+      // Identity
+      Section {
+        VStack(alignment: .leading, spacing: 6) {
+          HStack(spacing: 6) {
+            TypeBadgeView(type: adversary.type)
+            Text("Tier \(adversary.tier)")
+              .font(.caption)
+              .foregroundStyle(.secondary)
+            if adversary.source != "srd" {
+              Text(adversary.source)
+                .font(.caption2)
+                .foregroundStyle(.white)
+                .padding(.horizontal, 5)
+                .padding(.vertical, 2)
+                .background(.blue)
+                .clipShape(.capsule)
             }
-
-            // Combat Stats
-            Section("Combat Stats") {
-                LabeledContent("Difficulty", value: adversary.difficulty, format: .number)
-                LabeledContent("Hit Points", value: adversary.hp, format: .number)
-                LabeledContent("Stress", value: adversary.stress, format: .number)
-                LabeledContent("Major Threshold", value: adversary.thresholdMajor, format: .number)
-                LabeledContent("Severe Threshold", value: adversary.thresholdSevere, format: .number)
-            }
-
-            // Standard Attack
-            Section("Standard Attack") {
-                LabeledContent("Attack") {
-                    Text("\(adversary.attackName) \(adversary.attackModifier)")
-                }
-                LabeledContent("Range", value: adversary.attackRange.rawValue)
-                LabeledContent("Damage", value: adversary.damage)
-            }
-
-            // Experience
-            if let experience = adversary.experience {
-                Section("Experience") {
-                    Text(experience)
-                        .font(.subheadline)
-                }
-            }
-
-            // Features grouped: passives → actions → reactions
-            FeatureSectionsView(features: adversary.features)
-
-            // Motives & Tactics
-            if let motives = adversary.motivesAndTactics {
-                Section("Motives & Tactics") {
-                    Text(motives)
-                        .font(.subheadline)
-                }
-            }
+          }
+          Text(adversary.description)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
         }
-        .navigationTitle(adversary.name)
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.large)
-        #endif
-        .toolbar {
-            if let onSelect {
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Add to Encounter") {
-                        onSelect(adversary)
-                        dismiss()
-                    }
-                }
-            }
+        .padding(.vertical, 4)
+      }
+
+      // Combat Stats
+      Section("Combat Stats") {
+        LabeledContent("Difficulty", value: adversary.difficulty, format: .number)
+        LabeledContent("Hit Points", value: adversary.hp, format: .number)
+        LabeledContent("Stress", value: adversary.stress, format: .number)
+        LabeledContent("Major Threshold", value: adversary.thresholdMajor, format: .number)
+        LabeledContent("Severe Threshold", value: adversary.thresholdSevere, format: .number)
+      }
+
+      // Standard Attack
+      Section("Standard Attack") {
+        LabeledContent("Attack") {
+          Text("\(adversary.attackName) \(adversary.attackModifier)")
         }
+        LabeledContent("Range", value: adversary.attackRange.rawValue)
+        LabeledContent("Damage", value: adversary.damage)
+      }
+
+      // Experience
+      if let experience = adversary.experience {
+        Section("Experience") {
+          Text(experience)
+            .font(.subheadline)
+        }
+      }
+
+      // Features grouped: passives → actions → reactions
+      FeatureSectionsView(features: adversary.features)
+
+      // Motives & Tactics
+      if let motives = adversary.motivesAndTactics {
+        Section("Motives & Tactics") {
+          Text(motives)
+            .font(.subheadline)
+        }
+      }
     }
+    .navigationTitle(adversary.name)
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.large)
+    #endif
+    .toolbar {
+      if let onSelect {
+        ToolbarItem(placement: .primaryAction) {
+          Button("Add to Encounter") {
+            onSelect(adversary)
+            dismiss()
+          }
+        }
+      }
+    }
+  }
 
 }
 
 #Preview {
-    NavigationStack {
-        AdversaryDetailView(adversary: Adversary(
-            id: "goblin",
-            name: "Goblin",
-            tier: 1,
-            type: .minion,
-            description: "Small, cunning, and cowardly alone but dangerous in numbers.",
-            motivesAndTactics: "Goblins mob weak targets and flee from strong ones.",
-            difficulty: 10,
-            thresholdMajor: 5,
-            thresholdSevere: 10,
-            hp: 3,
-            stress: 2,
-            attackModifier: "+2",
-            attackName: "Rusty Blade",
-            attackRange: .veryClose,
-            damage: "1d4 phy",
-            features: [
-                AdversaryFeature(name: "Pack Tactics", text: "Deal +1 damage for each ally adjacent to the target.", featType: .passive),
-                AdversaryFeature(name: "Sneak Attack", text: "Once per round, deal +1d6 damage when hidden.", featType: .action),
-            ]
-        ))
-    }
+  NavigationStack {
+    AdversaryDetailView(
+      adversary: Adversary(
+        id: "goblin",
+        name: "Goblin",
+        tier: 1,
+        type: .minion,
+        description: "Small, cunning, and cowardly alone but dangerous in numbers.",
+        motivesAndTactics: "Goblins mob weak targets and flee from strong ones.",
+        difficulty: 10,
+        thresholdMajor: 5,
+        thresholdSevere: 10,
+        hp: 3,
+        stress: 2,
+        attackModifier: "+2",
+        attackName: "Rusty Blade",
+        attackRange: .veryClose,
+        damage: "1d4 phy",
+        features: [
+          AdversaryFeature(
+            name: "Pack Tactics", text: "Deal +1 damage for each ally adjacent to the target.",
+            featType: .passive),
+          AdversaryFeature(
+            name: "Sneak Attack", text: "Once per round, deal +1d6 damage when hidden.",
+            featType: .action),
+        ]
+      ))
+  }
 }

--- a/Encounter/Views/AdversaryFeatureRow.swift
+++ b/Encounter/Views/AdversaryFeatureRow.swift
@@ -9,35 +9,37 @@
 import SwiftUI
 
 struct AdversaryFeatureRow: View {
-    let feature: AdversaryFeature
+  let feature: AdversaryFeature
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            HStack(spacing: 6) {
-                Text(feature.name)
-                    .font(.subheadline)
-                    .fontWeight(.semibold)
-                Text(feature.featType.rawValue.capitalized)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-                    .padding(.horizontal, 5)
-                    .padding(.vertical, 2)
-                    .background(.secondary.opacity(0.15))
-                    .clipShape(.capsule)
-            }
-            Text(feature.text)
-                .font(.footnote)
-                .foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 2)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      HStack(spacing: 6) {
+        Text(feature.name)
+          .font(.subheadline)
+          .fontWeight(.semibold)
+        Text(feature.featType.rawValue.capitalized)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 5)
+          .padding(.vertical, 2)
+          .background(.secondary.opacity(0.15))
+          .clipShape(.capsule)
+      }
+      Text(feature.text)
+        .font(.footnote)
+        .foregroundStyle(.secondary)
     }
+    .padding(.vertical, 2)
+  }
 }
 
 #Preview {
-    AdversaryFeatureRow(feature: AdversaryFeature(
-        name: "Pack Tactics",
-        text: "Deal +1 damage for each ally adjacent to the target.",
-        featType: .passive
-    ))
-    .padding()
+  AdversaryFeatureRow(
+    feature: AdversaryFeature(
+      name: "Pack Tactics",
+      text: "Deal +1 damage for each ally adjacent to the target.",
+      featType: .passive
+    )
+  )
+  .padding()
 }

--- a/Encounter/Views/AdversaryListView.swift
+++ b/Encounter/Views/AdversaryListView.swift
@@ -9,44 +9,46 @@
 import SwiftUI
 
 struct AdversaryListView: View {
-    let adversaries: [Adversary]
+  let adversaries: [Adversary]
 
-    var body: some View {
-        if adversaries.isEmpty {
-            ContentUnavailableView(
-                "No Adversaries",
-                systemImage: "magnifyingglass",
-                description: Text("Try a different search or filter.")
-            )
-        } else {
-            List(adversaries) { adversary in
-                NavigationLink(value: adversary) {
-                    AdversaryRow(adversary: adversary)
-                }
-            }
+  var body: some View {
+    if adversaries.isEmpty {
+      ContentUnavailableView(
+        "No Adversaries",
+        systemImage: "magnifyingglass",
+        description: Text("Try a different search or filter.")
+      )
+    } else {
+      List(adversaries) { adversary in
+        NavigationLink(value: adversary) {
+          AdversaryRow(adversary: adversary)
         }
+      }
     }
+  }
 }
 
 #Preview("With results") {
-    NavigationStack {
-        AdversaryListView(adversaries: [
-            Adversary(id: "goblin", name: "Goblin", tier: 1, type: .minion,
-                      description: "Small and cunning.", difficulty: 10,
-                      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-                      attackModifier: "+2", attackName: "Rusty Blade",
-                      attackRange: .veryClose, damage: "1d4 phy"),
-            Adversary(id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
-                      description: "Massive and relentless.", difficulty: 14,
-                      thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
-                      attackModifier: "+5", attackName: "Great Axe",
-                      attackRange: .veryClose, damage: "2d10+4 phy"),
-        ])
-    }
+  NavigationStack {
+    AdversaryListView(adversaries: [
+      Adversary(
+        id: "goblin", name: "Goblin", tier: 1, type: .minion,
+        description: "Small and cunning.", difficulty: 10,
+        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+        attackModifier: "+2", attackName: "Rusty Blade",
+        attackRange: .veryClose, damage: "1d4 phy"),
+      Adversary(
+        id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
+        description: "Massive and relentless.", difficulty: 14,
+        thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+        attackModifier: "+5", attackName: "Great Axe",
+        attackRange: .veryClose, damage: "2d10+4 phy"),
+    ])
+  }
 }
 
 #Preview("Empty") {
-    NavigationStack {
-        AdversaryListView(adversaries: [])
-    }
+  NavigationStack {
+    AdversaryListView(adversaries: [])
+  }
 }

--- a/Encounter/Views/AdversaryRosterRow.swift
+++ b/Encounter/Views/AdversaryRosterRow.swift
@@ -9,42 +9,43 @@
 import SwiftUI
 
 struct AdversaryRosterRow: View {
-    let adversaryID: String
-    let compendium: Compendium
+  let adversaryID: String
+  let compendium: Compendium
 
-    private var adversary: Adversary? {
-        compendium.adversary(id: adversaryID)
-    }
+  private var adversary: Adversary? {
+    compendium.adversary(id: adversaryID)
+  }
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(adversary?.name ?? "Unknown Adversary")
-                .font(.body)
-            if let adversary {
-                Text("\(adversary.type.rawValue) · Tier \(adversary.tier)")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            } else {
-                Text("ID: \(adversaryID)")
-                    .font(.caption2)
-                    .foregroundStyle(.tertiary)
-            }
-        }
-        .padding(.vertical, 2)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(adversary?.name ?? "Unknown Adversary")
+        .font(.body)
+      if let adversary {
+        Text("\(adversary.type.rawValue) · Tier \(adversary.tier)")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      } else {
+        Text("ID: \(adversaryID)")
+          .font(.caption2)
+          .foregroundStyle(.tertiary)
+      }
     }
+    .padding(.vertical, 2)
+  }
 }
 
 #Preview {
-    let compendium = Compendium()
-    compendium.addAdversary(Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
-        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-        attackModifier: "+2", attackName: "Rusty Blade",
-        attackRange: .veryClose, damage: "1d4 phy"
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, type: .minion,
+      description: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
     ))
-    return List {
-        AdversaryRosterRow(adversaryID: "goblin", compendium: compendium)
-        AdversaryRosterRow(adversaryID: "missing-id", compendium: compendium)
-    }
+  return List {
+    AdversaryRosterRow(adversaryID: "goblin", compendium: compendium)
+    AdversaryRosterRow(adversaryID: "missing-id", compendium: compendium)
+  }
 }

--- a/Encounter/Views/AdversaryRosterSection.swift
+++ b/Encounter/Views/AdversaryRosterSection.swift
@@ -9,51 +9,52 @@
 import SwiftUI
 
 struct AdversaryRosterSection: View {
-    let adversaryIDs: [String]
-    let compendium: Compendium
-    let onBrowse: () -> Void
-    let onRemove: (IndexSet) -> Void
+  let adversaryIDs: [String]
+  let compendium: Compendium
+  let onBrowse: () -> Void
+  let onRemove: (IndexSet) -> Void
 
-    var body: some View {
-        Section {
-            if adversaryIDs.isEmpty {
-                Text("No adversaries added yet.")
-                    .foregroundStyle(.secondary)
-                    .italic()
-            } else {
-                ForEach(adversaryIDs.indices, id: \.self) { index in
-                    AdversaryRosterRow(adversaryID: adversaryIDs[index], compendium: compendium)
-                }
-                .onDelete(perform: onRemove)
-            }
-        } header: {
-            HStack {
-                Text("Adversaries")
-                Spacer()
-                Button("Add", systemImage: "plus", action: onBrowse)
-                    .buttonStyle(.borderless)
-                    .font(.caption)
-                    .labelStyle(.iconOnly)
-            }
+  var body: some View {
+    Section {
+      if adversaryIDs.isEmpty {
+        Text("No adversaries added yet.")
+          .foregroundStyle(.secondary)
+          .italic()
+      } else {
+        ForEach(adversaryIDs.indices, id: \.self) { index in
+          AdversaryRosterRow(adversaryID: adversaryIDs[index], compendium: compendium)
         }
+        .onDelete(perform: onRemove)
+      }
+    } header: {
+      HStack {
+        Text("Adversaries")
+        Spacer()
+        Button("Add", systemImage: "plus", action: onBrowse)
+          .buttonStyle(.borderless)
+          .font(.caption)
+          .labelStyle(.iconOnly)
+      }
     }
+  }
 }
 
 #Preview {
-    let compendium = Compendium()
-    compendium.addAdversary(Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
-        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-        attackModifier: "+2", attackName: "Rusty Blade",
-        attackRange: .veryClose, damage: "1d4 phy"
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, type: .minion,
+      description: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
     ))
-    return Form {
-        AdversaryRosterSection(
-            adversaryIDs: ["goblin", "goblin"],
-            compendium: compendium,
-            onBrowse: {},
-            onRemove: { _ in }
-        )
-    }
+  return Form {
+    AdversaryRosterSection(
+      adversaryIDs: ["goblin", "goblin"],
+      compendium: compendium,
+      onBrowse: {},
+      onRemove: { _ in }
+    )
+  }
 }

--- a/Encounter/Views/AdversaryRow.swift
+++ b/Encounter/Views/AdversaryRow.swift
@@ -8,47 +8,49 @@
 import SwiftUI
 
 struct AdversaryRow: View {
-    let adversary: Adversary
+  let adversary: Adversary
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
-                Text(adversary.name)
-                    .font(.body)
-                if adversary.isHomebrew {
-                    Text(adversary.source)
-                        .font(.caption2)
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(.blue)
-                        .clipShape(.capsule)
-                }
-            }
-            Text("\(adversary.type.rawValue) · Tier \(adversary.tier) · DC \(adversary.difficulty)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      HStack {
+        Text(adversary.name)
+          .font(.body)
+        if adversary.isHomebrew {
+          Text(adversary.source)
+            .font(.caption2)
+            .foregroundStyle(.white)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(.blue)
+            .clipShape(.capsule)
         }
-        .padding(.vertical, 2)
+      }
+      Text("\(adversary.type.rawValue) · Tier \(adversary.tier) · DC \(adversary.difficulty)")
+        .font(.caption)
+        .foregroundStyle(.secondary)
     }
+    .padding(.vertical, 2)
+  }
 }
 
 #Preview {
-    AdversaryRow(adversary: Adversary(
-        id: "goblin",
-        name: "Goblin",
-        tier: 1,
-        type: .minion,
-        description: "Small and cunning.",
-        difficulty: 10,
-        thresholdMajor: 5,
-        thresholdSevere: 10,
-        hp: 3,
-        stress: 2,
-        attackModifier: "+2",
-        attackName: "Rusty Blade",
-        attackRange: .veryClose,
-        damage: "1d4 phy"
-    ))
-    .padding()
+  AdversaryRow(
+    adversary: Adversary(
+      id: "goblin",
+      name: "Goblin",
+      tier: 1,
+      type: .minion,
+      description: "Small and cunning.",
+      difficulty: 10,
+      thresholdMajor: 5,
+      thresholdSevere: 10,
+      hp: 3,
+      stress: 2,
+      attackModifier: "+2",
+      attackName: "Rusty Blade",
+      attackRange: .veryClose,
+      damage: "1d4 phy"
+    )
+  )
+  .padding()
 }

--- a/Encounter/Views/AdversaryRunnerCard.swift
+++ b/Encounter/Views/AdversaryRunnerCard.swift
@@ -15,99 +15,108 @@
 import SwiftUI
 
 struct AdversaryRunnerCard: View {
-    let slot: AdversarySlot
-    let session: EncounterSession
-    let compendium: Compendium
-    let onCollapse: () -> Void
+  let slot: AdversarySlot
+  let session: EncounterSession
+  let compendium: Compendium
+  let onCollapse: () -> Void
 
-    private var displayName: String {
-        let adversary = compendium.adversary(id: slot.adversaryID)
-        return slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
-    }
+  private var displayName: String {
+    let adversary = compendium.adversary(id: slot.adversaryID)
+    return slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
+  }
 
-    var body: some View {
-        let adversary = compendium.adversary(id: slot.adversaryID)
-        let major = adversary.map { "\($0.thresholdMajor)" } ?? "—"
-        let severe = adversary.map { "\($0.thresholdSevere)" } ?? "—"
+  var body: some View {
+    let adversary = compendium.adversary(id: slot.adversaryID)
+    let major = adversary.map { "\($0.thresholdMajor)" } ?? "—"
+    let severe = adversary.map { "\($0.thresholdSevere)" } ?? "—"
 
-        VStack(alignment: .leading, spacing: 12) {
+    VStack(alignment: .leading, spacing: 12) {
 
-            // Header
-            HStack {
-                Text(displayName)
-                    .font(.headline)
-                Spacer()
-                Button("Collapse", systemImage: "chevron.up", action: onCollapse)
-                .labelStyle(.iconOnly)
-                .buttonStyle(.borderless)
-            }
+      // Header
+      HStack {
+        Text(displayName)
+          .font(.headline)
+        Spacer()
+        Button("Collapse", systemImage: "chevron.up", action: onCollapse)
+          .labelStyle(.iconOnly)
+          .buttonStyle(.borderless)
+      }
 
-            // HP pip track
-            HStack(spacing: 4) {
-                Text("HP")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-                PipTrack(current: slot.currentHP, maximum: slot.maxHP)
-                if slot.isDefeated {
-                    Text("Defeated")
-                        .font(.caption)
-                        .foregroundStyle(.red)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.red.opacity(0.12))
-                        .clipShape(.capsule)
-                }
-            }
-
-            // Damage threshold buttons
-            HStack(spacing: 8) {
-                ThresholdButton(label: "Minor",  subtitle: "< \(major)",  marks: 1, isDefeated: slot.isDefeated, session: session, slotID: slot.id)
-                ThresholdButton(label: "Major",  subtitle: "≥ \(major)",  marks: 2, isDefeated: slot.isDefeated, session: session, slotID: slot.id)
-                ThresholdButton(label: "Severe", subtitle: "≥ \(severe)", marks: 3, isDefeated: slot.isDefeated, session: session, slotID: slot.id)
-            }
-
-            // Stress
-            Button("+1 Stress (\(slot.currentStress)/\(slot.maxStress))") {
-                session.applyStress(1, to: slot.id)
-            }
-            .buttonStyle(.bordered)
-            .disabled(slot.currentStress >= slot.maxStress || slot.isDefeated)
-
-            // Condition toggles
-            AdversaryConditionsSection(slot: slot, session: session)
-
-            // Stat reference
-            if let adversary {
-                AdversaryStatReference(adversary: adversary)
-            }
+      // HP pip track
+      HStack(spacing: 4) {
+        Text("HP")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        PipTrack(current: slot.currentHP, maximum: slot.maxHP)
+        if slot.isDefeated {
+          Text("Defeated")
+            .font(.caption)
+            .foregroundStyle(.red)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.red.opacity(0.12))
+            .clipShape(.capsule)
         }
-        .padding(.vertical, 8)
+      }
+
+      // Damage threshold buttons
+      HStack(spacing: 8) {
+        ThresholdButton(
+          label: "Minor", subtitle: "< \(major)", marks: 1, isDefeated: slot.isDefeated,
+          session: session, slotID: slot.id)
+        ThresholdButton(
+          label: "Major", subtitle: "≥ \(major)", marks: 2, isDefeated: slot.isDefeated,
+          session: session, slotID: slot.id)
+        ThresholdButton(
+          label: "Severe", subtitle: "≥ \(severe)", marks: 3, isDefeated: slot.isDefeated,
+          session: session, slotID: slot.id)
+      }
+
+      // Stress
+      Button("+1 Stress (\(slot.currentStress)/\(slot.maxStress))") {
+        session.applyStress(1, to: slot.id)
+      }
+      .buttonStyle(.bordered)
+      .disabled(slot.currentStress >= slot.maxStress || slot.isDefeated)
+
+      // Condition toggles
+      AdversaryConditionsSection(slot: slot, session: session)
+
+      // Stat reference
+      if let adversary {
+        AdversaryStatReference(adversary: adversary)
+      }
     }
+    .padding(.vertical, 8)
+  }
 }
 
 #Preview {
-    let compendium = Compendium()
-    compendium.addAdversary(Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
-        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-        attackModifier: "+2", attackName: "Rusty Blade",
-        attackRange: .veryClose, damage: "1d4 phy",
-        features: [AdversaryFeature(name: "Sneak", text: "Can hide as a free action.", featType: .passive)]
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, type: .minion,
+      description: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy",
+      features: [
+        AdversaryFeature(name: "Sneak", text: "Can hide as a free action.", featType: .passive)
+      ]
     ))
-    let session = EncounterSession(name: "Test")
-    if let goblin = compendium.adversary(id: "goblin") {
-        session.add(adversary: goblin)
+  let session = EncounterSession(name: "Test")
+  if let goblin = compendium.adversary(id: "goblin") {
+    session.add(adversary: goblin)
+  }
+  return List {
+    if let slot = session.adversarySlots.first {
+      AdversaryRunnerCard(
+        slot: slot,
+        session: session,
+        compendium: compendium,
+        onCollapse: {}
+      )
     }
-    return List {
-        if let slot = session.adversarySlots.first {
-            AdversaryRunnerCard(
-                slot: slot,
-                session: session,
-                compendium: compendium,
-                onCollapse: {}
-            )
-        }
-    }
-    .environment(compendium)
+  }
+  .environment(compendium)
 }

--- a/Encounter/Views/AdversaryRunnerRow.swift
+++ b/Encounter/Views/AdversaryRunnerRow.swift
@@ -10,70 +10,72 @@
 import SwiftUI
 
 struct AdversaryRunnerRow: View {
-    let slot: AdversarySlot
-    let compendium: Compendium
+  let slot: AdversarySlot
+  let compendium: Compendium
 
-    private var displayName: String {
-        let adversary = compendium.adversary(id: slot.adversaryID)
-        return slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
-    }
+  private var displayName: String {
+    let adversary = compendium.adversary(id: slot.adversaryID)
+    return slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
+  }
 
-    var body: some View {
-        let adversary = compendium.adversary(id: slot.adversaryID)
+  var body: some View {
+    let adversary = compendium.adversary(id: slot.adversaryID)
 
-        VStack(alignment: .leading, spacing: 6) {
-            HStack(spacing: 6) {
-                Text(displayName)
-                    .font(.body)
-                    .fontWeight(.medium)
-                Spacer()
-                if let adversary {
-                    Text("\(adversary.type.rawValue) · T\(adversary.tier)")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                        .padding(.horizontal, 6)
-                        .padding(.vertical, 2)
-                        .background(.secondary.opacity(0.15))
-                        .clipShape(.capsule)
-                }
-            }
-            HStack(spacing: 16) {
-                HStack(spacing: 4) {
-                    Text("HP")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    PipTrack(current: slot.currentHP, maximum: slot.maxHP)
-                }
-                HStack(spacing: 4) {
-                    Text("St")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    PipTrack(current: slot.currentStress, maximum: slot.maxStress)
-                }
-            }
+    VStack(alignment: .leading, spacing: 6) {
+      HStack(spacing: 6) {
+        Text(displayName)
+          .font(.body)
+          .fontWeight(.medium)
+        Spacer()
+        if let adversary {
+          Text("\(adversary.type.rawValue) · T\(adversary.tier)")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+            .padding(.horizontal, 6)
+            .padding(.vertical, 2)
+            .background(.secondary.opacity(0.15))
+            .clipShape(.capsule)
         }
-        .padding(.vertical, 4)
+      }
+      HStack(spacing: 16) {
+        HStack(spacing: 4) {
+          Text("HP")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+          PipTrack(current: slot.currentHP, maximum: slot.maxHP)
+        }
+        HStack(spacing: 4) {
+          Text("St")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+          PipTrack(current: slot.currentStress, maximum: slot.maxStress)
+        }
+      }
     }
+    .padding(.vertical, 4)
+  }
 }
 
 #Preview {
-    let compendium = Compendium()
-    compendium.addAdversary(Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
-        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-        attackModifier: "+2", attackName: "Rusty Blade",
-        attackRange: .veryClose, damage: "1d4 phy"
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, type: .minion,
+      description: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
     ))
-    return List {
-        AdversaryRunnerRow(
-            slot: AdversarySlot(adversaryID: "goblin", maxHP: 3, maxStress: 2, currentHP: 2),
-            compendium: compendium
-        )
-        AdversaryRunnerRow(
-            slot: AdversarySlot(adversaryID: "goblin", maxHP: 3, maxStress: 2, currentHP: 0, isDefeated: true),
-            compendium: compendium
-        )
-        .opacity(0.4)
-    }
+  return List {
+    AdversaryRunnerRow(
+      slot: AdversarySlot(adversaryID: "goblin", maxHP: 3, maxStress: 2, currentHP: 2),
+      compendium: compendium
+    )
+    AdversaryRunnerRow(
+      slot: AdversarySlot(
+        adversaryID: "goblin", maxHP: 3, maxStress: 2, currentHP: 0, isDefeated: true),
+      compendium: compendium
+    )
+    .opacity(0.4)
+  }
 }

--- a/Encounter/Views/AdversaryRunnerSection.swift
+++ b/Encounter/Views/AdversaryRunnerSection.swift
@@ -10,32 +10,32 @@
 import SwiftUI
 
 struct AdversaryRunnerSection: View {
-    let slots: [AdversarySlot]
-    @Binding var expandedSlotID: UUID?
-    let session: EncounterSession
-    let compendium: Compendium
+  let slots: [AdversarySlot]
+  @Binding var expandedSlotID: UUID?
+  let session: EncounterSession
+  let compendium: Compendium
 
-    var body: some View {
-        ForEach(slots) { slot in
-            if expandedSlotID == slot.id {
-                AdversaryRunnerCard(
-                    slot: slot,
-                    session: session,
-                    compendium: compendium,
-                    onCollapse: { expandedSlotID = nil }
-                )
-                .opacity(slot.isDefeated ? 0.4 : 1.0)
-                .listRowSeparator(.hidden)
-            } else {
-                Button {
-                    expandedSlotID = slot.id
-                } label: {
-                    AdversaryRunnerRow(slot: slot, compendium: compendium)
-                        .opacity(slot.isDefeated ? 0.4 : 1.0)
-                        .contentShape(Rectangle())
-                }
-                .buttonStyle(.plain)
-            }
+  var body: some View {
+    ForEach(slots) { slot in
+      if expandedSlotID == slot.id {
+        AdversaryRunnerCard(
+          slot: slot,
+          session: session,
+          compendium: compendium,
+          onCollapse: { expandedSlotID = nil }
+        )
+        .opacity(slot.isDefeated ? 0.4 : 1.0)
+        .listRowSeparator(.hidden)
+      } else {
+        Button {
+          expandedSlotID = slot.id
+        } label: {
+          AdversaryRunnerRow(slot: slot, compendium: compendium)
+            .opacity(slot.isDefeated ? 0.4 : 1.0)
+            .contentShape(Rectangle())
         }
+        .buttonStyle(.plain)
+      }
     }
+  }
 }

--- a/Encounter/Views/AdversaryStatReference.swift
+++ b/Encounter/Views/AdversaryStatReference.swift
@@ -13,27 +13,28 @@ import SwiftUI
 /// Displays difficulty, damage thresholds, attack info, damage expression,
 /// and the full feature list. Preceded by a visual divider.
 struct AdversaryStatReference: View {
-    let adversary: Adversary
+  let adversary: Adversary
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 4) {
-            Divider()
-            LabeledContent("Difficulty", value: "\(adversary.difficulty)")
-                .font(.caption)
-            LabeledContent("Thresholds") {
-                Text("\(adversary.thresholdMajor) / \(adversary.thresholdSevere)")
-            }
-            .font(.caption)
-            LabeledContent("Attack") {
-                Text("\(adversary.attackName) \(adversary.attackModifier) · \(adversary.attackRange.rawValue)")
-            }
-            .font(.caption)
-            LabeledContent("Damage", value: adversary.damage)
-                .font(.caption)
-            if !adversary.features.isEmpty {
-                Divider()
-                ForEach(adversary.features) { AdversaryFeatureRow(feature: $0) }
-            }
-        }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 4) {
+      Divider()
+      LabeledContent("Difficulty", value: "\(adversary.difficulty)")
+        .font(.caption)
+      LabeledContent("Thresholds") {
+        Text("\(adversary.thresholdMajor) / \(adversary.thresholdSevere)")
+      }
+      .font(.caption)
+      LabeledContent("Attack") {
+        Text(
+          "\(adversary.attackName) \(adversary.attackModifier) · \(adversary.attackRange.rawValue)")
+      }
+      .font(.caption)
+      LabeledContent("Damage", value: adversary.damage)
+        .font(.caption)
+      if !adversary.features.isEmpty {
+        Divider()
+        ForEach(adversary.features) { AdversaryFeatureRow(feature: $0) }
+      }
     }
+  }
 }

--- a/Encounter/Views/BrowserTab.swift
+++ b/Encounter/Views/BrowserTab.swift
@@ -6,6 +6,6 @@
 //
 
 nonisolated enum BrowserTab: String, CaseIterable {
-    case adversaries  = "Adversaries"
-    case environments = "Environments"
+  case adversaries = "Adversaries"
+  case environments = "Environments"
 }

--- a/Encounter/Views/BuilderNotesSection.swift
+++ b/Encounter/Views/BuilderNotesSection.swift
@@ -9,25 +9,25 @@
 import SwiftUI
 
 struct BuilderNotesSection: View {
-    @Binding var notes: String
-    @Binding var isExpanded: Bool
-    let onChange: () -> Void
+  @Binding var notes: String
+  @Binding var isExpanded: Bool
+  let onChange: () -> Void
 
-    var body: some View {
-        Section {
-            DisclosureGroup("Notes", isExpanded: $isExpanded) {
-                TextEditor(text: $notes)
-                    .frame(minHeight: 100)
-                    .onChange(of: notes) { _, _ in onChange() }
-            }
-        }
+  var body: some View {
+    Section {
+      DisclosureGroup("Notes", isExpanded: $isExpanded) {
+        TextEditor(text: $notes)
+          .frame(minHeight: 100)
+          .onChange(of: notes) { _, _ in onChange() }
+      }
     }
+  }
 }
 
 #Preview {
-    @Previewable @State var notes = ""
-    @Previewable @State var isExpanded = false
-    return Form {
-        BuilderNotesSection(notes: $notes, isExpanded: $isExpanded, onChange: {})
-    }
+  @Previewable @State var notes = ""
+  @Previewable @State var isExpanded = false
+  return Form {
+    BuilderNotesSection(notes: $notes, isExpanded: $isExpanded, onChange: {})
+  }
 }

--- a/Encounter/Views/CompendiumBrowserView.swift
+++ b/Encounter/Views/CompendiumBrowserView.swift
@@ -13,145 +13,150 @@
 import SwiftUI
 
 struct CompendiumBrowserView: View {
-    @Environment(Compendium.self) private var compendium
-    @Environment(\.dismiss) private var dismiss
+  @Environment(Compendium.self) private var compendium
+  @Environment(\.dismiss) private var dismiss
 
-    let onSelect: ((Adversary) -> Void)?
-    let onSelectEnvironment: ((DaggerheartEnvironment) -> Void)?
+  let onSelect: ((Adversary) -> Void)?
+  let onSelectEnvironment: ((DaggerheartEnvironment) -> Void)?
 
-    @State private var activeTab = BrowserTab.adversaries
-    @State private var searchText = ""
-    @State private var selectedType: AdversaryType?
+  @State private var activeTab = BrowserTab.adversaries
+  @State private var searchText = ""
+  @State private var selectedType: AdversaryType?
 
-    init(
-        onSelect: ((Adversary) -> Void)? = nil,
-        onSelectEnvironment: ((DaggerheartEnvironment) -> Void)? = nil
-    ) {
-        self.onSelect = onSelect
-        self.onSelectEnvironment = onSelectEnvironment
+  init(
+    onSelect: ((Adversary) -> Void)? = nil,
+    onSelectEnvironment: ((DaggerheartEnvironment) -> Void)? = nil
+  ) {
+    self.onSelect = onSelect
+    self.onSelectEnvironment = onSelectEnvironment
+  }
+
+  var filteredAdversaries: [Adversary] {
+    let base =
+      selectedType.map { t in compendium.adversaries.filter { $0.type == t } }
+      ?? compendium.adversaries
+    guard !searchText.isEmpty else { return base }
+    return base.filter {
+      $0.name.localizedStandardContains(searchText)
+        || $0.description.localizedStandardContains(searchText)
+    }
+  }
+
+  var filteredEnvironments: [DaggerheartEnvironment] {
+    guard !searchText.isEmpty else { return compendium.environments }
+    return compendium.environments.filter {
+      $0.name.localizedStandardContains(searchText)
+        || $0.description.localizedStandardContains(searchText)
+    }
+  }
+
+  var body: some View {
+    Group {
+      switch activeTab {
+      case .adversaries:
+        AdversaryListView(adversaries: filteredAdversaries)
+      case .environments:
+        EnvironmentListView(environments: filteredEnvironments)
+      }
+    }
+    .navigationTitle("Compendium")
+    .navigationDestination(for: Adversary.self) { adversary in
+      AdversaryDetailView(adversary: adversary, onSelect: onSelect)
+    }
+    .navigationDestination(for: DaggerheartEnvironment.self) { environment in
+      EnvironmentDetailView(environment: environment, onSelect: onSelectEnvironment)
+    }
+    .searchable(text: $searchText, prompt: "Search \(activeTab.rawValue.lowercased())")
+    .onChange(of: activeTab) { selectedType = nil }
+    .toolbar { toolbarContent }
+  }
+
+  @ToolbarContentBuilder
+  private var toolbarContent: some ToolbarContent {
+    // Done button when shown as a sheet from the builder
+    if onSelect != nil || onSelectEnvironment != nil {
+      ToolbarItem(placement: .cancellationAction) {
+        Button("Done") { dismiss() }
+      }
     }
 
-    var filteredAdversaries: [Adversary] {
-        let base = selectedType.map { t in compendium.adversaries.filter { $0.type == t } }
-            ?? compendium.adversaries
-        guard !searchText.isEmpty else { return base }
-        return base.filter {
-            $0.name.localizedStandardContains(searchText) ||
-            $0.description.localizedStandardContains(searchText)
+    // Tab switcher
+    ToolbarItem(placement: .principal) {
+      Picker("Category", selection: $activeTab) {
+        ForEach(BrowserTab.allCases, id: \.self) { tab in
+          Text(tab.rawValue).tag(tab)
         }
+      }
+      .pickerStyle(.segmented)
+      .frame(maxWidth: 240)
     }
 
-    var filteredEnvironments: [DaggerheartEnvironment] {
-        guard !searchText.isEmpty else { return compendium.environments }
-        return compendium.environments.filter {
-            $0.name.localizedStandardContains(searchText) ||
-            $0.description.localizedStandardContains(searchText)
+    // Type filter — adversaries tab only
+    ToolbarItem(placement: .primaryAction) {
+      if activeTab == .adversaries {
+        Menu {
+          Button("All Types") { selectedType = nil }
+          Divider()
+          ForEach(AdversaryType.allCases, id: \.self) { type in
+            Button(type.rawValue) { selectedType = type }
+          }
+        } label: {
+          Label(
+            selectedType?.rawValue ?? "Filter",
+            systemImage: selectedType != nil
+              ? "line.3.horizontal.decrease.circle.fill"
+              : "line.3.horizontal.decrease.circle"
+          )
         }
+      }
     }
-
-    var body: some View {
-        Group {
-            switch activeTab {
-            case .adversaries:
-                AdversaryListView(adversaries: filteredAdversaries)
-            case .environments:
-                EnvironmentListView(environments: filteredEnvironments)
-            }
-        }
-        .navigationTitle("Compendium")
-        .navigationDestination(for: Adversary.self) { adversary in
-            AdversaryDetailView(adversary: adversary, onSelect: onSelect)
-        }
-        .navigationDestination(for: DaggerheartEnvironment.self) { environment in
-            EnvironmentDetailView(environment: environment, onSelect: onSelectEnvironment)
-        }
-        .searchable(text: $searchText, prompt: "Search \(activeTab.rawValue.lowercased())")
-        .onChange(of: activeTab) { selectedType = nil }
-        .toolbar { toolbarContent }
-    }
-
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        // Done button when shown as a sheet from the builder
-        if onSelect != nil || onSelectEnvironment != nil {
-            ToolbarItem(placement: .cancellationAction) {
-                Button("Done") { dismiss() }
-            }
-        }
-
-        // Tab switcher
-        ToolbarItem(placement: .principal) {
-            Picker("Category", selection: $activeTab) {
-                ForEach(BrowserTab.allCases, id: \.self) { tab in
-                    Text(tab.rawValue).tag(tab)
-                }
-            }
-            .pickerStyle(.segmented)
-            .frame(maxWidth: 240)
-        }
-
-        // Type filter — adversaries tab only
-        ToolbarItem(placement: .primaryAction) {
-            if activeTab == .adversaries {
-                Menu {
-                    Button("All Types") { selectedType = nil }
-                    Divider()
-                    ForEach(AdversaryType.allCases, id: \.self) { type in
-                        Button(type.rawValue) { selectedType = type }
-                    }
-                } label: {
-                    Label(
-                        selectedType?.rawValue ?? "Filter",
-                        systemImage: selectedType != nil
-                            ? "line.3.horizontal.decrease.circle.fill"
-                            : "line.3.horizontal.decrease.circle"
-                    )
-                }
-            }
-        }
-    }
+  }
 }
 
 #Preview("Standalone") {
-    let compendium = Compendium()
-    compendium.addAdversary(Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
-        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-        attackModifier: "+2", attackName: "Rusty Blade",
-        attackRange: .veryClose, damage: "1d4 phy"
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, type: .minion,
+      description: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
     ))
-    compendium.addAdversary(Adversary(
-        id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
-        description: "Massive and relentless.", difficulty: 14,
-        thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
-        attackModifier: "+5", attackName: "Great Axe",
-        attackRange: .veryClose, damage: "2d10+4 phy"
+  compendium.addAdversary(
+    Adversary(
+      id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
+      description: "Massive and relentless.", difficulty: 14,
+      thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+      attackModifier: "+5", attackName: "Great Axe",
+      attackRange: .veryClose, damage: "2d10+4 phy"
     ))
-    compendium.addEnvironment(DaggerheartEnvironment(
-        id: "collapsing-cavern", name: "Collapsing Cavern",
-        description: "The ceiling threatens to fall with every heavy blow."
+  compendium.addEnvironment(
+    DaggerheartEnvironment(
+      id: "collapsing-cavern", name: "Collapsing Cavern",
+      description: "The ceiling threatens to fall with every heavy blow."
     ))
-    return NavigationStack {
-        CompendiumBrowserView()
-    }
-    .environment(compendium)
+  return NavigationStack {
+    CompendiumBrowserView()
+  }
+  .environment(compendium)
 }
 
 #Preview("From Builder (with selection)") {
-    let compendium = Compendium()
-    compendium.addAdversary(Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
-        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-        attackModifier: "+2", attackName: "Rusty Blade",
-        attackRange: .veryClose, damage: "1d4 phy"
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, type: .minion,
+      description: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
     ))
-    return NavigationStack {
-        CompendiumBrowserView(
-            onSelect: { adversary in print("Selected: \(adversary.name)") },
-            onSelectEnvironment: { env in print("Selected: \(env.name)") }
-        )
-    }
-    .environment(compendium)
+  return NavigationStack {
+    CompendiumBrowserView(
+      onSelect: { adversary in print("Selected: \(adversary.name)") },
+      onSelectEnvironment: { env in print("Selected: \(env.name)") }
+    )
+  }
+  .environment(compendium)
 }

--- a/Encounter/Views/ContentSourceRemovableRow.swift
+++ b/Encounter/Views/ContentSourceRemovableRow.swift
@@ -9,26 +9,26 @@
 import SwiftUI
 
 struct ContentSourceRemovableRow: View {
-    let source: ContentSource
-    let onRemove: (ContentSource) -> Void
+  let source: ContentSource
+  let onRemove: (ContentSource) -> Void
 
-    var body: some View {
-        ContentSourceRow(source: source)
-            #if os(iOS)
-            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                Button(role: .destructive) {
-                    onRemove(source)
-                } label: {
-                    Label("Remove", systemImage: "trash")
-                }
-            }
-            #endif
-            .contextMenu {
-                Button(role: .destructive) {
-                    onRemove(source)
-                } label: {
-                    Label("Remove", systemImage: "trash")
-                }
-            }
-    }
+  var body: some View {
+    ContentSourceRow(source: source)
+      #if os(iOS)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+          Button(role: .destructive) {
+            onRemove(source)
+          } label: {
+            Label("Remove", systemImage: "trash")
+          }
+        }
+      #endif
+      .contextMenu {
+        Button(role: .destructive) {
+          onRemove(source)
+        } label: {
+          Label("Remove", systemImage: "trash")
+        }
+      }
+  }
 }

--- a/Encounter/Views/ContentSourceRow.swift
+++ b/Encounter/Views/ContentSourceRow.swift
@@ -8,57 +8,59 @@
 import SwiftUI
 
 struct ContentSourceRow: View {
-    let source: ContentSource
+  let source: ContentSource
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(source.name)
-                .font(.body)
-            Text(subtitle)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-            HStack(spacing: 8) {
-                LastFetchedLabel(lastFetched: source.lastFetched)
-                if source.isThrottled() {
-                    Text("Fetch paused")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                }
-            }
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(source.name)
+        .font(.body)
+      Text(subtitle)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      HStack(spacing: 8) {
+        LastFetchedLabel(lastFetched: source.lastFetched)
+        if source.isThrottled() {
+          Text("Fetch paused")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
         }
+      }
     }
+  }
 
-    private var subtitle: String {
-        if source.isLocalImport {
-            return "Imported from file"
-        } else if let url = source.url {
-            return url.absoluteString
-        } else {
-            return "Unknown source"
-        }
+  private var subtitle: String {
+    if source.isLocalImport {
+      return "Imported from file"
+    } else if let url = source.url {
+      return url.absoluteString
+    } else {
+      return "Unknown source"
     }
+  }
 }
 
 #Preview("Local import") {
-    List {
-        ContentSourceRow(source: ContentSource(
-            id: "sample-homebrew",
-            name: "sample-homebrew",
-            importedAt: Date().addingTimeInterval(-3600)
-        ))
-    }
+  List {
+    ContentSourceRow(
+      source: ContentSource(
+        id: "sample-homebrew",
+        name: "sample-homebrew",
+        importedAt: Date().addingTimeInterval(-3600)
+      ))
+  }
 }
 
 #Preview("Remote source") {
-    let url = URL(string: "https://example.com/expanded.dhpack")
-    List {
-        if let url {
-            ContentSourceRow(source: ContentSource(
-                id: "expanded-compendium",
-                name: "Expanded Adversary Compendium",
-                url: url,
-                lastFetched: Date().addingTimeInterval(-86400)
-            ))
-        }
+  let url = URL(string: "https://example.com/expanded.dhpack")
+  List {
+    if let url {
+      ContentSourceRow(
+        source: ContentSource(
+          id: "expanded-compendium",
+          name: "Expanded Adversary Compendium",
+          url: url,
+          lastFetched: Date().addingTimeInterval(-86400)
+        ))
     }
+  }
 }

--- a/Encounter/Views/ContentSourcesView.swift
+++ b/Encounter/Views/ContentSourcesView.swift
@@ -8,117 +8,120 @@
 import SwiftUI
 
 struct ContentSourcesView: View {
-    @Environment(ContentStore.self) private var contentStore
-    @Environment(\.dismiss) private var dismiss
+  @Environment(ContentStore.self) private var contentStore
+  @Environment(\.dismiss) private var dismiss
 
-    @State private var removeTarget: ContentSource?
-    @State private var isConfirmingRemove = false
+  @State private var removeTarget: ContentSource?
+  @State private var isConfirmingRemove = false
 
-    private var sortedSources: [ContentSource] {
-        contentStore.sources.values.sorted { $0.name < $1.name }
-    }
+  private var sortedSources: [ContentSource] {
+    contentStore.sources.values.sorted { $0.name < $1.name }
+  }
 
-    private var localImports: [ContentSource] {
-        sortedSources.filter { $0.isLocalImport }
-    }
+  private var localImports: [ContentSource] {
+    sortedSources.filter { $0.isLocalImport }
+  }
 
-    private var remoteSources: [ContentSource] {
-        sortedSources.filter { !$0.isLocalImport }
-    }
+  private var remoteSources: [ContentSource] {
+    sortedSources.filter { !$0.isLocalImport }
+  }
 
-    var body: some View {
-        Group {
-            if contentStore.sources.isEmpty {
-                ContentUnavailableView {
-                    Label("No Content Packs", systemImage: "archivebox")
-                } description: {
-                    Text("Import a .dhpack file or add a remote source URL to get started.")
-                }
-            } else {
-                List {
-                    if !localImports.isEmpty {
-                        Section("Local Imports") {
-                            ForEach(localImports) { source in
-                                ContentSourceRemovableRow(source: source, onRemove: beginRemove)
-                            }
-                        }
-                    }
-                    if !remoteSources.isEmpty {
-                        Section("Remote Sources") {
-                            ForEach(remoteSources) { source in
-                                ContentSourceRemovableRow(source: source, onRemove: beginRemove)
-                            }
-                        }
-                    }
-                }
+  var body: some View {
+    Group {
+      if contentStore.sources.isEmpty {
+        ContentUnavailableView {
+          Label("No Content Packs", systemImage: "archivebox")
+        } description: {
+          Text("Import a .dhpack file or add a remote source URL to get started.")
+        }
+      } else {
+        List {
+          if !localImports.isEmpty {
+            Section("Local Imports") {
+              ForEach(localImports) { source in
+                ContentSourceRemovableRow(source: source, onRemove: beginRemove)
+              }
             }
-        }
-        .navigationTitle("Content Sources")
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
-        #endif
-        .toolbar {
-            ToolbarItem(placement: .confirmationAction) {
-                Button("Done") { dismiss() }
+          }
+          if !remoteSources.isEmpty {
+            Section("Remote Sources") {
+              ForEach(remoteSources) { source in
+                ContentSourceRemovableRow(source: source, onRemove: beginRemove)
+              }
             }
+          }
         }
-        .confirmationDialog(
-            "Remove \"\(removeTarget?.name ?? "")\"?",
-            isPresented: $isConfirmingRemove,
-            presenting: removeTarget
-        ) { source in
-            Button("Remove", role: .destructive) { commitRemove(source) }
-            Button("Cancel", role: .cancel) { }
-        } message: { _ in
-            Text("All adversaries and environments from this pack will be removed immediately.")
-        }
+      }
     }
+    .navigationTitle("Content Sources")
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.inline)
+    #endif
+    .toolbar {
+      ToolbarItem(placement: .confirmationAction) {
+        Button("Done") { dismiss() }
+      }
+    }
+    .confirmationDialog(
+      "Remove \"\(removeTarget?.name ?? "")\"?",
+      isPresented: $isConfirmingRemove,
+      presenting: removeTarget
+    ) { source in
+      Button("Remove", role: .destructive) { commitRemove(source) }
+      Button("Cancel", role: .cancel) {}
+    } message: { _ in
+      Text("All adversaries and environments from this pack will be removed immediately.")
+    }
+  }
 
-    private func beginRemove(_ source: ContentSource) {
-        removeTarget = source
-        isConfirmingRemove = true
-    }
+  private func beginRemove(_ source: ContentSource) {
+    removeTarget = source
+    isConfirmingRemove = true
+  }
 
-    private func commitRemove(_ source: ContentSource) {
-        removeTarget = nil
-        Task {
-            await contentStore.removeSource(id: source.id)
-        }
+  private func commitRemove(_ source: ContentSource) {
+    removeTarget = nil
+    Task {
+      await contentStore.removeSource(id: source.id)
     }
+  }
 }
 
 #Preview("Empty") {
-    NavigationStack {
-        ContentSourcesView()
-    }
-    .environment(ContentStore(
-        contentDirectory: .temporaryDirectory,
-        compendium: Compendium()
+  NavigationStack {
+    ContentSourcesView()
+  }
+  .environment(
+    ContentStore(
+      contentDirectory: .temporaryDirectory,
+      compendium: Compendium()
     ))
 }
 
 #Preview("With sources") {
-    let store = ContentStore(
-        contentDirectory: .temporaryDirectory,
-        compendium: Compendium()
-    )
-    NavigationStack {
-        ContentSourcesView()
-    }
-    .environment(store)
-    .task {
-        await store.addSource(ContentSource(
-            id: "sample-homebrew",
-            name: "sample-homebrew",
-            importedAt: Date().addingTimeInterval(-3600)
+  let store = ContentStore(
+    contentDirectory: .temporaryDirectory,
+    compendium: Compendium()
+  )
+  NavigationStack {
+    ContentSourcesView()
+  }
+  .environment(store)
+  .task {
+    await store.addSource(
+      ContentSource(
+        id: "sample-homebrew",
+        name: "sample-homebrew",
+        importedAt: Date().addingTimeInterval(-3600)
+      ))
+    if let url = URL(string: "https://example.com/expanded.dhpack") {
+      await store.addSource(
+        ContentSource(
+          id: "expanded-compendium",
+          name: "Expanded Adversary Compendium",
+          url: url,
+          lastFetched: Date().addingTimeInterval(-86400)
         ))
-        if let url = URL(string: "https://example.com/expanded.dhpack") {
-            await store.addSource(ContentSource(
-                id: "expanded-compendium",
-                name: "Expanded Adversary Compendium",
-                url: url,
-                lastFetched: Date().addingTimeInterval(-86400)
-            ))
-        }
     }
+  }
 }

--- a/Encounter/Views/DifficultyAssessorView.swift
+++ b/Encounter/Views/DifficultyAssessorView.swift
@@ -19,119 +19,118 @@
 import SwiftUI
 
 struct DifficultyAssessorView: View {
-    let rating: DifficultyBudget.Rating
-    let autoAdjustments: Set<DifficultyBudget.Adjustment>
-    @Binding var manualAdjustments: Set<DifficultyBudget.Adjustment>
+  let rating: DifficultyBudget.Rating
+  let autoAdjustments: Set<DifficultyBudget.Adjustment>
+  @Binding var manualAdjustments: Set<DifficultyBudget.Adjustment>
 
-    // Only these four adjustments can be toggled manually.
-    // multipleSolos and noBigThreats are auto-detected from the roster.
-    private static let manualCases: [DifficultyBudget.Adjustment] = [
-        .easierFight, .harderFight, .boostedDamage, .lowerTierAdversary
-    ]
+  // Only these four adjustments can be toggled manually.
+  // multipleSolos and noBigThreats are auto-detected from the roster.
+  private static let manualCases: [DifficultyBudget.Adjustment] = [
+    .easierFight, .harderFight, .boostedDamage, .lowerTierAdversary,
+  ]
 
-    private var difficultyLabel: String {
-        switch rating.remaining {
-        case 4...:      return "Too Easy"
-        case 1...3:     return "Well Matched"
-        case 0:         return "On Budget"
-        case -3 ... -1: return "Challenging"
-        case -6 ... -4: return "Dangerous"
-        default:        return "Likely TPK"
-        }
+  private var difficultyLabel: String {
+    switch rating.remaining {
+    case 4...: return "Too Easy"
+    case 1...3: return "Well Matched"
+    case 0: return "On Budget"
+    case -3 ... -1: return "Challenging"
+    case -6 ... -4: return "Dangerous"
+    default: return "Likely TPK"
     }
+  }
 
-    private var difficultyColor: Color {
-        switch rating.remaining {
-        case 4...:      return .teal
-        case 1...:      return .green
-        case 0:         return .green
-        case -3 ... -1: return .orange
-        case -6 ... -4: return .red
-        default:        return .red
-        }
+  private var difficultyColor: Color {
+    switch rating.remaining {
+    case 4...: return .teal
+    case 1...: return .green
+    case 0: return .green
+    case -3 ... -1: return .orange
+    case -6 ... -4: return .red
+    default: return .red
     }
+  }
 
-    private var isPulsing: Bool { rating.remaining <= -7 }
+  private var isPulsing: Bool { rating.remaining <= -7 }
 
-    private func toggleBinding(for adj: DifficultyBudget.Adjustment) -> Binding<Bool> {
-        Binding(
-            get: { manualAdjustments.contains(adj) },
-            set: { on in
-                if on { manualAdjustments.insert(adj) }
-                else  { manualAdjustments.remove(adj) }
+  private func toggleBinding(for adj: DifficultyBudget.Adjustment) -> Binding<Bool> {
+    Binding(
+      get: { manualAdjustments.contains(adj) },
+      set: { on in
+        if on { manualAdjustments.insert(adj) } else { manualAdjustments.remove(adj) }
+      }
+    )
+  }
+
+  @State private var animating = false
+
+  var body: some View {
+    VStack(spacing: 0) {
+      Divider()
+      VStack(alignment: .leading, spacing: 8) {
+        // BP summary row
+        HStack {
+          Text(difficultyLabel)
+            .font(.headline)
+            .foregroundStyle(difficultyColor)
+            .opacity(animating ? 0.35 : 1.0)
+            .animation(
+              animating
+                ? .easeInOut(duration: 0.8).repeatForever(autoreverses: true)
+                : .easeInOut(duration: 0.3),
+              value: animating
+            )
+          Spacer()
+          Text("\(rating.totalCost) / \(rating.budget) BP")
+            .font(.subheadline)
+            .monospacedDigit()
+            .foregroundStyle(.secondary)
+        }
+
+        // Auto-detected adjustments (informational, non-interactive)
+        if !autoAdjustments.isEmpty {
+          VStack(alignment: .leading, spacing: 2) {
+            ForEach(Array(autoAdjustments), id: \.self) { adj in
+              Label(adj.label, systemImage: "checkmark.circle.fill")
+                .font(.caption)
+                .foregroundStyle(.secondary)
             }
-        )
-    }
-
-    @State private var animating = false
-
-    var body: some View {
-        VStack(spacing: 0) {
-            Divider()
-            VStack(alignment: .leading, spacing: 8) {
-                // BP summary row
-                HStack {
-                    Text(difficultyLabel)
-                        .font(.headline)
-                        .foregroundStyle(difficultyColor)
-                        .opacity(animating ? 0.35 : 1.0)
-                        .animation(
-                            animating
-                                ? .easeInOut(duration: 0.8).repeatForever(autoreverses: true)
-                                : .easeInOut(duration: 0.3),
-                            value: animating
-                        )
-                    Spacer()
-                    Text("\(rating.totalCost) / \(rating.budget) BP")
-                        .font(.subheadline)
-                        .monospacedDigit()
-                        .foregroundStyle(.secondary)
-                }
-
-                // Auto-detected adjustments (informational, non-interactive)
-                if !autoAdjustments.isEmpty {
-                    VStack(alignment: .leading, spacing: 2) {
-                        ForEach(Array(autoAdjustments), id: \.self) { adj in
-                            Label(adj.label, systemImage: "checkmark.circle.fill")
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                        }
-                    }
-                }
-
-                // Manual GM-discretionary toggles
-                VStack(alignment: .leading, spacing: 2) {
-                    ForEach(Self.manualCases, id: \.self) { adj in
-                        Toggle(adj.label, isOn: toggleBinding(for: adj))
-                            .font(.caption)
-                    }
-                }
-            }
-            .padding(.horizontal)
-            .padding(.vertical, 8)
-            .background(.regularMaterial)
+          }
         }
-        .onAppear { animating = isPulsing }
-        .onChange(of: isPulsing) { _, nowPulsing in
-            animating = nowPulsing
+
+        // Manual GM-discretionary toggles
+        VStack(alignment: .leading, spacing: 2) {
+          ForEach(Self.manualCases, id: \.self) { adj in
+            Toggle(adj.label, isOn: toggleBinding(for: adj))
+              .font(.caption)
+          }
         }
+      }
+      .padding(.horizontal)
+      .padding(.vertical, 8)
+      .background(.regularMaterial)
     }
+    .onAppear { animating = isPulsing }
+    .onChange(of: isPulsing) { _, nowPulsing in
+      animating = nowPulsing
+    }
+  }
 }
 
 #Preview("On Budget — 4 players, 14 BP spent") {
-    @Previewable @State var manual: Set<DifficultyBudget.Adjustment> = []
-    let rating = DifficultyBudget.Rating(budget: 14, totalCost: 14, remaining: 0)
-    return DifficultyAssessorView(rating: rating, autoAdjustments: [], manualAdjustments: $manual)
-        .padding()
+  @Previewable @State var manual: Set<DifficultyBudget.Adjustment> = []
+  let rating = DifficultyBudget.Rating(budget: 14, totalCost: 14, remaining: 0)
+  return DifficultyAssessorView(rating: rating, autoAdjustments: [], manualAdjustments: $manual)
+    .padding()
 }
 
 #Preview("Dangerous — over budget") {
-    @Previewable @State var manual: Set<DifficultyBudget.Adjustment> = []
-    let rating = DifficultyBudget.Rating(budget: 14, totalCost: 19, remaining: -5)
-    return DifficultyAssessorView(
-        rating: rating,
-        autoAdjustments: [.multipleSolos],
-        manualAdjustments: $manual
-    )
-    .padding()
+  @Previewable @State var manual: Set<DifficultyBudget.Adjustment> = []
+  let rating = DifficultyBudget.Rating(budget: 14, totalCost: 19, remaining: -5)
+  return DifficultyAssessorView(
+    rating: rating,
+    autoAdjustments: [.multipleSolos],
+    manualAdjustments: $manual
+  )
+  .padding()
 }

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -13,244 +13,246 @@
 import SwiftUI
 
 struct EncounterBuilderView: View {
-    let definition: EncounterDefinition
+  let definition: EncounterDefinition
 
-    @State private var draft: EncounterDefinition
-    @Environment(EncounterStore.self) private var store
-    @Environment(Compendium.self) private var compendium
-    @Environment(SessionRegistry.self) private var sessionRegistry
+  @State private var draft: EncounterDefinition
+  @Environment(EncounterStore.self) private var store
+  @Environment(Compendium.self) private var compendium
+  @Environment(SessionRegistry.self) private var sessionRegistry
 
-    @State private var showCompendium = false
-    @State private var showAddPlayer = false
-    @State private var notesExpanded = false
-    @State private var manualAdjustments: Set<DifficultyBudget.Adjustment> = []
-    @State private var saveError: String?
-    @State private var runSession: EncounterSession?
-    @State private var saveTask: Task<Void, Never>?
+  @State private var showCompendium = false
+  @State private var showAddPlayer = false
+  @State private var notesExpanded = false
+  @State private var manualAdjustments: Set<DifficultyBudget.Adjustment> = []
+  @State private var saveError: String?
+  @State private var runSession: EncounterSession?
+  @State private var saveTask: Task<Void, Never>?
 
-    init(definition: EncounterDefinition) {
-        self.definition = definition
-        _draft = State(initialValue: definition)
+  init(definition: EncounterDefinition) {
+    self.definition = definition
+    _draft = State(initialValue: definition)
+  }
+
+  // MARK: - Computed difficulty
+
+  private var adversaryTypes: [AdversaryType] {
+    draft.adversaryIDs.compactMap { compendium.adversary(id: $0)?.type }
+  }
+
+  private var autoAdjustments: Set<DifficultyBudget.Adjustment> {
+    DifficultyBudget.suggestedAdjustments(adversaryTypes: adversaryTypes)
+  }
+
+  private var budgetAdjustment: Int {
+    autoAdjustments.union(manualAdjustments).reduce(0) { $0 + $1.pointValue }
+  }
+
+  private var difficultyRating: DifficultyBudget.Rating {
+    DifficultyBudget.rating(
+      adversaryTypes: adversaryTypes,
+      playerCount: draft.playerConfigs.count,
+      budgetAdjustment: budgetAdjustment
+    )
+  }
+
+  // MARK: - Body
+
+  var body: some View {
+    Form {
+      AdversaryRosterSection(
+        adversaryIDs: draft.adversaryIDs,
+        compendium: compendium,
+        onBrowse: { showCompendium = true },
+        onRemove: removeAdversary(at:)
+      )
+      EnvironmentSection(
+        environmentIDs: draft.environmentIDs,
+        compendium: compendium,
+        onBrowse: { showCompendium = true },
+        onRemove: removeEnvironment(at:)
+      )
+      PlayerRosterSection(
+        playerConfigs: draft.playerConfigs,
+        onAddPlayer: { showAddPlayer = true },
+        onRemove: removePlayer(at:)
+      )
+      BuilderNotesSection(
+        notes: $draft.gmNotes,
+        isExpanded: $notesExpanded,
+        onChange: saveDebounced
+      )
     }
-
-    // MARK: - Computed difficulty
-
-    private var adversaryTypes: [AdversaryType] {
-        draft.adversaryIDs.compactMap { compendium.adversary(id: $0)?.type }
+    .navigationTitle(draft.name)
+    .toolbar { toolbarContent }
+    .safeAreaInset(edge: .bottom) {
+      DifficultyAssessorView(
+        rating: difficultyRating,
+        autoAdjustments: autoAdjustments,
+        manualAdjustments: $manualAdjustments
+      )
     }
-
-    private var autoAdjustments: Set<DifficultyBudget.Adjustment> {
-        DifficultyBudget.suggestedAdjustments(adversaryTypes: adversaryTypes)
+    .safeAreaInset(edge: .top) {
+      if let error = saveError {
+        EncounterErrorBanner(message: error, onDismiss: { saveError = nil })
+      }
     }
-
-    private var budgetAdjustment: Int {
-        autoAdjustments.union(manualAdjustments).reduce(0) { $0 + $1.pointValue }
-    }
-
-    private var difficultyRating: DifficultyBudget.Rating {
-        DifficultyBudget.rating(
-            adversaryTypes: adversaryTypes,
-            playerCount: draft.playerConfigs.count,
-            budgetAdjustment: budgetAdjustment
+    .sheet(isPresented: $showCompendium) {
+      NavigationStack {
+        CompendiumBrowserView(
+          onSelect: { adversary in
+            addAdversary(adversary)
+            showCompendium = false
+          },
+          onSelectEnvironment: { environment in
+            setEnvironment(environment)
+            showCompendium = false
+          }
         )
+      }
+      #if os(macOS)
+        .frame(minWidth: 540, minHeight: 480)
+      #endif
+      .environment(compendium)
     }
-
-    // MARK: - Body
-
-    var body: some View {
-        Form {
-            AdversaryRosterSection(
-                adversaryIDs: draft.adversaryIDs,
-                compendium: compendium,
-                onBrowse: { showCompendium = true },
-                onRemove: removeAdversary(at:)
-            )
-            EnvironmentSection(
-                environmentIDs: draft.environmentIDs,
-                compendium: compendium,
-                onBrowse: { showCompendium = true },
-                onRemove: removeEnvironment(at:)
-            )
-            PlayerRosterSection(
-                playerConfigs: draft.playerConfigs,
-                onAddPlayer: { showAddPlayer = true },
-                onRemove: removePlayer(at:)
-            )
-            BuilderNotesSection(
-                notes: $draft.gmNotes,
-                isExpanded: $notesExpanded,
-                onChange: saveDebounced
-            )
-        }
-        .navigationTitle(draft.name)
-        .toolbar { toolbarContent }
-        .safeAreaInset(edge: .bottom) {
-            DifficultyAssessorView(
-                rating: difficultyRating,
-                autoAdjustments: autoAdjustments,
-                manualAdjustments: $manualAdjustments
-            )
-        }
-        .safeAreaInset(edge: .top) {
-            if let error = saveError {
-                EncounterErrorBanner(message: error, onDismiss: { saveError = nil })
-            }
-        }
-        .sheet(isPresented: $showCompendium) {
-            NavigationStack {
-                CompendiumBrowserView(
-                    onSelect: { adversary in
-                        addAdversary(adversary)
-                        showCompendium = false
-                    },
-                    onSelectEnvironment: { environment in
-                        setEnvironment(environment)
-                        showCompendium = false
-                    }
-                )
-            }
-            #if os(macOS)
-            .frame(minWidth: 540, minHeight: 480)
-            #endif
-            .environment(compendium)
-        }
-        .sheet(isPresented: $showAddPlayer) {
-            AddPlayerForm { config in
-                addPlayer(config)
-            }
-        }
-        .navigationDestination(item: $runSession) { session in
-            EncounterRunnerView(session: session, definition: draft)
-        }
-        .onChange(of: definition) { _, newDefinition in
-            if newDefinition.modifiedAt > draft.modifiedAt {
-                draft = newDefinition
-            }
-        }
+    .sheet(isPresented: $showAddPlayer) {
+      AddPlayerForm { config in
+        addPlayer(config)
+      }
     }
-
-    // MARK: - Toolbar
-
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .primaryAction) {
-            Button("Run Encounter") {
-                runSession = sessionRegistry.session(
-                    for: draft.id,
-                    definition: draft,
-                    compendium: compendium
-                )
-            }
-            .disabled(draft.adversaryIDs.isEmpty)
-        }
-        ToolbarItem(placement: .primaryAction) {
-            Button("Browse Compendium", systemImage: "books.vertical") {
-                showCompendium = true
-            }
-        }
+    .navigationDestination(item: $runSession) { session in
+      EncounterRunnerView(session: session, definition: draft)
     }
-
-    // MARK: - Mutations
-
-    private func addAdversary(_ adversary: Adversary) {
-        draft.adversaryIDs.append(adversary.id)
-        save()
+    .onChange(of: definition) { _, newDefinition in
+      if newDefinition.modifiedAt > draft.modifiedAt {
+        draft = newDefinition
+      }
     }
+  }
 
-    private func removeAdversary(at offsets: IndexSet) {
-        draft.adversaryIDs.remove(atOffsets: offsets)
-        save()
-    }
+  // MARK: - Toolbar
 
-    private func setEnvironment(_ environment: DaggerheartEnvironment) {
-        draft.environmentIDs = [environment.id]
-        save()
+  @ToolbarContentBuilder
+  private var toolbarContent: some ToolbarContent {
+    ToolbarItem(placement: .primaryAction) {
+      Button("Run Encounter") {
+        runSession = sessionRegistry.session(
+          for: draft.id,
+          definition: draft,
+          compendium: compendium
+        )
+      }
+      .disabled(draft.adversaryIDs.isEmpty)
     }
+    ToolbarItem(placement: .primaryAction) {
+      Button("Browse Compendium", systemImage: "books.vertical") {
+        showCompendium = true
+      }
+    }
+  }
 
-    private func removeEnvironment(at offsets: IndexSet) {
-        draft.environmentIDs.remove(atOffsets: offsets)
-        save()
-    }
+  // MARK: - Mutations
 
-    private func addPlayer(_ config: PlayerConfig) {
-        draft.playerConfigs.append(config)
-        save()
-    }
+  private func addAdversary(_ adversary: Adversary) {
+    draft.adversaryIDs.append(adversary.id)
+    save()
+  }
 
-    private func removePlayer(at offsets: IndexSet) {
-        draft.playerConfigs.remove(atOffsets: offsets)
-        save()
-    }
+  private func removeAdversary(at offsets: IndexSet) {
+    draft.adversaryIDs.remove(atOffsets: offsets)
+    save()
+  }
 
-    private func save() {
-        Task {
-            do {
-                try await store.save(draft)
-            } catch {
-                saveError = error.localizedDescription
-            }
-        }
-    }
+  private func setEnvironment(_ environment: DaggerheartEnvironment) {
+    draft.environmentIDs = [environment.id]
+    save()
+  }
 
-    /// Debounced save for notes changes — coalesces rapid keystrokes into one write.
-    private func saveDebounced() {
-        saveTask?.cancel()
-        saveTask = Task {
-            try? await Task.sleep(for: .milliseconds(400))
-            guard !Task.isCancelled else { return }
-            do {
-                try await store.save(draft)
-            } catch is CancellationError {
-                // Normal — view dismissed or a newer keystroke cancelled this save.
-            } catch {
-                saveError = error.localizedDescription
-            }
-        }
+  private func removeEnvironment(at offsets: IndexSet) {
+    draft.environmentIDs.remove(atOffsets: offsets)
+    save()
+  }
+
+  private func addPlayer(_ config: PlayerConfig) {
+    draft.playerConfigs.append(config)
+    save()
+  }
+
+  private func removePlayer(at offsets: IndexSet) {
+    draft.playerConfigs.remove(atOffsets: offsets)
+    save()
+  }
+
+  private func save() {
+    Task {
+      do {
+        try await store.save(draft)
+      } catch {
+        saveError = error.localizedDescription
+      }
     }
+  }
+
+  /// Debounced save for notes changes — coalesces rapid keystrokes into one write.
+  private func saveDebounced() {
+    saveTask?.cancel()
+    saveTask = Task {
+      try? await Task.sleep(for: .milliseconds(400))
+      guard !Task.isCancelled else { return }
+      do {
+        try await store.save(draft)
+      } catch is CancellationError {
+        // Normal — view dismissed or a newer keystroke cancelled this save.
+      } catch {
+        saveError = error.localizedDescription
+      }
+    }
+  }
 }
 
 #Preview {
-    let store = EncounterStore(directory: URL.temporaryDirectory.appending(path: "preview-builder"))
-    let compendium = Compendium()
-    compendium.addAdversary(Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
-        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-        attackModifier: "+2", attackName: "Rusty Blade",
-        attackRange: .veryClose, damage: "1d4 phy"
+  let store = EncounterStore(directory: URL.temporaryDirectory.appending(path: "preview-builder"))
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, type: .minion,
+      description: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
     ))
-    compendium.addAdversary(Adversary(
-        id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
-        description: "Massive and relentless.", difficulty: 14,
-        thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
-        attackModifier: "+5", attackName: "Great Axe",
-        attackRange: .veryClose, damage: "2d10+4 phy"
+  compendium.addAdversary(
+    Adversary(
+      id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
+      description: "Massive and relentless.", difficulty: 14,
+      thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+      attackModifier: "+5", attackName: "Great Axe",
+      attackRange: .veryClose, damage: "2d10+4 phy"
     ))
-    return NavigationStack {
-        // Create and inject a matching definition so auto-save succeeds in preview
-        EncounterBuilderPreviewWrapper()
-    }
-    .environment(store)
-    .environment(compendium)
-    .environment(SessionRegistry())
+  return NavigationStack {
+    // Create and inject a matching definition so auto-save succeeds in preview
+    EncounterBuilderPreviewWrapper()
+  }
+  .environment(store)
+  .environment(compendium)
+  .environment(SessionRegistry())
 }
 
 /// Preview wrapper that creates a definition in the store before showing the builder.
 private struct EncounterBuilderPreviewWrapper: View {
-    @Environment(EncounterStore.self) private var store
-    @State private var definition: EncounterDefinition?
+  @Environment(EncounterStore.self) private var store
+  @State private var definition: EncounterDefinition?
 
-    var body: some View {
-        Group {
-            if let definition {
-                EncounterBuilderView(definition: definition)
-            } else {
-                ProgressView()
-                    .task {
-                        try? await store.create(name: "Goblin Ambush")
-                        definition = store.definitions.first
-                    }
-            }
-        }
+  var body: some View {
+    Group {
+      if let definition {
+        EncounterBuilderView(definition: definition)
+      } else {
+        ProgressView()
+          .task {
+            try? await store.create(name: "Goblin Ambush")
+            definition = store.definitions.first
+          }
+      }
     }
+  }
 }

--- a/Encounter/Views/EncounterErrorBanner.swift
+++ b/Encounter/Views/EncounterErrorBanner.swift
@@ -8,26 +8,26 @@
 import SwiftUI
 
 struct EncounterErrorBanner: View {
-    let message: String
-    let onDismiss: () -> Void
+  let message: String
+  let onDismiss: () -> Void
 
-    var body: some View {
-        HStack {
-            Image(systemName: "exclamationmark.triangle.fill")
-                .foregroundStyle(.yellow)
-                .accessibilityHidden(true)
-            Text(message)
-                .font(.footnote)
-            Spacer()
-            Button("Dismiss", action: onDismiss)
-                .font(.footnote)
-        }
-        .padding(.horizontal)
-        .padding(.vertical, 8)
-        .background(.thinMaterial)
+  var body: some View {
+    HStack {
+      Image(systemName: "exclamationmark.triangle.fill")
+        .foregroundStyle(.yellow)
+        .accessibilityHidden(true)
+      Text(message)
+        .font(.footnote)
+      Spacer()
+      Button("Dismiss", action: onDismiss)
+        .font(.footnote)
     }
+    .padding(.horizontal)
+    .padding(.vertical, 8)
+    .background(.thinMaterial)
+  }
 }
 
 #Preview {
-    EncounterErrorBanner(message: "Could not load encounters.", onDismiss: {})
+  EncounterErrorBanner(message: "Could not load encounters.", onDismiss: {})
 }

--- a/Encounter/Views/EncounterLibraryEmptyState.swift
+++ b/Encounter/Views/EncounterLibraryEmptyState.swift
@@ -8,20 +8,20 @@
 import SwiftUI
 
 struct EncounterLibraryEmptyState: View {
-    let onCreateTapped: () -> Void
+  let onCreateTapped: () -> Void
 
-    var body: some View {
-        ContentUnavailableView {
-            Label("No Encounters", systemImage: "list.bullet.clipboard")
-        } description: {
-            Text("Create your first encounter to get started.")
-        } actions: {
-            Button("Create Encounter", action: onCreateTapped)
-                .buttonStyle(.borderedProminent)
-        }
+  var body: some View {
+    ContentUnavailableView {
+      Label("No Encounters", systemImage: "list.bullet.clipboard")
+    } description: {
+      Text("Create your first encounter to get started.")
+    } actions: {
+      Button("Create Encounter", action: onCreateTapped)
+        .buttonStyle(.borderedProminent)
     }
+  }
 }
 
 #Preview {
-    EncounterLibraryEmptyState(onCreateTapped: {})
+  EncounterLibraryEmptyState(onCreateTapped: {})
 }

--- a/Encounter/Views/EncounterLibraryList.swift
+++ b/Encounter/Views/EncounterLibraryList.swift
@@ -8,79 +8,79 @@
 import SwiftUI
 
 struct EncounterLibraryList: View {
-    let definitions: [EncounterDefinition]
-    @Binding var selection: EncounterDefinition.ID?
-    let onRename: (EncounterDefinition) -> Void
-    let onDelete: (EncounterDefinition) -> Void
+  let definitions: [EncounterDefinition]
+  @Binding var selection: EncounterDefinition.ID?
+  let onRename: (EncounterDefinition) -> Void
+  let onDelete: (EncounterDefinition) -> Void
 
-    var body: some View {
-        List(definitions, selection: $selection) { definition in
-            #if os(macOS)
-            EncounterLibraryRow(definition: definition)
-                .contextMenu {
-                    Button {
-                        onRename(definition)
-                    } label: {
-                        Label("Rename", systemImage: "pencil")
-                    }
-                    Divider()
-                    Button(role: .destructive) {
-                        onDelete(definition)
-                    } label: {
-                        Label("Delete", systemImage: "trash")
-                    }
-                }
-            #else
-            NavigationLink(value: definition) {
-                EncounterLibraryRow(definition: definition)
+  var body: some View {
+    List(definitions, selection: $selection) { definition in
+      #if os(macOS)
+        EncounterLibraryRow(definition: definition)
+          .contextMenu {
+            Button {
+              onRename(definition)
+            } label: {
+              Label("Rename", systemImage: "pencil")
             }
-            .swipeActions(edge: .trailing, allowsFullSwipe: false) {
-                Button(role: .destructive) {
-                    onDelete(definition)
-                } label: {
-                    Label("Delete", systemImage: "trash")
-                }
-                Button {
-                    onRename(definition)
-                } label: {
-                    Label("Rename", systemImage: "pencil")
-                }
-                .tint(.orange)
+            Divider()
+            Button(role: .destructive) {
+              onDelete(definition)
+            } label: {
+              Label("Delete", systemImage: "trash")
             }
-            .contextMenu {
-                Button {
-                    onRename(definition)
-                } label: {
-                    Label("Rename", systemImage: "pencil")
-                }
-                Divider()
-                Button(role: .destructive) {
-                    onDelete(definition)
-                } label: {
-                    Label("Delete", systemImage: "trash")
-                }
-            }
-            #endif
+          }
+      #else
+        NavigationLink(value: definition) {
+          EncounterLibraryRow(definition: definition)
         }
-        #if !os(macOS)
-        .navigationDestination(for: EncounterDefinition.self) { definition in
-            EncounterBuilderView(definition: definition)
+        .swipeActions(edge: .trailing, allowsFullSwipe: false) {
+          Button(role: .destructive) {
+            onDelete(definition)
+          } label: {
+            Label("Delete", systemImage: "trash")
+          }
+          Button {
+            onRename(definition)
+          } label: {
+            Label("Rename", systemImage: "pencil")
+          }
+          .tint(.orange)
         }
-        #endif
+        .contextMenu {
+          Button {
+            onRename(definition)
+          } label: {
+            Label("Rename", systemImage: "pencil")
+          }
+          Divider()
+          Button(role: .destructive) {
+            onDelete(definition)
+          } label: {
+            Label("Delete", systemImage: "trash")
+          }
+        }
+      #endif
     }
+    #if !os(macOS)
+      .navigationDestination(for: EncounterDefinition.self) { definition in
+        EncounterBuilderView(definition: definition)
+      }
+    #endif
+  }
 }
 
 #Preview {
-    @Previewable @State var selection: EncounterDefinition.ID? = nil
-    NavigationStack {
-        EncounterLibraryList(
-            definitions: [
-                EncounterDefinition(name: "Goblin Ambush"),
-                EncounterDefinition(name: "Dragon's Lair"),
-            ],
-            selection: $selection,
-            onRename: { _ in },
-            onDelete: { _ in }
-        )
-    }
+  @Previewable @State var selection: EncounterDefinition.ID? = nil
+  NavigationStack {
+    EncounterLibraryList(
+      definitions: [
+        EncounterDefinition(name: "Goblin Ambush"),
+        EncounterDefinition(name: "Dragon's Lair"),
+      ],
+      selection: $selection,
+      onRename: { _ in },
+      onDelete: { _ in }
+    )
+  }
 }

--- a/Encounter/Views/EncounterLibraryRow.swift
+++ b/Encounter/Views/EncounterLibraryRow.swift
@@ -8,21 +8,21 @@
 import SwiftUI
 
 struct EncounterLibraryRow: View {
-    let definition: EncounterDefinition
+  let definition: EncounterDefinition
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(definition.name)
-                .font(.body)
-            Text(definition.modifiedAt, style: .relative)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 2)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(definition.name)
+        .font(.body)
+      Text(definition.modifiedAt, style: .relative)
+        .font(.caption)
+        .foregroundStyle(.secondary)
     }
+    .padding(.vertical, 2)
+  }
 }
 
 #Preview {
-    EncounterLibraryRow(definition: EncounterDefinition(name: "Goblin Ambush"))
-        .padding()
+  EncounterLibraryRow(definition: EncounterDefinition(name: "Goblin Ambush"))
+    .padding()
 }

--- a/Encounter/Views/EncounterLibraryView.swift
+++ b/Encounter/Views/EncounterLibraryView.swift
@@ -8,161 +8,161 @@
 import SwiftUI
 
 struct EncounterLibraryView: View {
-    @Environment(EncounterStore.self) private var store
+  @Environment(EncounterStore.self) private var store
 
-    @Binding var selection: EncounterDefinition.ID?
-    @State private var isCreating = false
-    @State private var newName = ""
-    @State private var isRenaming = false
-    @State private var renameTarget: EncounterDefinition?
-    @State private var renameText = ""
-    @State private var isConfirmingDelete = false
-    @State private var deleteTarget: EncounterDefinition?
-    @State private var actionError: String?
-    @State private var loadErrorDismissed = false
-    @State private var isShowingSources = false
+  @Binding var selection: EncounterDefinition.ID?
+  @State private var isCreating = false
+  @State private var newName = ""
+  @State private var isRenaming = false
+  @State private var renameTarget: EncounterDefinition?
+  @State private var renameText = ""
+  @State private var isConfirmingDelete = false
+  @State private var deleteTarget: EncounterDefinition?
+  @State private var actionError: String?
+  @State private var loadErrorDismissed = false
+  @State private var isShowingSources = false
 
-    var body: some View {
-        Group {
-            if store.isLoading {
-                ProgressView()
-                    .frame(maxWidth: .infinity, maxHeight: .infinity)
-            } else if store.definitions.isEmpty {
-                EncounterLibraryEmptyState(onCreateTapped: beginCreate)
-            } else {
-                EncounterLibraryList(
-                    definitions: store.definitions,
-                    selection: $selection,
-                    onRename: beginRename,
-                    onDelete: beginDelete
-                )
-            }
-        }
-        .navigationTitle("Encounters")
-        .toolbar { toolbarContent }
-        // Create alert
-        .alert("New Encounter", isPresented: $isCreating) {
-            TextField("Encounter name", text: $newName)
-            Button("Create") { createEncounter() }
-            Button("Cancel", role: .cancel) { newName = "" }
-        }
-        // Rename alert — uses presenting: to avoid Binding(get:set:)
-        .alert("Rename Encounter", isPresented: $isRenaming, presenting: renameTarget) { _ in
-            TextField("Name", text: $renameText)
-            Button("Rename") { commitRename() }
-            Button("Cancel", role: .cancel) { }
-        }
-        // Delete confirmation — uses presenting: to avoid Binding(get:set:)
-        .confirmationDialog(
-            "Delete Encounter?",
-            isPresented: $isConfirmingDelete,
-            presenting: deleteTarget
-        ) { target in
-            Button("Delete \"\(target.name)\"", role: .destructive) { commitDelete() }
-            Button("Cancel", role: .cancel) { }
-        } message: { _ in
-            Text("This action cannot be undone.")
-        }
-        // Reset dismissed flag whenever a new distinct error appears, so fresh errors surface.
-        .onChange(of: store.loadError?.localizedDescription) { _, newDescription in
-            if newDescription != nil { loadErrorDismissed = false }
-        }
-        .sheet(isPresented: $isShowingSources) {
-            NavigationStack {
-                ContentSourcesView()
-            }
-        }
-        // Error banners
-        .safeAreaInset(edge: .top) {
-            if let error = store.loadError, !loadErrorDismissed {
-                EncounterErrorBanner(
-                    message: error.localizedDescription,
-                    onDismiss: { loadErrorDismissed = true }
-                )
-            } else if let error = actionError {
-                EncounterErrorBanner(
-                    message: error,
-                    onDismiss: { actionError = nil }
-                )
-            }
-        }
+  var body: some View {
+    Group {
+      if store.isLoading {
+        ProgressView()
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+      } else if store.definitions.isEmpty {
+        EncounterLibraryEmptyState(onCreateTapped: beginCreate)
+      } else {
+        EncounterLibraryList(
+          definitions: store.definitions,
+          selection: $selection,
+          onRename: beginRename,
+          onDelete: beginDelete
+        )
+      }
     }
-
-    @ToolbarContentBuilder
-    private var toolbarContent: some ToolbarContent {
-        ToolbarItem(placement: .primaryAction) {
-            Button("New Encounter", systemImage: "plus", action: beginCreate)
-        }
-        ToolbarItem(placement: .secondaryAction) {
-            Button("Content Sources", systemImage: "archivebox") {
-                isShowingSources = true
-            }
-        }
+    .navigationTitle("Encounters")
+    .toolbar { toolbarContent }
+    // Create alert
+    .alert("New Encounter", isPresented: $isCreating) {
+      TextField("Encounter name", text: $newName)
+      Button("Create") { createEncounter() }
+      Button("Cancel", role: .cancel) { newName = "" }
     }
-
-    // MARK: - Actions
-
-    private func beginCreate() {
-        newName = ""
-        isCreating = true
+    // Rename alert — uses presenting: to avoid Binding(get:set:)
+    .alert("Rename Encounter", isPresented: $isRenaming, presenting: renameTarget) { _ in
+      TextField("Name", text: $renameText)
+      Button("Rename") { commitRename() }
+      Button("Cancel", role: .cancel) {}
     }
-
-    private func createEncounter() {
-        let name = newName.trimmingCharacters(in: .whitespaces)
-        let finalName = name.isEmpty ? "New Encounter" : name
-        newName = ""
-        Task {
-            do {
-                try await store.create(name: finalName)
-            } catch {
-                actionError = error.localizedDescription
-            }
-        }
+    // Delete confirmation — uses presenting: to avoid Binding(get:set:)
+    .confirmationDialog(
+      "Delete Encounter?",
+      isPresented: $isConfirmingDelete,
+      presenting: deleteTarget
+    ) { target in
+      Button("Delete \"\(target.name)\"", role: .destructive) { commitDelete() }
+      Button("Cancel", role: .cancel) {}
+    } message: { _ in
+      Text("This action cannot be undone.")
     }
-
-    private func beginRename(_ definition: EncounterDefinition) {
-        renameText = definition.name
-        renameTarget = definition
-        isRenaming = true
+    // Reset dismissed flag whenever a new distinct error appears, so fresh errors surface.
+    .onChange(of: store.loadError?.localizedDescription) { _, newDescription in
+      if newDescription != nil { loadErrorDismissed = false }
     }
-
-    private func commitRename() {
-        guard var target = renameTarget else { return }
-        let trimmed = renameText.trimmingCharacters(in: .whitespaces)
-        guard !trimmed.isEmpty else { return }
-        target.name = trimmed
-        renameTarget = nil
-        Task {
-            do {
-                try await store.save(target)
-            } catch {
-                actionError = error.localizedDescription
-            }
-        }
+    .sheet(isPresented: $isShowingSources) {
+      NavigationStack {
+        ContentSourcesView()
+      }
     }
-
-    private func beginDelete(_ definition: EncounterDefinition) {
-        deleteTarget = definition
-        isConfirmingDelete = true
+    // Error banners
+    .safeAreaInset(edge: .top) {
+      if let error = store.loadError, !loadErrorDismissed {
+        EncounterErrorBanner(
+          message: error.localizedDescription,
+          onDismiss: { loadErrorDismissed = true }
+        )
+      } else if let error = actionError {
+        EncounterErrorBanner(
+          message: error,
+          onDismiss: { actionError = nil }
+        )
+      }
     }
+  }
 
-    private func commitDelete() {
-        guard let target = deleteTarget else { return }
-        deleteTarget = nil
-        Task {
-            do {
-                try await store.delete(id: target.id)
-            } catch {
-                actionError = error.localizedDescription
-            }
-        }
+  @ToolbarContentBuilder
+  private var toolbarContent: some ToolbarContent {
+    ToolbarItem(placement: .primaryAction) {
+      Button("New Encounter", systemImage: "plus", action: beginCreate)
     }
+    ToolbarItem(placement: .secondaryAction) {
+      Button("Content Sources", systemImage: "archivebox") {
+        isShowingSources = true
+      }
+    }
+  }
+
+  // MARK: - Actions
+
+  private func beginCreate() {
+    newName = ""
+    isCreating = true
+  }
+
+  private func createEncounter() {
+    let name = newName.trimmingCharacters(in: .whitespaces)
+    let finalName = name.isEmpty ? "New Encounter" : name
+    newName = ""
+    Task {
+      do {
+        try await store.create(name: finalName)
+      } catch {
+        actionError = error.localizedDescription
+      }
+    }
+  }
+
+  private func beginRename(_ definition: EncounterDefinition) {
+    renameText = definition.name
+    renameTarget = definition
+    isRenaming = true
+  }
+
+  private func commitRename() {
+    guard var target = renameTarget else { return }
+    let trimmed = renameText.trimmingCharacters(in: .whitespaces)
+    guard !trimmed.isEmpty else { return }
+    target.name = trimmed
+    renameTarget = nil
+    Task {
+      do {
+        try await store.save(target)
+      } catch {
+        actionError = error.localizedDescription
+      }
+    }
+  }
+
+  private func beginDelete(_ definition: EncounterDefinition) {
+    deleteTarget = definition
+    isConfirmingDelete = true
+  }
+
+  private func commitDelete() {
+    guard let target = deleteTarget else { return }
+    deleteTarget = nil
+    Task {
+      do {
+        try await store.delete(id: target.id)
+      } catch {
+        actionError = error.localizedDescription
+      }
+    }
+  }
 }
 
 #Preview {
-    @Previewable @State var selection: EncounterDefinition.ID? = nil
-    NavigationStack {
-        EncounterLibraryView(selection: $selection)
-    }
-    .environment(EncounterStore(directory: .temporaryDirectory))
+  @Previewable @State var selection: EncounterDefinition.ID? = nil
+  NavigationStack {
+    EncounterLibraryView(selection: $selection)
+  }
+  .environment(EncounterStore(directory: .temporaryDirectory))
 }

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -14,83 +14,87 @@
 import SwiftUI
 
 struct EncounterRunnerView: View {
-    let session: EncounterSession
-    let definition: EncounterDefinition
+  let session: EncounterSession
+  let definition: EncounterDefinition
 
-    @Environment(Compendium.self) private var compendium
-    @Environment(SessionRegistry.self) private var sessionRegistry
-    @State private var expandedSlotID: UUID?
+  @Environment(Compendium.self) private var compendium
+  @Environment(SessionRegistry.self) private var sessionRegistry
+  @State private var expandedSlotID: UUID?
 
-    // MARK: - Sorted slots (computed, non-mutating)
-    // Active adversaries preserve original insertion order (stable sort).
-    // Defeated adversaries accumulate at the bottom in defeat order.
-    private var sortedAdversarySlots: [AdversarySlot] {
-        session.adversarySlots.sorted { !$0.isDefeated && $1.isDefeated }
+  // MARK: - Sorted slots (computed, non-mutating)
+  // Active adversaries preserve original insertion order (stable sort).
+  // Defeated adversaries accumulate at the bottom in defeat order.
+  private var sortedAdversarySlots: [AdversarySlot] {
+    session.adversarySlots.sorted { !$0.isDefeated && $1.isDefeated }
+  }
+
+  var body: some View {
+    List {
+      AdversaryRunnerSection(
+        slots: sortedAdversarySlots,
+        expandedSlotID: $expandedSlotID,
+        session: session,
+        compendium: compendium
+      )
     }
-
-    var body: some View {
-        List {
-            AdversaryRunnerSection(
-                slots: sortedAdversarySlots,
-                expandedSlotID: $expandedSlotID,
-                session: session,
-                compendium: compendium
-            )
+    .navigationTitle("\(session.name) · R\(session.currentRound)")
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.inline)
+    #endif
+    .toolbar {
+      ToolbarItem(placement: .primaryAction) {
+        FearTrackerButton(session: session)
+      }
+      ToolbarItem(placement: .secondaryAction) {
+        Button("Reset Session") {
+          sessionRegistry.resetSession(
+            for: definition.id,
+            definition: definition,
+            compendium: compendium
+          )
         }
-        .navigationTitle("\(session.name) · R\(session.currentRound)")
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.inline)
-        #endif
-        .toolbar {
-            ToolbarItem(placement: .primaryAction) {
-                FearTrackerButton(session: session)
-            }
-            ToolbarItem(placement: .secondaryAction) {
-                Button("Reset Session") {
-                    sessionRegistry.resetSession(
-                        for: definition.id,
-                        definition: definition,
-                        compendium: compendium
-                    )
-                }
-            }
-        }
-        .safeAreaInset(edge: .bottom) {
-            PlayerStrip(session: session)
-        }
+      }
     }
+    .safeAreaInset(edge: .bottom) {
+      PlayerStrip(session: session)
+    }
+  }
 }
 
 #Preview {
-    let compendium = Compendium()
-    compendium.addAdversary(Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
-        thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
-        attackModifier: "+2", attackName: "Rusty Blade",
-        attackRange: .veryClose, damage: "1d4 phy"
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, type: .minion,
+      description: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
     ))
-    compendium.addAdversary(Adversary(
-        id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
-        description: "Massive and relentless.", difficulty: 14,
-        thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
-        attackModifier: "+5", attackName: "Great Axe",
-        attackRange: .veryClose, damage: "2d10+4 phy"
+  compendium.addAdversary(
+    Adversary(
+      id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
+      description: "Massive and relentless.", difficulty: 14,
+      thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+      attackModifier: "+5", attackName: "Great Axe",
+      attackRange: .veryClose, damage: "2d10+4 phy"
     ))
-    let definition = EncounterDefinition(
-        name: "Goblin Ambush",
-        adversaryIDs: ["goblin", "goblin", "orc"],
-        playerConfigs: [
-            PlayerConfig(name: "Aric", maxHP: 6, maxStress: 6, evasion: 12,
-                         thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
-            PlayerConfig(name: "Lira", maxHP: 5, maxStress: 7, evasion: 14,
-                         thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
-        ]
-    )
-    let session = EncounterSession.start(from: definition, using: compendium)
-    return NavigationStack {
-        EncounterRunnerView(session: session, definition: definition)
-    }
-    .environment(compendium)
-    .environment(SessionRegistry())
+  let definition = EncounterDefinition(
+    name: "Goblin Ambush",
+    adversaryIDs: ["goblin", "goblin", "orc"],
+    playerConfigs: [
+      PlayerConfig(
+        name: "Aric", maxHP: 6, maxStress: 6, evasion: 12,
+        thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
+      PlayerConfig(
+        name: "Lira", maxHP: 5, maxStress: 7, evasion: 14,
+        thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
+    ]
+  )
+  let session = EncounterSession.start(from: definition, using: compendium)
+  return NavigationStack {
+    EncounterRunnerView(session: session, definition: definition)
+  }
+  .environment(compendium)
+  .environment(SessionRegistry())
 }

--- a/Encounter/Views/EnvironmentDetailView.swift
+++ b/Encounter/Views/EnvironmentDetailView.swift
@@ -9,67 +9,73 @@
 import SwiftUI
 
 struct EnvironmentDetailView: View {
-    let environment: DaggerheartEnvironment
-    let onSelect: ((DaggerheartEnvironment) -> Void)?
+  let environment: DaggerheartEnvironment
+  let onSelect: ((DaggerheartEnvironment) -> Void)?
 
-    @Environment(\.dismiss) private var dismiss
+  @Environment(\.dismiss) private var dismiss
 
-    init(environment: DaggerheartEnvironment, onSelect: ((DaggerheartEnvironment) -> Void)? = nil) {
-        self.environment = environment
-        self.onSelect = onSelect
-    }
+  init(environment: DaggerheartEnvironment, onSelect: ((DaggerheartEnvironment) -> Void)? = nil) {
+    self.environment = environment
+    self.onSelect = onSelect
+  }
 
-    var body: some View {
-        List {
-            // Identity
-            Section {
-                VStack(alignment: .leading, spacing: 6) {
-                    if environment.source != "srd" {
-                        Text(environment.source)
-                            .font(.caption2)
-                            .foregroundStyle(.white)
-                            .padding(.horizontal, 5)
-                            .padding(.vertical, 2)
-                            .background(.blue)
-                            .clipShape(.capsule)
-                    }
-                    Text(environment.description)
-                        .font(.subheadline)
-                        .foregroundStyle(.secondary)
-                }
-                .padding(.vertical, 4)
-            }
-
-            // Features grouped: passives → actions → reactions
-            FeatureSectionsView(features: environment.features)
+  var body: some View {
+    List {
+      // Identity
+      Section {
+        VStack(alignment: .leading, spacing: 6) {
+          if environment.source != "srd" {
+            Text(environment.source)
+              .font(.caption2)
+              .foregroundStyle(.white)
+              .padding(.horizontal, 5)
+              .padding(.vertical, 2)
+              .background(.blue)
+              .clipShape(.capsule)
+          }
+          Text(environment.description)
+            .font(.subheadline)
+            .foregroundStyle(.secondary)
         }
-        .navigationTitle(environment.name)
-        #if os(iOS)
-        .navigationBarTitleDisplayMode(.large)
-        #endif
-        .toolbar {
-            if let onSelect {
-                ToolbarItem(placement: .primaryAction) {
-                    Button("Add to Encounter") {
-                        onSelect(environment)
-                        dismiss()
-                    }
-                }
-            }
-        }
+        .padding(.vertical, 4)
+      }
+
+      // Features grouped: passives → actions → reactions
+      FeatureSectionsView(features: environment.features)
     }
+    .navigationTitle(environment.name)
+    #if os(iOS)
+      .navigationBarTitleDisplayMode(.large)
+    #endif
+    .toolbar {
+      if let onSelect {
+        ToolbarItem(placement: .primaryAction) {
+          Button("Add to Encounter") {
+            onSelect(environment)
+            dismiss()
+          }
+        }
+      }
+    }
+  }
 
 }
 
 #Preview {
-    NavigationStack {
-        EnvironmentDetailView(environment: DaggerheartEnvironment(
-            id: "collapsing-cavern",
-            name: "Collapsing Cavern",
-            description: "The ceiling threatens to fall with every heavy blow. Whenever a Severe hit is dealt, roll 1d6 — on a 1–3, a section collapses.",
-            features: [
-                AdversaryFeature(name: "Cave-In", text: "When a Severe hit is dealt, roll 1d6. On 1–3, creatures in the area make an Agility roll against DC 14 or take 2d8 physical damage.", featType: .reaction),
-            ]
-        ))
-    }
+  NavigationStack {
+    EnvironmentDetailView(
+      environment: DaggerheartEnvironment(
+        id: "collapsing-cavern",
+        name: "Collapsing Cavern",
+        description:
+          "The ceiling threatens to fall with every heavy blow. Whenever a Severe hit is dealt, roll 1d6 — on a 1–3, a section collapses.",
+        features: [
+          AdversaryFeature(
+            name: "Cave-In",
+            text:
+              "When a Severe hit is dealt, roll 1d6. On 1–3, creatures in the area make an Agility roll against DC 14 or take 2d8 physical damage.",
+            featType: .reaction)
+        ]
+      ))
+  }
 }

--- a/Encounter/Views/EnvironmentListView.swift
+++ b/Encounter/Views/EnvironmentListView.swift
@@ -9,38 +9,40 @@
 import SwiftUI
 
 struct EnvironmentListView: View {
-    let environments: [DaggerheartEnvironment]
+  let environments: [DaggerheartEnvironment]
 
-    var body: some View {
-        if environments.isEmpty {
-            ContentUnavailableView(
-                "No Environments",
-                systemImage: "magnifyingglass",
-                description: Text("Try a different search term.")
-            )
-        } else {
-            List(environments) { environment in
-                NavigationLink(value: environment) {
-                    EnvironmentRow(environment: environment)
-                }
-            }
+  var body: some View {
+    if environments.isEmpty {
+      ContentUnavailableView(
+        "No Environments",
+        systemImage: "magnifyingglass",
+        description: Text("Try a different search term.")
+      )
+    } else {
+      List(environments) { environment in
+        NavigationLink(value: environment) {
+          EnvironmentRow(environment: environment)
         }
+      }
     }
+  }
 }
 
 #Preview("With results") {
-    NavigationStack {
-        EnvironmentListView(environments: [
-            DaggerheartEnvironment(id: "collapsing-cavern", name: "Collapsing Cavern",
-                description: "The ceiling threatens to fall with every heavy blow."),
-            DaggerheartEnvironment(id: "burning-bridge", name: "Burning Bridge",
-                description: "The planks crumble underfoot as flames spread."),
-        ])
-    }
+  NavigationStack {
+    EnvironmentListView(environments: [
+      DaggerheartEnvironment(
+        id: "collapsing-cavern", name: "Collapsing Cavern",
+        description: "The ceiling threatens to fall with every heavy blow."),
+      DaggerheartEnvironment(
+        id: "burning-bridge", name: "Burning Bridge",
+        description: "The planks crumble underfoot as flames spread."),
+    ])
+  }
 }
 
 #Preview("Empty") {
-    NavigationStack {
-        EnvironmentListView(environments: [])
-    }
+  NavigationStack {
+    EnvironmentListView(environments: [])
+  }
 }

--- a/Encounter/Views/EnvironmentRow.swift
+++ b/Encounter/Views/EnvironmentRow.swift
@@ -8,37 +8,39 @@
 import SwiftUI
 
 struct EnvironmentRow: View {
-    let environment: DaggerheartEnvironment
+  let environment: DaggerheartEnvironment
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            HStack {
-                Text(environment.name)
-                    .font(.body)
-                if environment.isHomebrew {
-                    Text(environment.source)
-                        .font(.caption2)
-                        .foregroundStyle(.white)
-                        .padding(.horizontal, 5)
-                        .padding(.vertical, 2)
-                        .background(.blue)
-                        .clipShape(.capsule)
-                }
-            }
-            Text(environment.description)
-                .font(.caption)
-                .foregroundStyle(.secondary)
-                .lineLimit(1)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      HStack {
+        Text(environment.name)
+          .font(.body)
+        if environment.isHomebrew {
+          Text(environment.source)
+            .font(.caption2)
+            .foregroundStyle(.white)
+            .padding(.horizontal, 5)
+            .padding(.vertical, 2)
+            .background(.blue)
+            .clipShape(.capsule)
         }
-        .padding(.vertical, 2)
+      }
+      Text(environment.description)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .lineLimit(1)
     }
+    .padding(.vertical, 2)
+  }
 }
 
 #Preview {
-    EnvironmentRow(environment: DaggerheartEnvironment(
-        id: "collapsing-cavern",
-        name: "Collapsing Cavern",
-        description: "The ceiling threatens to fall with every heavy blow."
-    ))
-    .padding()
+  EnvironmentRow(
+    environment: DaggerheartEnvironment(
+      id: "collapsing-cavern",
+      name: "Collapsing Cavern",
+      description: "The ceiling threatens to fall with every heavy blow."
+    )
+  )
+  .padding()
 }

--- a/Encounter/Views/EnvironmentSection.swift
+++ b/Encounter/Views/EnvironmentSection.swift
@@ -10,78 +10,79 @@
 import SwiftUI
 
 struct EnvironmentSection: View {
-    let environmentIDs: [String]
-    let compendium: Compendium
-    let onBrowse: () -> Void
-    let onRemove: (IndexSet) -> Void
+  let environmentIDs: [String]
+  let compendium: Compendium
+  let onBrowse: () -> Void
+  let onRemove: (IndexSet) -> Void
 
-    var body: some View {
-        Section {
-            if environmentIDs.isEmpty {
-                Button {
-                    onBrowse()
-                } label: {
-                    Label("Add Environment", systemImage: "plus")
-                }
-            } else {
-                ForEach(environmentIDs.indices, id: \.self) { index in
-                    let environment = compendium.environment(id: environmentIDs[index])
-                    VStack(alignment: .leading, spacing: 2) {
-                        Text(environment?.name ?? "Unknown Environment")
-                            .font(.body)
-                        if let desc = environment?.description {
-                            Text(desc)
-                                .font(.caption)
-                                .foregroundStyle(.secondary)
-                                .lineLimit(2)
-                        } else {
-                            Text("ID: \(environmentIDs[index])")
-                                .font(.caption2)
-                                .foregroundStyle(.tertiary)
-                        }
-                    }
-                    .padding(.vertical, 2)
-                }
-                .onDelete(perform: onRemove)
-            }
-        } header: {
-            HStack {
-                Text("Environment")
-                Spacer()
-                if !environmentIDs.isEmpty {
-                    Button("Replace", systemImage: "arrow.triangle.2.circlepath", action: onBrowse)
-                        .buttonStyle(.borderless)
-                        .font(.caption)
-                        .labelStyle(.iconOnly)
-                }
-            }
+  var body: some View {
+    Section {
+      if environmentIDs.isEmpty {
+        Button {
+          onBrowse()
+        } label: {
+          Label("Add Environment", systemImage: "plus")
         }
+      } else {
+        ForEach(environmentIDs.indices, id: \.self) { index in
+          let environment = compendium.environment(id: environmentIDs[index])
+          VStack(alignment: .leading, spacing: 2) {
+            Text(environment?.name ?? "Unknown Environment")
+              .font(.body)
+            if let desc = environment?.description {
+              Text(desc)
+                .font(.caption)
+                .foregroundStyle(.secondary)
+                .lineLimit(2)
+            } else {
+              Text("ID: \(environmentIDs[index])")
+                .font(.caption2)
+                .foregroundStyle(.tertiary)
+            }
+          }
+          .padding(.vertical, 2)
+        }
+        .onDelete(perform: onRemove)
+      }
+    } header: {
+      HStack {
+        Text("Environment")
+        Spacer()
+        if !environmentIDs.isEmpty {
+          Button("Replace", systemImage: "arrow.triangle.2.circlepath", action: onBrowse)
+            .buttonStyle(.borderless)
+            .font(.caption)
+            .labelStyle(.iconOnly)
+        }
+      }
     }
+  }
 }
 
 #Preview("Empty") {
-    Form {
-        EnvironmentSection(
-            environmentIDs: [],
-            compendium: Compendium(),
-            onBrowse: {},
-            onRemove: { _ in }
-        )
-    }
+  Form {
+    EnvironmentSection(
+      environmentIDs: [],
+      compendium: Compendium(),
+      onBrowse: {},
+      onRemove: { _ in }
+    )
+  }
 }
 
 #Preview("With environment") {
-    let compendium = Compendium()
-    compendium.addEnvironment(DaggerheartEnvironment(
-        id: "collapsing-cavern", name: "Collapsing Cavern",
-        description: "The ceiling threatens to fall with every heavy blow."
+  let compendium = Compendium()
+  compendium.addEnvironment(
+    DaggerheartEnvironment(
+      id: "collapsing-cavern", name: "Collapsing Cavern",
+      description: "The ceiling threatens to fall with every heavy blow."
     ))
-    return Form {
-        EnvironmentSection(
-            environmentIDs: ["collapsing-cavern"],
-            compendium: compendium,
-            onBrowse: {},
-            onRemove: { _ in }
-        )
-    }
+  return Form {
+    EnvironmentSection(
+      environmentIDs: ["collapsing-cavern"],
+      compendium: compendium,
+      onBrowse: {},
+      onRemove: { _ in }
+    )
+  }
 }

--- a/Encounter/Views/FearTrackerButton.swift
+++ b/Encounter/Views/FearTrackerButton.swift
@@ -9,57 +9,57 @@
 import SwiftUI
 
 struct FearTrackerButton: View {
-    let session: EncounterSession
-    @State private var showPopover = false
+  let session: EncounterSession
+  @State private var showPopover = false
 
-    var body: some View {
-        Button {
-            showPopover.toggle()
-        } label: {
-            Label("\(session.fearPool)", systemImage: "flame.fill")
-                .monospacedDigit()
-        }
-        .tint(.orange)
-        .popover(isPresented: $showPopover) {
-            VStack(spacing: 12) {
-                Text("Fear")
-                    .font(.headline)
-                Text("\(session.fearPool)")
-                    .font(.largeTitle)
-                    .fontWeight(.bold)
-                    .monospacedDigit()
-                    .foregroundStyle(.orange)
-                HStack(spacing: 8) {
-                    Button("+1") { session.incrementFear(by: 1) }
-                        .buttonStyle(.bordered)
-                    Button("−1") { session.spendFear(1) }
-                        .buttonStyle(.bordered)
-                        .disabled(session.fearPool < 1)
-                    Button("−2") { session.spendFear(2) }
-                        .buttonStyle(.bordered)
-                        .disabled(session.fearPool < 2)
-                    Button("−3") { session.spendFear(3) }
-                        .buttonStyle(.bordered)
-                        .disabled(session.fearPool < 3)
-                }
-            }
-            .padding()
-            .frame(minWidth: 180)
-            .presentationCompactAdaptation(.popover)
-        }
+  var body: some View {
+    Button {
+      showPopover.toggle()
+    } label: {
+      Label("\(session.fearPool)", systemImage: "flame.fill")
+        .monospacedDigit()
     }
+    .tint(.orange)
+    .popover(isPresented: $showPopover) {
+      VStack(spacing: 12) {
+        Text("Fear")
+          .font(.headline)
+        Text("\(session.fearPool)")
+          .font(.largeTitle)
+          .fontWeight(.bold)
+          .monospacedDigit()
+          .foregroundStyle(.orange)
+        HStack(spacing: 8) {
+          Button("+1") { session.incrementFear(by: 1) }
+            .buttonStyle(.bordered)
+          Button("−1") { session.spendFear(1) }
+            .buttonStyle(.bordered)
+            .disabled(session.fearPool < 1)
+          Button("−2") { session.spendFear(2) }
+            .buttonStyle(.bordered)
+            .disabled(session.fearPool < 2)
+          Button("−3") { session.spendFear(3) }
+            .buttonStyle(.bordered)
+            .disabled(session.fearPool < 3)
+        }
+      }
+      .padding()
+      .frame(minWidth: 180)
+      .presentationCompactAdaptation(.popover)
+    }
+  }
 }
 
 #Preview {
-    let compendium = Compendium()
-    let session = EncounterSession(name: "Test", fearPool: 3)
-    return NavigationStack {
-        Text("Runner")
-            .toolbar {
-                ToolbarItem(placement: .primaryAction) {
-                    FearTrackerButton(session: session)
-                }
-            }
-    }
-    .environment(compendium)
+  let compendium = Compendium()
+  let session = EncounterSession(name: "Test", fearPool: 3)
+  return NavigationStack {
+    Text("Runner")
+      .toolbar {
+        ToolbarItem(placement: .primaryAction) {
+          FearTrackerButton(session: session)
+        }
+      }
+  }
+  .environment(compendium)
 }

--- a/Encounter/Views/FeatureSectionsView.swift
+++ b/Encounter/Views/FeatureSectionsView.swift
@@ -13,27 +13,27 @@ import SwiftUI
 /// Sections are shown only if at least one feature of that type exists.
 /// Intended for use inside a `List`.
 struct FeatureSectionsView: View {
-    let features: [AdversaryFeature]
+  let features: [AdversaryFeature]
 
-    var body: some View {
-        let passives  = features.filter { $0.featType == .passive }
-        let actions   = features.filter { $0.featType == .action }
-        let reactions = features.filter { $0.featType == .reaction }
+  var body: some View {
+    let passives = features.filter { $0.featType == .passive }
+    let actions = features.filter { $0.featType == .action }
+    let reactions = features.filter { $0.featType == .reaction }
 
-        if !passives.isEmpty {
-            Section("Passives") {
-                ForEach(passives) { AdversaryFeatureRow(feature: $0) }
-            }
-        }
-        if !actions.isEmpty {
-            Section("Actions") {
-                ForEach(actions) { AdversaryFeatureRow(feature: $0) }
-            }
-        }
-        if !reactions.isEmpty {
-            Section("Reactions") {
-                ForEach(reactions) { AdversaryFeatureRow(feature: $0) }
-            }
-        }
+    if !passives.isEmpty {
+      Section("Passives") {
+        ForEach(passives) { AdversaryFeatureRow(feature: $0) }
+      }
     }
+    if !actions.isEmpty {
+      Section("Actions") {
+        ForEach(actions) { AdversaryFeatureRow(feature: $0) }
+      }
+    }
+    if !reactions.isEmpty {
+      Section("Reactions") {
+        ForEach(reactions) { AdversaryFeatureRow(feature: $0) }
+      }
+    }
+  }
 }

--- a/Encounter/Views/LastFetchedLabel.swift
+++ b/Encounter/Views/LastFetchedLabel.swift
@@ -8,17 +8,17 @@
 import SwiftUI
 
 struct LastFetchedLabel: View {
-    let lastFetched: Date?
+  let lastFetched: Date?
 
-    var body: some View {
-        if let date = lastFetched {
-            Text("Last updated \(Text(date, style: .relative)) ago")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-        } else {
-            Text("Never updated")
-                .font(.caption2)
-                .foregroundStyle(.secondary)
-        }
+  var body: some View {
+    if let date = lastFetched {
+      Text("Last updated \(Text(date, style: .relative)) ago")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    } else {
+      Text("Never updated")
+        .font(.caption2)
+        .foregroundStyle(.secondary)
     }
+  }
 }

--- a/Encounter/Views/PipTrack.swift
+++ b/Encounter/Views/PipTrack.swift
@@ -13,47 +13,47 @@
 import SwiftUI
 
 struct PipTrack: View {
-    let current: Int
-    let maximum: Int
+  let current: Int
+  let maximum: Int
 
-    private let pipThreshold = 10
+  private let pipThreshold = 10
 
-    var body: some View {
-        if maximum > pipThreshold {
-            Text("\(current)/\(maximum)")
-                .font(.caption)
-                .monospacedDigit()
-                .foregroundStyle(current == 0 ? .red : .primary)
-        } else {
-            HStack(spacing: 3) {
-                ForEach(0 ..< max(maximum, 0), id: \.self) { i in
-                    Image(systemName: i < current ? "circle.fill" : "circle")
-                        .font(.system(size: 8))
-                        .foregroundStyle(i < current ? pipColor : .secondary.opacity(0.4))
-                        .accessibilityHidden(true)
-                }
-            }
-            .accessibilityLabel(Text("\(current) of \(maximum)"))
-            .accessibilityHidden(maximum == 0)
+  var body: some View {
+    if maximum > pipThreshold {
+      Text("\(current)/\(maximum)")
+        .font(.caption)
+        .monospacedDigit()
+        .foregroundStyle(current == 0 ? .red : .primary)
+    } else {
+      HStack(spacing: 3) {
+        ForEach(0..<max(maximum, 0), id: \.self) { i in
+          Image(systemName: i < current ? "circle.fill" : "circle")
+            .font(.system(size: 8))
+            .foregroundStyle(i < current ? pipColor : .secondary.opacity(0.4))
+            .accessibilityHidden(true)
         }
+      }
+      .accessibilityLabel(Text("\(current) of \(maximum)"))
+      .accessibilityHidden(maximum == 0)
     }
+  }
 
-    private var pipColor: Color {
-        guard maximum > 0 else { return .primary }
-        let ratio = Double(current) / Double(maximum)
-        if ratio > 0.66 { return .primary }
-        if ratio > 0.33 { return .orange }
-        return .red
-    }
+  private var pipColor: Color {
+    guard maximum > 0 else { return .primary }
+    let ratio = Double(current) / Double(maximum)
+    if ratio > 0.66 { return .primary }
+    if ratio > 0.33 { return .orange }
+    return .red
+  }
 }
 
 #Preview {
-    VStack(alignment: .leading, spacing: 8) {
-        PipTrack(current: 5, maximum: 5)
-        PipTrack(current: 3, maximum: 5)
-        PipTrack(current: 1, maximum: 5)
-        PipTrack(current: 0, maximum: 5)
-        PipTrack(current: 8, maximum: 12)   // text fallback
-    }
-    .padding()
+  VStack(alignment: .leading, spacing: 8) {
+    PipTrack(current: 5, maximum: 5)
+    PipTrack(current: 3, maximum: 5)
+    PipTrack(current: 1, maximum: 5)
+    PipTrack(current: 0, maximum: 5)
+    PipTrack(current: 8, maximum: 12)  // text fallback
+  }
+  .padding()
 }

--- a/Encounter/Views/PlayerEditPopover.swift
+++ b/Encounter/Views/PlayerEditPopover.swift
@@ -9,86 +9,87 @@
 import SwiftUI
 
 struct PlayerEditPopover: View {
-    let player: PlayerSlot
-    let session: EncounterSession
+  let player: PlayerSlot
+  let session: EncounterSession
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 16) {
-            Text(player.name)
-                .font(.headline)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 16) {
+      Text(player.name)
+        .font(.headline)
 
-            statRow(
-                label: "HP",
-                current: player.currentHP,
-                maximum: player.maxHP,
-                onDecrement: { session.applyPlayerDamage(1, to: player.id) },
-                onIncrement: { session.healPlayer(1, slotID: player.id) }
-            )
+      statRow(
+        label: "HP",
+        current: player.currentHP,
+        maximum: player.maxHP,
+        onDecrement: { session.applyPlayerDamage(1, to: player.id) },
+        onIncrement: { session.healPlayer(1, slotID: player.id) }
+      )
 
-            statRow(
-                label: "Stress",
-                current: player.currentStress,
-                maximum: player.maxStress,
-                onDecrement: { session.clearPlayerStress(1, slotID: player.id) },
-                onIncrement: { session.applyPlayerStress(1, to: player.id) }
-            )
+      statRow(
+        label: "Stress",
+        current: player.currentStress,
+        maximum: player.maxStress,
+        onDecrement: { session.clearPlayerStress(1, slotID: player.id) },
+        onIncrement: { session.applyPlayerStress(1, to: player.id) }
+      )
 
-            if player.armorSlots > 0 {
-                statRow(
-                    label: "Armor",
-                    current: player.currentArmorSlots,
-                    maximum: player.armorSlots,
-                    onDecrement: { session.markPlayerArmorSlot(player.id) },
-                    onIncrement: { session.restorePlayerArmorSlot(player.id) }
-                )
-            }
-        }
-        .padding()
-        .frame(minWidth: 220)
+      if player.armorSlots > 0 {
+        statRow(
+          label: "Armor",
+          current: player.currentArmorSlots,
+          maximum: player.armorSlots,
+          onDecrement: { session.markPlayerArmorSlot(player.id) },
+          onIncrement: { session.restorePlayerArmorSlot(player.id) }
+        )
+      }
     }
+    .padding()
+    .frame(minWidth: 220)
+  }
 
-    @ViewBuilder
-    private func statRow(
-        label: String,
-        current: Int,
-        maximum: Int,
-        onDecrement: @escaping () -> Void,
-        onIncrement: @escaping () -> Void
-    ) -> some View {
-        HStack {
-            Text(label)
-                .font(.subheadline)
-                .frame(minWidth: 60, alignment: .leading)
-            Spacer()
-            Button("Decrease \(label)", systemImage: "minus.circle", action: onDecrement)
-                .labelStyle(.iconOnly)
-                .font(.title3)
-                .buttonStyle(.borderless)
-                .disabled(current <= 0)
+  @ViewBuilder
+  private func statRow(
+    label: String,
+    current: Int,
+    maximum: Int,
+    onDecrement: @escaping () -> Void,
+    onIncrement: @escaping () -> Void
+  ) -> some View {
+    HStack {
+      Text(label)
+        .font(.subheadline)
+        .frame(minWidth: 60, alignment: .leading)
+      Spacer()
+      Button("Decrease \(label)", systemImage: "minus.circle", action: onDecrement)
+        .labelStyle(.iconOnly)
+        .font(.title3)
+        .buttonStyle(.borderless)
+        .disabled(current <= 0)
 
-            Text("\(current) / \(maximum)")
-                .font(.body)
-                .monospacedDigit()
-                .frame(minWidth: 64, alignment: .center)
+      Text("\(current) / \(maximum)")
+        .font(.body)
+        .monospacedDigit()
+        .frame(minWidth: 64, alignment: .center)
 
-            Button("Increase \(label)", systemImage: "plus.circle", action: onIncrement)
-                .labelStyle(.iconOnly)
-                .font(.title3)
-                .buttonStyle(.borderless)
-                .disabled(current >= maximum)
-        }
+      Button("Increase \(label)", systemImage: "plus.circle", action: onIncrement)
+        .labelStyle(.iconOnly)
+        .font(.title3)
+        .buttonStyle(.borderless)
+        .disabled(current >= maximum)
     }
+  }
 }
 
 #Preview {
-    let session = EncounterSession(name: "Test")
-    session.addPlayer(PlayerSlot(
-        name: "Aric Stonehammer",
-        maxHP: 6, maxStress: 6, evasion: 12,
-        thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3
+  let session = EncounterSession(name: "Test")
+  session.addPlayer(
+    PlayerSlot(
+      name: "Aric Stonehammer",
+      maxHP: 6, maxStress: 6, evasion: 12,
+      thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3
     ))
-    return PlayerEditPopover(
-        player: session.playerSlots[0],
-        session: session
-    )
+  return PlayerEditPopover(
+    player: session.playerSlots[0],
+    session: session
+  )
 }

--- a/Encounter/Views/PlayerRosterRow.swift
+++ b/Encounter/Views/PlayerRosterRow.swift
@@ -9,31 +9,33 @@
 import SwiftUI
 
 struct PlayerRosterRow: View {
-    let config: PlayerConfig
+  let config: PlayerConfig
 
-    var body: some View {
-        VStack(alignment: .leading, spacing: 2) {
-            Text(config.name)
-                .font(.body)
-            Text("HP: \(config.maxHP)  Stress: \(config.maxStress)  Evasion: \(config.evasion)")
-                .font(.caption)
-                .foregroundStyle(.secondary)
-        }
-        .padding(.vertical, 2)
+  var body: some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(config.name)
+        .font(.body)
+      Text("HP: \(config.maxHP)  Stress: \(config.maxStress)  Evasion: \(config.evasion)")
+        .font(.caption)
+        .foregroundStyle(.secondary)
     }
+    .padding(.vertical, 2)
+  }
 }
 
 #Preview {
-    List {
-        PlayerRosterRow(config: PlayerConfig(
-            name: "Aric Stonehammer",
-            maxHP: 6, maxStress: 6, evasion: 12,
-            thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3
-        ))
-        PlayerRosterRow(config: PlayerConfig(
-            name: "Lira Dawnwhisper",
-            maxHP: 5, maxStress: 7, evasion: 14,
-            thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2
-        ))
-    }
+  List {
+    PlayerRosterRow(
+      config: PlayerConfig(
+        name: "Aric Stonehammer",
+        maxHP: 6, maxStress: 6, evasion: 12,
+        thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3
+      ))
+    PlayerRosterRow(
+      config: PlayerConfig(
+        name: "Lira Dawnwhisper",
+        maxHP: 5, maxStress: 7, evasion: 14,
+        thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2
+      ))
+  }
 }

--- a/Encounter/Views/PlayerRosterSection.swift
+++ b/Encounter/Views/PlayerRosterSection.swift
@@ -10,56 +10,58 @@
 import SwiftUI
 
 struct PlayerRosterSection: View {
-    let playerConfigs: [PlayerConfig]
-    let onAddPlayer: () -> Void
-    let onRemove: (IndexSet) -> Void
+  let playerConfigs: [PlayerConfig]
+  let onAddPlayer: () -> Void
+  let onRemove: (IndexSet) -> Void
 
-    var body: some View {
-        Section {
-            ForEach(playerConfigs) { config in
-                PlayerRosterRow(config: config)
-            }
-            .onDelete(perform: onRemove)
-        } header: {
-            HStack {
-                Text("Players")
-                Spacer()
-                Button("Add Player", systemImage: "person.badge.plus", action: onAddPlayer)
-                    .buttonStyle(.borderless)
-                    .font(.caption)
-                    .labelStyle(.iconOnly)
-            }
-        } footer: {
-            if playerConfigs.isEmpty {
-                Text("Add players to calculate an accurate difficulty budget.")
-                    .font(.caption)
-                    .foregroundStyle(.secondary)
-            }
-        }
+  var body: some View {
+    Section {
+      ForEach(playerConfigs) { config in
+        PlayerRosterRow(config: config)
+      }
+      .onDelete(perform: onRemove)
+    } header: {
+      HStack {
+        Text("Players")
+        Spacer()
+        Button("Add Player", systemImage: "person.badge.plus", action: onAddPlayer)
+          .buttonStyle(.borderless)
+          .font(.caption)
+          .labelStyle(.iconOnly)
+      }
+    } footer: {
+      if playerConfigs.isEmpty {
+        Text("Add players to calculate an accurate difficulty budget.")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
     }
+  }
 }
 
 #Preview("Empty") {
-    Form {
-        PlayerRosterSection(
-            playerConfigs: [],
-            onAddPlayer: {},
-            onRemove: { _ in }
-        )
-    }
+  Form {
+    PlayerRosterSection(
+      playerConfigs: [],
+      onAddPlayer: {},
+      onRemove: { _ in }
+    )
+  }
 }
 
 #Preview("With players") {
-    Form {
-        PlayerRosterSection(
-            playerConfigs: [
-                PlayerConfig(name: "Aric", maxHP: 6, maxStress: 6, evasion: 12,
-                             thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
-                PlayerConfig(name: "Lira", maxHP: 5, maxStress: 7, evasion: 14,
-                             thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
-            ],
-            onAddPlayer: {},
-            onRemove: { _ in }
-        )
-    }
+  Form {
+    PlayerRosterSection(
+      playerConfigs: [
+        PlayerConfig(
+          name: "Aric", maxHP: 6, maxStress: 6, evasion: 12,
+          thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
+        PlayerConfig(
+          name: "Lira", maxHP: 5, maxStress: 7, evasion: 14,
+          thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
+      ],
+      onAddPlayer: {},
+      onRemove: { _ in }
+    )
+  }
 }

--- a/Encounter/Views/PlayerStrip.swift
+++ b/Encounter/Views/PlayerStrip.swift
@@ -9,37 +9,39 @@
 import SwiftUI
 
 struct PlayerStrip: View {
-    let session: EncounterSession
+  let session: EncounterSession
 
-    var body: some View {
-        VStack(spacing: 0) {
-            Divider()
-            VStack(spacing: 4) {
-                ForEach(session.playerSlots) { player in
-                    PlayerStripRow(player: player, session: session)
-                }
-            }
-            .padding(.horizontal)
-            .padding(.vertical, 6)
-            .background(.regularMaterial)
+  var body: some View {
+    VStack(spacing: 0) {
+      Divider()
+      VStack(spacing: 4) {
+        ForEach(session.playerSlots) { player in
+          PlayerStripRow(player: player, session: session)
         }
+      }
+      .padding(.horizontal)
+      .padding(.vertical, 6)
+      .background(.regularMaterial)
     }
+  }
 }
 
 #Preview {
-    let session = EncounterSession(
-        name: "Goblin Ambush",
-        playerSlots: [
-            PlayerSlot(name: "Aric Stonehammer",
-                       maxHP: 6, maxStress: 6, evasion: 12,
-                       thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
-            PlayerSlot(name: "Lira Dawnwhisper",
-                       maxHP: 5, currentHP: 3, maxStress: 7, currentStress: 2,
-                       evasion: 14, thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
-        ]
-    )
-    VStack {
-        Spacer()
-        PlayerStrip(session: session)
-    }
+  let session = EncounterSession(
+    name: "Goblin Ambush",
+    playerSlots: [
+      PlayerSlot(
+        name: "Aric Stonehammer",
+        maxHP: 6, maxStress: 6, evasion: 12,
+        thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
+      PlayerSlot(
+        name: "Lira Dawnwhisper",
+        maxHP: 5, currentHP: 3, maxStress: 7, currentStress: 2,
+        evasion: 14, thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
+    ]
+  )
+  VStack {
+    Spacer()
+    PlayerStrip(session: session)
+  }
 }

--- a/Encounter/Views/PlayerStripRow.swift
+++ b/Encounter/Views/PlayerStripRow.swift
@@ -10,74 +10,76 @@
 import SwiftUI
 
 struct PlayerStripRow: View {
-    let player: PlayerSlot
-    let session: EncounterSession
-    @State private var showPopover = false
+  let player: PlayerSlot
+  let session: EncounterSession
+  @State private var showPopover = false
 
-    var body: some View {
-        Button {
-            showPopover = true
-        } label: {
-            HStack(spacing: 8) {
-                Text(player.name)
-                    .font(.caption)
-                    .fontWeight(.medium)
-                    .frame(minWidth: 60, alignment: .leading)
-                    .lineLimit(1)
-                    .truncationMode(.tail)
+  var body: some View {
+    Button {
+      showPopover = true
+    } label: {
+      HStack(spacing: 8) {
+        Text(player.name)
+          .font(.caption)
+          .fontWeight(.medium)
+          .frame(minWidth: 60, alignment: .leading)
+          .lineLimit(1)
+          .truncationMode(.tail)
 
-                Spacer()
+        Spacer()
 
-                HStack(spacing: 4) {
-                    Text("HP")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    PipTrack(current: player.currentHP, maximum: player.maxHP)
-                }
-
-                HStack(spacing: 4) {
-                    Text("St")
-                        .font(.caption2)
-                        .foregroundStyle(.secondary)
-                    PipTrack(current: player.currentStress, maximum: player.maxStress)
-                }
-
-                if player.armorSlots > 0 {
-                    HStack(spacing: 4) {
-                        Text("Arm")
-                            .font(.caption2)
-                            .foregroundStyle(.secondary)
-                        Text("\(player.currentArmorSlots)/\(player.armorSlots)")
-                            .font(.caption)
-                            .monospacedDigit()
-                    }
-                }
-            }
-            .foregroundStyle(.primary)
+        HStack(spacing: 4) {
+          Text("HP")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+          PipTrack(current: player.currentHP, maximum: player.maxHP)
         }
-        .buttonStyle(.plain)
-        .popover(isPresented: $showPopover) {
-            PlayerEditPopover(player: player, session: session)
-                .presentationCompactAdaptation(.popover)
+
+        HStack(spacing: 4) {
+          Text("St")
+            .font(.caption2)
+            .foregroundStyle(.secondary)
+          PipTrack(current: player.currentStress, maximum: player.maxStress)
         }
+
+        if player.armorSlots > 0 {
+          HStack(spacing: 4) {
+            Text("Arm")
+              .font(.caption2)
+              .foregroundStyle(.secondary)
+            Text("\(player.currentArmorSlots)/\(player.armorSlots)")
+              .font(.caption)
+              .monospacedDigit()
+          }
+        }
+      }
+      .foregroundStyle(.primary)
     }
+    .buttonStyle(.plain)
+    .popover(isPresented: $showPopover) {
+      PlayerEditPopover(player: player, session: session)
+        .presentationCompactAdaptation(.popover)
+    }
+  }
 }
 
 #Preview {
-    let session = EncounterSession(
-        name: "Test",
-        playerSlots: [
-            PlayerSlot(name: "Aric Stonehammer",
-                       maxHP: 6, maxStress: 6, evasion: 12,
-                       thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
-            PlayerSlot(name: "Lira Dawnwhisper",
-                       maxHP: 5, currentHP: 3, maxStress: 7, currentStress: 2,
-                       evasion: 14, thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
-        ]
-    )
-    List {
-        ForEach(session.playerSlots) { player in
-            PlayerStripRow(player: player, session: session)
-        }
+  let session = EncounterSession(
+    name: "Test",
+    playerSlots: [
+      PlayerSlot(
+        name: "Aric Stonehammer",
+        maxHP: 6, maxStress: 6, evasion: 12,
+        thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3),
+      PlayerSlot(
+        name: "Lira Dawnwhisper",
+        maxHP: 5, currentHP: 3, maxStress: 7, currentStress: 2,
+        evasion: 14, thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
+    ]
+  )
+  List {
+    ForEach(session.playerSlots) { player in
+      PlayerStripRow(player: player, session: session)
     }
+  }
 }

--- a/Encounter/Views/ThresholdButton.swift
+++ b/Encounter/Views/ThresholdButton.swift
@@ -13,28 +13,28 @@ import SwiftUI
 /// Displays the hit label and the damage range subtitle, and is disabled
 /// when the slot is already defeated.
 struct ThresholdButton: View {
-    let label: String
-    let subtitle: String
-    let marks: Int
-    let isDefeated: Bool
-    let session: EncounterSession
-    let slotID: UUID
+  let label: String
+  let subtitle: String
+  let marks: Int
+  let isDefeated: Bool
+  let session: EncounterSession
+  let slotID: UUID
 
-    var body: some View {
-        Button {
-            session.applyDamage(marks, to: slotID)
-        } label: {
-            VStack(spacing: 2) {
-                Text(label)
-                    .font(.subheadline)
-                    .bold()
-                Text(subtitle)
-                    .font(.caption2)
-                    .foregroundStyle(.secondary)
-            }
-            .frame(maxWidth: .infinity)
-        }
-        .buttonStyle(.bordered)
-        .disabled(isDefeated)
+  var body: some View {
+    Button {
+      session.applyDamage(marks, to: slotID)
+    } label: {
+      VStack(spacing: 2) {
+        Text(label)
+          .font(.subheadline)
+          .bold()
+        Text(subtitle)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
+      }
+      .frame(maxWidth: .infinity)
     }
+    .buttonStyle(.bordered)
+    .disabled(isDefeated)
+  }
 }

--- a/Encounter/Views/TypeBadgeView.swift
+++ b/Encounter/Views/TypeBadgeView.swift
@@ -9,24 +9,24 @@ import SwiftUI
 
 /// A small capsule badge displaying an adversary's role type.
 struct TypeBadgeView: View {
-    let type: AdversaryType
+  let type: AdversaryType
 
-    var body: some View {
-        Text(type.rawValue)
-            .font(.caption)
-            .foregroundStyle(.secondary)
-            .padding(.horizontal, 6)
-            .padding(.vertical, 2)
-            .background(.secondary.opacity(0.15))
-            .clipShape(.capsule)
-    }
+  var body: some View {
+    Text(type.rawValue)
+      .font(.caption)
+      .foregroundStyle(.secondary)
+      .padding(.horizontal, 6)
+      .padding(.vertical, 2)
+      .background(.secondary.opacity(0.15))
+      .clipShape(.capsule)
+  }
 }
 
 #Preview {
-    HStack {
-        TypeBadgeView(type: .minion)
-        TypeBadgeView(type: .solo)
-        TypeBadgeView(type: .bruiser)
-    }
-    .padding()
+  HStack {
+    TypeBadgeView(type: .minion)
+    TypeBadgeView(type: .solo)
+    TypeBadgeView(type: .bruiser)
+  }
+  .padding()
 }


### PR DESCRIPTION
## Summary

- Runs `swift-format format --recursive --in-place Encounter/` with no functional changes
- Pure reformatting: indentation, line breaks, trailing whitespace — no logic or content changes
- Lands this separately so that the accessibility identifier PR (#55) has a clean, readable diff

## Test plan

- [x] macOS build succeeds
- [x] Full unit test suite passes (no functional changes)

Merge this before #55.