### PR TITLE
feat: DPCGL attribution, DHModels/DHKit package rename, and API migration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -32,18 +32,22 @@ Encounter/
 └── CLAUDE.md                   # This file
 ```
 
-### DaggerheartModels package (gwillish/DaggerheartModels)
+### DHModels package (gwillish/DHModels)
+
+The package repo was formerly named `gwillish/DaggerheartModels`. It was renamed to
+`DHModels`/`DHKit` to avoid using the DAGGERHEART Name Mark (DPCGL §2.5) in a
+title-like position.
 
 The app imports two products from this package:
 
 | Product | Import | Contents |
 |---|---|---|
-| **DaggerheartModels** | `import DaggerheartModels` | Value types: `Adversary`, `DaggerheartEnvironment`, `EncounterDefinition`, `PlayerSlot`, `DHPackContent`, `ContentSource`, `ContentFingerprint`, `ContentStoreError`, `DifficultyBudget`, `Condition` |
-| **DaggerheartKit** | `import DaggerheartKit` | `@Observable` stores: `Compendium`, `EncounterStore`, `EncounterSession`, `SessionRegistry`; also re-depends on DaggerheartModels |
+| **DHModels** | `import DHModels` | Value types: `Adversary`, `DaggerheartEnvironment`, `EncounterDefinition`, `PlayerSlot`, `DHPackContent`, `ContentSource`, `ContentFingerprint`, `ContentStoreError`, `DifficultyBudget`, `Condition` |
+| **DHKit** | `import DHKit` | `@Observable` stores: `Compendium`, `EncounterStore`, `EncounterSession`, `SessionRegistry`; also re-depends on DHModels |
 
-**Import rule:** Any file that references value types needs `import DaggerheartModels`; any file
-that uses the observable stores needs `import DaggerheartKit`. With `MemberImportVisibility`
-active, both must be explicit — `import DaggerheartKit` alone does not expose DaggerheartModels types.
+**Import rule:** Any file that references value types needs `import DHModels`; any file
+that uses the observable stores needs `import DHKit`. With `MemberImportVisibility`
+active, both must be explicit — `import DHKit` alone does not expose DHModels types.
 
 **Important:** The Xcode project uses `PBXFileSystemSynchronizedRootGroup` (Xcode 16+).
 Any `.swift` file added to `Encounter/` or its subdirectories is **automatically included**
@@ -92,7 +96,7 @@ can resolve `adversaryID` slugs to full `Adversary` structs when needed. Defined
 
 ```swift
 // EncounterApp.swift
-import DaggerheartKit
+import DHKit
 
 @State private var compendium = Compendium()
 @State private var store = EncounterStore(directory: EncounterStore.localDirectory)
@@ -107,8 +111,8 @@ WindowGroup {
 }
 
 // In a view:
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 
 @Environment(Compendium.self) var compendium
 ```

--- a/Encounter.xcodeproj/project.pbxproj
+++ b/Encounter.xcodeproj/project.pbxproj
@@ -10,8 +10,8 @@
 		1AD61A3B2F74D3F900296F39 /* InMemoryLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 1AD61A3A2F74D3F900296F39 /* InMemoryLogging */; };
 		1AD61A3D2F74D3F900296F39 /* Logging in Frameworks */ = {isa = PBXBuildFile; productRef = 1AD61A3C2F74D3F900296F39 /* Logging */; };
 		1AD61A402F74D40B00296F39 /* OSLogging in Frameworks */ = {isa = PBXBuildFile; productRef = 1AD61A3F2F74D40B00296F39 /* OSLogging */; };
-		5B67DAEC49BC4CA58D0F68CB /* DaggerheartKit in Frameworks */ = {isa = PBXBuildFile; productRef = 696E5A197EC643C8822586E5 /* DaggerheartKit */; };
-		720CFEA27FDB4C618D811F30 /* DaggerheartModels in Frameworks */ = {isa = PBXBuildFile; productRef = 372D78F7B37E42698659576B /* DaggerheartModels */; };
+		5B67DAEC49BC4CA58D0F68CB /* DHKit in Frameworks */ = {isa = PBXBuildFile; productRef = 696E5A197EC643C8822586E5 /* DHKit */; };
+		720CFEA27FDB4C618D811F30 /* DHModels in Frameworks */ = {isa = PBXBuildFile; productRef = 372D78F7B37E42698659576B /* DHModels */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -76,8 +76,8 @@
 				1AD61A402F74D40B00296F39 /* OSLogging in Frameworks */,
 				1AD61A3D2F74D3F900296F39 /* Logging in Frameworks */,
 				1AD61A3B2F74D3F900296F39 /* InMemoryLogging in Frameworks */,
-				720CFEA27FDB4C618D811F30 /* DaggerheartModels in Frameworks */,
-				5B67DAEC49BC4CA58D0F68CB /* DaggerheartKit in Frameworks */,
+				720CFEA27FDB4C618D811F30 /* DHModels in Frameworks */,
+				5B67DAEC49BC4CA58D0F68CB /* DHKit in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -141,8 +141,8 @@
 				1AD61A3A2F74D3F900296F39 /* InMemoryLogging */,
 				1AD61A3C2F74D3F900296F39 /* Logging */,
 				1AD61A3F2F74D40B00296F39 /* OSLogging */,
-				372D78F7B37E42698659576B /* DaggerheartModels */,
-				696E5A197EC643C8822586E5 /* DaggerheartKit */,
+				372D78F7B37E42698659576B /* DHModels */,
+				696E5A197EC643C8822586E5 /* DHKit */,
 			);
 			productName = Encounter;
 			productReference = 1A8F7B9A2F660D3800548E3A /* Encounter.app */;
@@ -234,7 +234,7 @@
 			packageReferences = (
 				1AD61A392F74D3F900296F39 /* XCRemoteSwiftPackageReference "swift-log" */,
 				1AD61A3E2F74D40B00296F39 /* XCRemoteSwiftPackageReference "swift-oslog" */,
-				6E36C5CB9EA54972BB735840 /* XCRemoteSwiftPackageReference "DaggerheartModels" */,
+				6E36C5CB9EA54972BB735840 /* XCRemoteSwiftPackageReference "DHModels" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 1A8F7B9B2F660D3800548E3A /* Products */;
@@ -680,9 +680,9 @@
 				minimumVersion = 1.0.0;
 			};
 		};
-		6E36C5CB9EA54972BB735840 /* XCRemoteSwiftPackageReference "DaggerheartModels" */ = {
+		6E36C5CB9EA54972BB735840 /* XCRemoteSwiftPackageReference "DHModels" */ = {
 			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/gwillish/DaggerheartModels";
+			repositoryURL = "https://github.com/gwillish/DHModels";
 			requirement = {
 				kind = upToNextMajorVersion;
 				minimumVersion = 0.1.0;
@@ -706,15 +706,15 @@
 			package = 1AD61A3E2F74D40B00296F39 /* XCRemoteSwiftPackageReference "swift-oslog" */;
 			productName = OSLogging;
 		};
-		372D78F7B37E42698659576B /* DaggerheartModels */ = {
+		372D78F7B37E42698659576B /* DHModels */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6E36C5CB9EA54972BB735840 /* XCRemoteSwiftPackageReference "DaggerheartModels" */;
-			productName = DaggerheartModels;
+			package = 6E36C5CB9EA54972BB735840 /* XCRemoteSwiftPackageReference "DHModels" */;
+			productName = DHModels;
 		};
-		696E5A197EC643C8822586E5 /* DaggerheartKit */ = {
+		696E5A197EC643C8822586E5 /* DHKit */ = {
 			isa = XCSwiftPackageProductDependency;
-			package = 6E36C5CB9EA54972BB735840 /* XCRemoteSwiftPackageReference "DaggerheartModels" */;
-			productName = DaggerheartKit;
+			package = 6E36C5CB9EA54972BB735840 /* XCRemoteSwiftPackageReference "DHModels" */;
+			productName = DHKit;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/Encounter/ContentView.swift
+++ b/Encounter/ContentView.swift
@@ -2,11 +2,10 @@
 //  ContentView.swift
 //  Encounter
 //
-//  Created by Joe Heck on 3/14/26.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct ContentView: View {

--- a/Encounter/EncounterApp.swift
+++ b/Encounter/EncounterApp.swift
@@ -2,10 +2,9 @@
 //  EncounterApp.swift
 //  Encounter
 //
-//  Created by Joe Heck on 3/14/26.
 //
 
-import DaggerheartKit
+import DHKit
 import Logging
 import OSLogging
 import SwiftUI
@@ -29,6 +28,8 @@ struct EncounterApp: App {
     contentDirectory: ContentStore.localContentDirectory,
     compendium: Compendium()  // placeholder; replaced by the real compendium below
   )
+
+  @State private var isShowingAbout = false
 
   var body: some Scene {
     WindowGroup {
@@ -62,6 +63,9 @@ struct EncounterApp: App {
         // onOpenURL on the root view handles .dhpack file opens on both
         // iOS and macOS. contentStore is non-nil from first render, so
         // there is no startup race.
+        .sheet(isPresented: $isShowingAbout) {
+          AboutView()
+        }
         .onOpenURL { url in
           guard url.pathExtension.lowercased() == "dhpack" else { return }
           guard url.startAccessingSecurityScopedResource() else { return }
@@ -71,5 +75,14 @@ struct EncounterApp: App {
           }
         }
     }
+    #if os(macOS)
+      .commands {
+        CommandGroup(replacing: .appInfo) {
+          Button("About Encounter") {
+            isShowingAbout = true
+          }
+        }
+      }
+    #endif
   }
 }

--- a/Encounter/Services/ContentFetcher.swift
+++ b/Encounter/Services/ContentFetcher.swift
@@ -8,7 +8,7 @@
 //
 
 import CryptoKit
-import DaggerheartModels
+import DHModels
 import Foundation
 import OSLog
 

--- a/Encounter/Services/ContentStore.swift
+++ b/Encounter/Services/ContentStore.swift
@@ -8,8 +8,8 @@
 //  on the main actor.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import Foundation
 import OSLog
 import Observation

--- a/Encounter/Services/ContentWriter.swift
+++ b/Encounter/Services/ContentWriter.swift
@@ -9,7 +9,7 @@
 //  No main-actor state is accessed; callers assign results back on their actor.
 //
 
-import DaggerheartModels
+import DHModels
 import Foundation
 import OSLog
 

--- a/Encounter/Views/AboutView.swift
+++ b/Encounter/Views/AboutView.swift
@@ -1,0 +1,75 @@
+//
+//  AboutView.swift
+//  Encounter
+//
+
+import SwiftUI
+
+struct AboutView: View {
+  @Environment(\.dismiss) private var dismiss
+
+  private var appVersion: String {
+    Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "—"
+  }
+
+  private var buildNumber: String {
+    Bundle.main.infoDictionary?["CFBundleVersion"] as? String ?? "—"
+  }
+
+  var body: some View {
+    NavigationStack {
+      List {
+        Section {
+          VStack(alignment: .leading, spacing: 4) {
+            Text("Encounter")
+              .font(.headline)
+            Text("Version \(appVersion) (\(buildNumber))")
+              .font(.subheadline)
+              .foregroundStyle(.secondary)
+          }
+          .padding(.vertical, 4)
+        }
+
+        Section("Attribution") {
+          Text(
+            "This product includes materials from the Daggerheart System Reference Document 1.0, © Critical Role, LLC. under the terms of the Darrington Press Community Gaming (DPCGL) License."
+          )
+          .font(.footnote)
+
+          Link(
+            "More information at daggerheart.com",
+            destination: URL(string: "https://www.daggerheart.com")!
+          )
+          .font(.footnote)
+
+          Link(
+            "DPCGL license text at darringtonpress.com/license",
+            destination: URL(string: "https://darringtonpress.com/license/")!
+          )
+          .font(.footnote)
+        }
+
+        Section("Disclaimer") {
+          Text(
+            "This app is not affiliated with, endorsed by, or sponsored by Darrington Press, LLC or Critical Role, LLC. Daggerheart is a trademark of Critical Role, LLC."
+          )
+          .font(.footnote)
+          .foregroundStyle(.secondary)
+        }
+      }
+      .navigationTitle("About")
+      #if os(iOS) || os(visionOS)
+        .navigationBarTitleDisplayMode(.inline)
+        .toolbar {
+          ToolbarItem(placement: .confirmationAction) {
+            Button("Done") { dismiss() }
+          }
+        }
+      #endif
+    }
+  }
+}
+
+#Preview {
+  AboutView()
+}

--- a/Encounter/Views/AddPlayerForm.swift
+++ b/Encounter/Views/AddPlayerForm.swift
@@ -7,8 +7,8 @@
 //  all fields pass validation.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AddPlayerForm: View {

--- a/Encounter/Views/AdversaryConditionsSection.swift
+++ b/Encounter/Views/AdversaryConditionsSection.swift
@@ -5,8 +5,8 @@
 //  Condition toggle strip for an adversary slot in the live encounter runner.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 /// Displays toggleable condition buttons for an adversary slot.
@@ -27,9 +27,9 @@ struct AdversaryConditionsSection: View {
           let active = slot.conditions.contains(condition)
           Button(condition.displayName) {
             if active {
-              session.removeCondition(condition, from: slot.id)
+              session.removeCondition(condition, from: slot)
             } else {
-              session.applyCondition(condition, to: slot.id)
+              session.applyCondition(condition, to: slot)
             }
           }
           .font(.caption)

--- a/Encounter/Views/AdversaryDetailView.swift
+++ b/Encounter/Views/AdversaryDetailView.swift
@@ -7,8 +7,8 @@
 //  an "Add to Encounter" toolbar button is shown.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryDetailView: View {
@@ -28,7 +28,7 @@ struct AdversaryDetailView: View {
       Section {
         VStack(alignment: .leading, spacing: 6) {
           HStack(spacing: 6) {
-            TypeBadgeView(type: adversary.type)
+            TypeBadgeView(type: adversary.role)
             Text("Tier \(adversary.tier)")
               .font(.caption)
               .foregroundStyle(.secondary)
@@ -112,8 +112,8 @@ struct AdversaryDetailView: View {
         id: "goblin",
         name: "Goblin",
         tier: 1,
-        type: .minion,
-        description: "Small, cunning, and cowardly alone but dangerous in numbers.",
+        role: .minion,
+        flavorText: "Small, cunning, and cowardly alone but dangerous in numbers.",
         motivesAndTactics: "Goblins mob weak targets and flee from strong ones.",
         difficulty: 10,
         thresholdMajor: 5,
@@ -125,12 +125,12 @@ struct AdversaryDetailView: View {
         attackRange: .veryClose,
         damage: "1d4 phy",
         features: [
-          AdversaryFeature(
+          EncounterFeature(
             name: "Pack Tactics", text: "Deal +1 damage for each ally adjacent to the target.",
-            featType: .passive),
-          AdversaryFeature(
+            kind: .passive),
+          EncounterFeature(
             name: "Sneak Attack", text: "Once per round, deal +1d6 damage when hidden.",
-            featType: .action),
+            kind: .action),
         ]
       ))
   }

--- a/Encounter/Views/AdversaryFeatureRow.swift
+++ b/Encounter/Views/AdversaryFeatureRow.swift
@@ -6,12 +6,12 @@
 //  Used in both AdversaryDetailView and EnvironmentDetailView.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryFeatureRow: View {
-  let feature: AdversaryFeature
+  let feature: EncounterFeature
 
   var body: some View {
     VStack(alignment: .leading, spacing: 4) {
@@ -19,7 +19,7 @@ struct AdversaryFeatureRow: View {
         Text(feature.name)
           .font(.subheadline)
           .fontWeight(.semibold)
-        Text(feature.featType.rawValue.capitalized)
+        Text(feature.kind.rawValue.capitalized)
           .font(.caption2)
           .foregroundStyle(.secondary)
           .padding(.horizontal, 5)
@@ -37,10 +37,10 @@ struct AdversaryFeatureRow: View {
 
 #Preview {
   AdversaryFeatureRow(
-    feature: AdversaryFeature(
+    feature: EncounterFeature(
       name: "Pack Tactics",
       text: "Deal +1 damage for each ally adjacent to the target.",
-      featType: .passive
+      kind: .passive
     )
   )
   .padding()

--- a/Encounter/Views/AdversaryListView.swift
+++ b/Encounter/Views/AdversaryListView.swift
@@ -6,8 +6,8 @@
 //  on the parent CompendiumBrowserView so they persist across tab switches.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryListView: View {
@@ -37,14 +37,14 @@ struct AdversaryListView: View {
   NavigationStack {
     AdversaryListView(adversaries: [
       Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
+        id: "goblin", name: "Goblin", tier: 1, role: .minion,
+        flavorText: "Small and cunning.", difficulty: 10,
         thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
         attackModifier: "+2", attackName: "Rusty Blade",
         attackRange: .veryClose, damage: "1d4 phy"),
       Adversary(
-        id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
-        description: "Massive and relentless.", difficulty: 14,
+        id: "orc", name: "Orc Bruiser", tier: 2, role: .bruiser,
+        flavorText: "Massive and relentless.", difficulty: 14,
         thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
         attackModifier: "+5", attackName: "Great Axe",
         attackRange: .veryClose, damage: "2d10+4 phy"),

--- a/Encounter/Views/AdversaryRosterRow.swift
+++ b/Encounter/Views/AdversaryRosterRow.swift
@@ -6,8 +6,8 @@
 //  Looks up the adversary by ID for display; shows a fallback if unresolvable.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryRosterRow: View {
@@ -23,7 +23,7 @@ struct AdversaryRosterRow: View {
       Text(adversary?.name ?? "Unknown Adversary")
         .font(.body)
       if let adversary {
-        Text("\(adversary.type.rawValue) · Tier \(adversary.tier)")
+        Text("\(adversary.role.rawValue) · Tier \(adversary.tier)")
           .font(.caption)
           .foregroundStyle(.secondary)
       } else {
@@ -40,8 +40,8 @@ struct AdversaryRosterRow: View {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
-      id: "goblin", name: "Goblin", tier: 1, type: .minion,
-      description: "Small and cunning.", difficulty: 10,
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
       thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
       attackModifier: "+2", attackName: "Rusty Blade",
       attackRange: .veryClose, damage: "1d4 phy"

--- a/Encounter/Views/AdversaryRosterSection.swift
+++ b/Encounter/Views/AdversaryRosterSection.swift
@@ -6,8 +6,8 @@
 //  Uses index-based identity to support duplicate adversary IDs; onDelete receives a position-based IndexSet.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryRosterSection: View {
@@ -46,8 +46,8 @@ struct AdversaryRosterSection: View {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
-      id: "goblin", name: "Goblin", tier: 1, type: .minion,
-      description: "Small and cunning.", difficulty: 10,
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
       thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
       attackModifier: "+2", attackName: "Rusty Blade",
       attackRange: .veryClose, damage: "1d4 phy"

--- a/Encounter/Views/AdversaryRow.swift
+++ b/Encounter/Views/AdversaryRow.swift
@@ -5,8 +5,8 @@
 //  A single row in the adversary list: name, type/tier/difficulty, homebrew badge.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryRow: View {
@@ -27,7 +27,7 @@ struct AdversaryRow: View {
             .clipShape(.capsule)
         }
       }
-      Text("\(adversary.type.rawValue) · Tier \(adversary.tier) · DC \(adversary.difficulty)")
+      Text("\(adversary.role.rawValue) · Tier \(adversary.tier) · DC \(adversary.difficulty)")
         .font(.caption)
         .foregroundStyle(.secondary)
     }
@@ -41,8 +41,8 @@ struct AdversaryRow: View {
       id: "goblin",
       name: "Goblin",
       tier: 1,
-      type: .minion,
-      description: "Small and cunning.",
+      role: .minion,
+      flavorText: "Small and cunning.",
       difficulty: 10,
       thresholdMajor: 5,
       thresholdSevere: 10,

--- a/Encounter/Views/AdversaryRunnerCard.swift
+++ b/Encounter/Views/AdversaryRunnerCard.swift
@@ -12,8 +12,8 @@
 //    Severe hit (at/above Severe threshold): mark 3 HP
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryRunnerCard: View {
@@ -66,18 +66,18 @@ struct AdversaryRunnerCard: View {
       HStack(spacing: 8) {
         ThresholdButton(
           label: "Minor", subtitle: "< \(major)", marks: 1, isDefeated: slot.isDefeated,
-          session: session, slotID: slot.id)
+          session: session, slot: slot)
         ThresholdButton(
           label: "Major", subtitle: "≥ \(major)", marks: 2, isDefeated: slot.isDefeated,
-          session: session, slotID: slot.id)
+          session: session, slot: slot)
         ThresholdButton(
           label: "Severe", subtitle: "≥ \(severe)", marks: 3, isDefeated: slot.isDefeated,
-          session: session, slotID: slot.id)
+          session: session, slot: slot)
       }
 
       // Stress
       Button("+1 Stress (\(slot.currentStress)/\(slot.maxStress))") {
-        session.applyStress(1, to: slot.id)
+        session.applyStress(1, to: slot)
       }
       .buttonStyle(.bordered)
       .disabled(slot.currentStress >= slot.maxStress || slot.isDefeated)
@@ -99,13 +99,13 @@ struct AdversaryRunnerCard: View {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
-      id: "goblin", name: "Goblin", tier: 1, type: .minion,
-      description: "Small and cunning.", difficulty: 10,
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
       thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
       attackModifier: "+2", attackName: "Rusty Blade",
       attackRange: .veryClose, damage: "1d4 phy",
       features: [
-        AdversaryFeature(name: "Sneak", text: "Can hide as a free action.", featType: .passive)
+        EncounterFeature(name: "Sneak", text: "Can hide as a free action.", kind: .passive)
       ]
     ))
   let session = EncounterSession(name: "Test")

--- a/Encounter/Views/AdversaryRunnerRow.swift
+++ b/Encounter/Views/AdversaryRunnerRow.swift
@@ -7,8 +7,8 @@
 //  Tapping expands to AdversaryRunnerCard (managed by AdversaryRunnerSection).
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryRunnerRow: View {
@@ -30,7 +30,7 @@ struct AdversaryRunnerRow: View {
           .fontWeight(.medium)
         Spacer()
         if let adversary {
-          Text("\(adversary.type.rawValue) · T\(adversary.tier)")
+          Text("\(adversary.role.rawValue) · T\(adversary.tier)")
             .font(.caption2)
             .foregroundStyle(.secondary)
             .padding(.horizontal, 6)
@@ -62,8 +62,8 @@ struct AdversaryRunnerRow: View {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
-      id: "goblin", name: "Goblin", tier: 1, type: .minion,
-      description: "Small and cunning.", difficulty: 10,
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
       thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
       attackModifier: "+2", attackName: "Rusty Blade",
       attackRange: .veryClose, damage: "1d4 phy"

--- a/Encounter/Views/AdversaryRunnerSection.swift
+++ b/Encounter/Views/AdversaryRunnerSection.swift
@@ -7,8 +7,8 @@
 //  card can be open at a time by design (single UUID stored).
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct AdversaryRunnerSection: View {

--- a/Encounter/Views/AdversaryStatReference.swift
+++ b/Encounter/Views/AdversaryStatReference.swift
@@ -6,8 +6,8 @@
 //  Includes core stats, attack info, and the adversary's feature list.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 /// Compact stat reference shown in the expanded adversary runner card.

--- a/Encounter/Views/CompendiumBrowserView.swift
+++ b/Encounter/Views/CompendiumBrowserView.swift
@@ -10,8 +10,8 @@
 //  and dismisses the sheet.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct CompendiumBrowserView: View {
@@ -35,7 +35,7 @@ struct CompendiumBrowserView: View {
 
   var filteredAdversaries: [Adversary] {
     let base =
-      selectedType.map { t in compendium.adversaries.filter { $0.type == t } }
+      selectedType.map { t in compendium.adversaries.filter { $0.role == t } }
       ?? compendium.adversaries
     guard !searchText.isEmpty else { return base }
     return base.filter {
@@ -121,16 +121,16 @@ struct CompendiumBrowserView: View {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
-      id: "goblin", name: "Goblin", tier: 1, type: .minion,
-      description: "Small and cunning.", difficulty: 10,
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
       thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
       attackModifier: "+2", attackName: "Rusty Blade",
       attackRange: .veryClose, damage: "1d4 phy"
     ))
   compendium.addAdversary(
     Adversary(
-      id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
-      description: "Massive and relentless.", difficulty: 14,
+      id: "orc", name: "Orc Bruiser", tier: 2, role: .bruiser,
+      flavorText: "Massive and relentless.", difficulty: 14,
       thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
       attackModifier: "+5", attackName: "Great Axe",
       attackRange: .veryClose, damage: "2d10+4 phy"
@@ -138,7 +138,7 @@ struct CompendiumBrowserView: View {
   compendium.addEnvironment(
     DaggerheartEnvironment(
       id: "collapsing-cavern", name: "Collapsing Cavern",
-      description: "The ceiling threatens to fall with every heavy blow."
+      flavorText: "The ceiling threatens to fall with every heavy blow."
     ))
   return NavigationStack {
     CompendiumBrowserView()
@@ -150,8 +150,8 @@ struct CompendiumBrowserView: View {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
-      id: "goblin", name: "Goblin", tier: 1, type: .minion,
-      description: "Small and cunning.", difficulty: 10,
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
       thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
       attackModifier: "+2", attackName: "Rusty Blade",
       attackRange: .veryClose, damage: "1d4 phy"

--- a/Encounter/Views/ContentSourceRemovableRow.swift
+++ b/Encounter/Views/ContentSourceRemovableRow.swift
@@ -6,8 +6,8 @@
 //  remove action, used in ContentSourcesView.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct ContentSourceRemovableRow: View {

--- a/Encounter/Views/ContentSourceRow.swift
+++ b/Encounter/Views/ContentSourceRow.swift
@@ -5,8 +5,8 @@
 //  A single row in the content sources list showing a registered ContentSource.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct ContentSourceRow: View {

--- a/Encounter/Views/ContentSourcesView.swift
+++ b/Encounter/Views/ContentSourcesView.swift
@@ -5,8 +5,8 @@
 //  Lists all registered content sources and lets the GM remove any of them.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct ContentSourcesView: View {

--- a/Encounter/Views/DifficultyAssessorView.swift
+++ b/Encounter/Views/DifficultyAssessorView.swift
@@ -16,8 +16,8 @@
 //  as read-only labels. GM-discretionary adjustments are Toggle rows.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct DifficultyAssessorView: View {
@@ -93,7 +93,7 @@ struct DifficultyAssessorView: View {
         if !autoAdjustments.isEmpty {
           VStack(alignment: .leading, spacing: 2) {
             ForEach(Array(autoAdjustments), id: \.self) { adj in
-              Label(adj.label, systemImage: "checkmark.circle.fill")
+              Label(adj.displayName, systemImage: "checkmark.circle.fill")
                 .font(.caption)
                 .foregroundStyle(.secondary)
             }
@@ -103,7 +103,7 @@ struct DifficultyAssessorView: View {
         // Manual GM-discretionary toggles
         VStack(alignment: .leading, spacing: 2) {
           ForEach(Self.manualCases, id: \.self) { adj in
-            Toggle(adj.label, isOn: toggleBinding(for: adj))
+            Toggle(adj.displayName, isOn: toggleBinding(for: adj))
               .font(.caption)
               .accessibilityIdentifier(
                 "builder.difficulty.toggle.\(String(describing: adj))"

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -10,8 +10,8 @@
 //  and pushes EncounterRunnerView.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EncounterBuilderView: View {
@@ -38,7 +38,7 @@ struct EncounterBuilderView: View {
   // MARK: - Computed difficulty
 
   private var adversaryTypes: [AdversaryType] {
-    draft.adversaryIDs.compactMap { compendium.adversary(id: $0)?.type }
+    draft.adversaryIDs.compactMap { compendium.adversary(id: $0)?.role }
   }
 
   private var autoAdjustments: Set<DifficultyBudget.Adjustment> {
@@ -226,16 +226,16 @@ struct EncounterBuilderView: View {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
-      id: "goblin", name: "Goblin", tier: 1, type: .minion,
-      description: "Small and cunning.", difficulty: 10,
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
       thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
       attackModifier: "+2", attackName: "Rusty Blade",
       attackRange: .veryClose, damage: "1d4 phy"
     ))
   compendium.addAdversary(
     Adversary(
-      id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
-      description: "Massive and relentless.", difficulty: 14,
+      id: "orc", name: "Orc Bruiser", tier: 2, role: .bruiser,
+      flavorText: "Massive and relentless.", difficulty: 14,
       thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
       attackModifier: "+5", attackName: "Great Axe",
       attackRange: .veryClose, damage: "2d10+4 phy"

--- a/Encounter/Views/EncounterLibraryList.swift
+++ b/Encounter/Views/EncounterLibraryList.swift
@@ -5,8 +5,8 @@
 //  The populated list of encounter definitions with swipe and context menu actions.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EncounterLibraryList: View {

--- a/Encounter/Views/EncounterLibraryRow.swift
+++ b/Encounter/Views/EncounterLibraryRow.swift
@@ -5,8 +5,8 @@
 //  A single row in the encounter library list.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EncounterLibraryRow: View {

--- a/Encounter/Views/EncounterLibraryView.swift
+++ b/Encounter/Views/EncounterLibraryView.swift
@@ -5,8 +5,8 @@
 //  Browse, create, rename, and delete encounter definitions.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EncounterLibraryView: View {
@@ -23,6 +23,7 @@ struct EncounterLibraryView: View {
   @State private var actionError: String?
   @State private var loadErrorDismissed = false
   @State private var isShowingSources = false
+  @State private var isShowingAbout = false
 
   var body: some View {
     Group {
@@ -76,6 +77,9 @@ struct EncounterLibraryView: View {
         ContentSourcesView()
       }
     }
+    .sheet(isPresented: $isShowingAbout) {
+      AboutView()
+    }
     // Error banners
     .safeAreaInset(edge: .top) {
       if let error = store.loadError, !loadErrorDismissed {
@@ -104,6 +108,14 @@ struct EncounterLibraryView: View {
       }
       .accessibilityIdentifier("library.sources-button")
     }
+    #if os(iOS) || os(visionOS)
+      ToolbarItem(placement: .secondaryAction) {
+        Button("About", systemImage: "info.circle") {
+          isShowingAbout = true
+        }
+        .accessibilityIdentifier("library.about-button")
+      }
+    #endif
   }
 
   // MARK: - Actions

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -11,8 +11,8 @@
 //   - PlayerStrip pinned to bottom via .safeAreaInset
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EncounterRunnerView: View {
@@ -40,7 +40,7 @@ struct EncounterRunnerView: View {
       )
     }
     .accessibilityIdentifier("runner.adversary-list")
-    .navigationTitle("\(session.name) · R\(session.currentRound)")
+    .navigationTitle(session.name)
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
     #endif
@@ -71,16 +71,16 @@ struct EncounterRunnerView: View {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
-      id: "goblin", name: "Goblin", tier: 1, type: .minion,
-      description: "Small and cunning.", difficulty: 10,
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
       thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
       attackModifier: "+2", attackName: "Rusty Blade",
       attackRange: .veryClose, damage: "1d4 phy"
     ))
   compendium.addAdversary(
     Adversary(
-      id: "orc", name: "Orc Bruiser", tier: 2, type: .bruiser,
-      description: "Massive and relentless.", difficulty: 14,
+      id: "orc", name: "Orc Bruiser", tier: 2, role: .bruiser,
+      flavorText: "Massive and relentless.", difficulty: 14,
       thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
       attackModifier: "+5", attackName: "Great Axe",
       attackRange: .veryClose, damage: "2d10+4 phy"
@@ -97,7 +97,7 @@ struct EncounterRunnerView: View {
         thresholdMajor: 4, thresholdSevere: 8, armorSlots: 2),
     ]
   )
-  let session = EncounterSession.start(from: definition, using: compendium)
+  let session = EncounterSession.make(from: definition, using: compendium)
   return NavigationStack {
     EncounterRunnerView(session: session, definition: definition)
   }

--- a/Encounter/Views/EnvironmentDetailView.swift
+++ b/Encounter/Views/EnvironmentDetailView.swift
@@ -6,8 +6,8 @@
 //  When onSelect is provided, an "Add to Encounter" toolbar button is shown.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EnvironmentDetailView: View {
@@ -70,14 +70,14 @@ struct EnvironmentDetailView: View {
       environment: DaggerheartEnvironment(
         id: "collapsing-cavern",
         name: "Collapsing Cavern",
-        description:
+        flavorText:
           "The ceiling threatens to fall with every heavy blow. Whenever a Severe hit is dealt, roll 1d6 — on a 1–3, a section collapses.",
         features: [
-          AdversaryFeature(
+          EncounterFeature(
             name: "Cave-In",
             text:
               "When a Severe hit is dealt, roll 1d6. On 1–3, creatures in the area make an Agility roll against DC 14 or take 2d8 physical damage.",
-            featType: .reaction)
+            kind: .reaction)
         ]
       ))
   }

--- a/Encounter/Views/EnvironmentListView.swift
+++ b/Encounter/Views/EnvironmentListView.swift
@@ -6,8 +6,8 @@
 //  on the parent CompendiumBrowserView so they persist across tab switches.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EnvironmentListView: View {
@@ -38,10 +38,10 @@ struct EnvironmentListView: View {
     EnvironmentListView(environments: [
       DaggerheartEnvironment(
         id: "collapsing-cavern", name: "Collapsing Cavern",
-        description: "The ceiling threatens to fall with every heavy blow."),
+        flavorText: "The ceiling threatens to fall with every heavy blow."),
       DaggerheartEnvironment(
         id: "burning-bridge", name: "Burning Bridge",
-        description: "The planks crumble underfoot as flames spread."),
+        flavorText: "The planks crumble underfoot as flames spread."),
     ])
   }
 }

--- a/Encounter/Views/EnvironmentRow.swift
+++ b/Encounter/Views/EnvironmentRow.swift
@@ -5,8 +5,8 @@
 //  A single row in the environment list: name, description preview, homebrew badge.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EnvironmentRow: View {
@@ -41,7 +41,7 @@ struct EnvironmentRow: View {
     environment: DaggerheartEnvironment(
       id: "collapsing-cavern",
       name: "Collapsing Cavern",
-      description: "The ceiling threatens to fall with every heavy blow."
+      flavorText: "The ceiling threatens to fall with every heavy blow."
     )
   )
   .padding()

--- a/Encounter/Views/EnvironmentSection.swift
+++ b/Encounter/Views/EnvironmentSection.swift
@@ -7,8 +7,8 @@
 //  when empty and a replace button when one is set.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct EnvironmentSection: View {
@@ -79,7 +79,7 @@ struct EnvironmentSection: View {
   compendium.addEnvironment(
     DaggerheartEnvironment(
       id: "collapsing-cavern", name: "Collapsing Cavern",
-      description: "The ceiling threatens to fall with every heavy blow."
+      flavorText: "The ceiling threatens to fall with every heavy blow."
     ))
   return Form {
     EnvironmentSection(

--- a/Encounter/Views/FearTrackerButton.swift
+++ b/Encounter/Views/FearTrackerButton.swift
@@ -6,8 +6,8 @@
 //  Tapping opens a compact popover with +1 / −1 / −2 / −3 controls.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct FearTrackerButton: View {
@@ -36,15 +36,15 @@ struct FearTrackerButton: View {
           Button("+1") { session.incrementFear(by: 1) }
             .buttonStyle(.bordered)
             .accessibilityIdentifier("runner.fear.increment")
-          Button("−1") { session.spendFear(1) }
+          Button("−1") { session.spendFear(by: 1) }
             .buttonStyle(.bordered)
             .disabled(session.fearPool < 1)
             .accessibilityIdentifier("runner.fear.spend-1")
-          Button("−2") { session.spendFear(2) }
+          Button("−2") { session.spendFear(by: 2) }
             .buttonStyle(.bordered)
             .disabled(session.fearPool < 2)
             .accessibilityIdentifier("runner.fear.spend-2")
-          Button("−3") { session.spendFear(3) }
+          Button("−3") { session.spendFear(by: 3) }
             .buttonStyle(.bordered)
             .disabled(session.fearPool < 3)
             .accessibilityIdentifier("runner.fear.spend-3")

--- a/Encounter/Views/FeatureSectionsView.swift
+++ b/Encounter/Views/FeatureSectionsView.swift
@@ -6,8 +6,8 @@
 //  as List sections. Used by AdversaryDetailView and EnvironmentDetailView.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 /// Renders a list of adversary features as grouped `Section` rows.
@@ -15,12 +15,12 @@ import SwiftUI
 /// Sections are shown only if at least one feature of that type exists.
 /// Intended for use inside a `List`.
 struct FeatureSectionsView: View {
-  let features: [AdversaryFeature]
+  let features: [EncounterFeature]
 
   var body: some View {
-    let passives = features.filter { $0.featType == .passive }
-    let actions = features.filter { $0.featType == .action }
-    let reactions = features.filter { $0.featType == .reaction }
+    let passives = features.filter { $0.kind == .passive }
+    let actions = features.filter { $0.kind == .action }
+    let reactions = features.filter { $0.kind == .reaction }
 
     if !passives.isEmpty {
       Section("Passives") {

--- a/Encounter/Views/LastFetchedLabel.swift
+++ b/Encounter/Views/LastFetchedLabel.swift
@@ -5,8 +5,8 @@
 //  Caption-sized label showing when a ContentSource was last fetched.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct LastFetchedLabel: View {

--- a/Encounter/Views/PlayerEditPopover.swift
+++ b/Encounter/Views/PlayerEditPopover.swift
@@ -6,8 +6,8 @@
 //  and Armor Slots during a live encounter.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct PlayerEditPopover: View {
@@ -23,16 +23,16 @@ struct PlayerEditPopover: View {
         label: "HP",
         current: player.currentHP,
         maximum: player.maxHP,
-        onDecrement: { session.applyPlayerDamage(1, to: player.id) },
-        onIncrement: { session.healPlayer(1, slotID: player.id) }
+        onDecrement: { session.applyDamage(1, to: player) },
+        onIncrement: { session.heal(1, to: player) }
       )
 
       statRow(
         label: "Stress",
         current: player.currentStress,
         maximum: player.maxStress,
-        onDecrement: { session.clearPlayerStress(1, slotID: player.id) },
-        onIncrement: { session.applyPlayerStress(1, to: player.id) }
+        onDecrement: { session.reduceStress(1, from: player) },
+        onIncrement: { session.applyStress(1, to: player) }
       )
 
       if player.armorSlots > 0 {
@@ -40,8 +40,8 @@ struct PlayerEditPopover: View {
           label: "Armor",
           current: player.currentArmorSlots,
           maximum: player.armorSlots,
-          onDecrement: { session.markPlayerArmorSlot(player.id) },
-          onIncrement: { session.restorePlayerArmorSlot(player.id) }
+          onDecrement: { session.markArmorSlot(for: player.id) },
+          onIncrement: { session.restoreArmorSlot(for: player.id) }
         )
       }
     }
@@ -90,8 +90,7 @@ struct PlayerEditPopover: View {
 
 #Preview {
   let session = EncounterSession(name: "Test")
-  session.addPlayer(
-    PlayerSlot(
+  session.add(player: PlayerSlot(
       name: "Aric Stonehammer",
       maxHP: 6, maxStress: 6, evasion: 12,
       thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3

--- a/Encounter/Views/PlayerRosterRow.swift
+++ b/Encounter/Views/PlayerRosterRow.swift
@@ -6,8 +6,8 @@
 //  Shows name, HP, Stress, and Evasion.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct PlayerRosterRow: View {

--- a/Encounter/Views/PlayerRosterSection.swift
+++ b/Encounter/Views/PlayerRosterSection.swift
@@ -7,8 +7,8 @@
 //  (player count drives the difficulty budget calculation).
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct PlayerRosterSection: View {

--- a/Encounter/Views/PlayerStrip.swift
+++ b/Encounter/Views/PlayerStrip.swift
@@ -6,8 +6,8 @@
 //  via .safeAreaInset(edge: .bottom). Shows all player slots.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct PlayerStrip: View {

--- a/Encounter/Views/PlayerStripRow.swift
+++ b/Encounter/Views/PlayerStripRow.swift
@@ -7,8 +7,8 @@
 //  Tapping opens PlayerEditPopover for HP/Stress/Armor stepper controls.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 struct PlayerStripRow: View {

--- a/Encounter/Views/ThresholdButton.swift
+++ b/Encounter/Views/ThresholdButton.swift
@@ -6,8 +6,8 @@
 //  HP mark count to an adversary slot.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 /// Applies a Daggerheart hit threshold (Minor/Major/Severe) to an adversary slot.
@@ -20,11 +20,11 @@ struct ThresholdButton: View {
   let marks: Int
   let isDefeated: Bool
   let session: EncounterSession
-  let slotID: UUID
+  let slot: AdversarySlot
 
   var body: some View {
     Button {
-      session.applyDamage(marks, to: slotID)
+      session.applyDamage(marks, to: slot)
     } label: {
       VStack(spacing: 2) {
         Text(label)

--- a/Encounter/Views/TypeBadgeView.swift
+++ b/Encounter/Views/TypeBadgeView.swift
@@ -5,8 +5,8 @@
 //  Capsule badge showing an adversary's role type (e.g. "Minion", "Bruiser").
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import SwiftUI
 
 /// A small capsule badge displaying an adversary's role type.

--- a/EncounterTests/ContentModelTests.swift
+++ b/EncounterTests/ContentModelTests.swift
@@ -7,8 +7,8 @@
 //  All tested types are pure value types with no I/O dependencies.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import Foundation
 import Testing
 

--- a/EncounterTests/ContentSourceIntegrationTests.swift
+++ b/EncounterTests/ContentSourceIntegrationTests.swift
@@ -6,8 +6,8 @@
 //  the sample-homebrew.dhpack fixture in EncounterTests/Fixtures/.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import Foundation
 import Testing
 

--- a/EncounterTests/ContentStoreTests.swift
+++ b/EncounterTests/ContentStoreTests.swift
@@ -6,8 +6,8 @@
 //  configure(compendium:), and relocate(to:) async behavior.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import Foundation
 import Testing
 
@@ -32,8 +32,8 @@ import Testing
     // Add an adversary to the real compendium.
     real.addAdversary(
       Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
+        id: "goblin", name: "Goblin", tier: 1, role: .minion,
+        flavorText: "Small and cunning.", difficulty: 10,
         thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
         attackModifier: "+2", attackName: "Rusty Blade",
         attackRange: .veryClose, damage: "1d4 phy"

--- a/EncounterTests/EncounterTests.swift
+++ b/EncounterTests/EncounterTests.swift
@@ -5,8 +5,8 @@
 //  Unit tests for Daggerheart data models.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import Foundation
 import Testing
 
@@ -101,9 +101,9 @@ struct AdversaryDecodingTests {
 
     let adversary = try JSONDecoder().decode(Adversary.self, from: json)
     #expect(adversary.features.count == 3)
-    #expect(adversary.features[0].featType == FeatureType.passive)
-    #expect(adversary.features[1].featType == FeatureType.reaction)
-    #expect(adversary.features[2].featType == FeatureType.action)
+    #expect(adversary.features[0].kind == FeatureType.passive)
+    #expect(adversary.features[1].kind == FeatureType.reaction)
+    #expect(adversary.features[2].kind == FeatureType.action)
   }
 
   // MARK: AdversaryType round-trip
@@ -150,7 +150,7 @@ struct AdversaryDecodingTests {
         """.data(using: .utf8)!
 
       let adversary = try JSONDecoder().decode(Adversary.self, from: json)
-      #expect(adversary.type.rawValue == typeString)
+      #expect(adversary.role.rawValue == typeString)
     }
   }
 
@@ -238,8 +238,8 @@ struct ConditionTests {
       id: "ironguard-soldier",
       name: "Ironguard Soldier",
       tier: 1,
-      type: .bruiser,
-      description: "A disciplined mercenary.",
+      role: .bruiser,
+      flavorText: "A disciplined mercenary.",
       difficulty: 11,
       thresholdMajor: 5,
       thresholdSevere: 10,
@@ -267,9 +267,8 @@ struct ConditionTests {
     let session = makeSession()
     let soldier = makeSoldier()
     session.add(adversary: soldier)
-    let slotID = session.adversarySlots[0].id
 
-    session.applyDamage(4, to: slotID)
+    session.applyDamage(4, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].currentHP == 2)
   }
 
@@ -277,9 +276,8 @@ struct ConditionTests {
     let session = makeSession()
     let soldier = makeSoldier()
     session.add(adversary: soldier)
-    let slotID = session.adversarySlots[0].id
 
-    session.applyDamage(100, to: slotID)
+    session.applyDamage(100, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].currentHP == 0)
     #expect(session.adversarySlots[0].isDefeated == true)
     #expect(session.activeAdversaries.isEmpty)
@@ -290,14 +288,14 @@ struct ConditionTests {
     session.incrementFear(by: 3)
     #expect(session.fearPool == 3)
 
-    session.spendFear(2)
+    session.spendFear(by: 2)
     #expect(session.fearPool == 1)
 
-    session.spendFear(10)  // clamped
+    session.spendFear(by: 10)  // clamped
     #expect(session.fearPool == 0)
 
     session.incrementHope(by: 5)
-    session.spendHope(2)
+    session.spendHope(by: 2)
     #expect(session.hopePool == 3)
   }
 
@@ -307,16 +305,8 @@ struct ConditionTests {
     session.add(adversary: soldier)
     #expect(session.isOver == false)
 
-    let slotID = session.adversarySlots[0].id
-    session.applyDamage(999, to: slotID)
+    session.applyDamage(999, to: session.adversarySlots[0])
     #expect(session.isOver == true)
-  }
-
-  @Test func advanceRoundIncrementsCounter() {
-    let session = makeSession()
-    #expect(session.currentRound == 1)
-    session.advanceRound()
-    #expect(session.currentRound == 2)
   }
 
   // MARK: Adversary Conditions
@@ -330,119 +320,54 @@ struct ConditionTests {
   @Test func applyConditionToAdversarySlot() {
     let session = makeSession()
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyCondition(.restrained, to: slotID)
+    session.applyCondition(.restrained, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].conditions.contains(.restrained))
   }
 
   @Test func removeConditionFromAdversarySlot() {
     let session = makeSession()
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyCondition(.hidden, to: slotID)
-    session.removeCondition(.hidden, from: slotID)
+    session.applyCondition(.hidden, to: session.adversarySlots[0])
+    session.removeCondition(.hidden, from: session.adversarySlots[0])
     #expect(!session.adversarySlots[0].conditions.contains(.hidden))
   }
 
   @Test func conditionsDoNotStack() {
     let session = makeSession()
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyCondition(.vulnerable, to: slotID)
-    session.applyCondition(.vulnerable, to: slotID)
+    session.applyCondition(.vulnerable, to: session.adversarySlots[0])
+    session.applyCondition(.vulnerable, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].conditions.count == 1)
   }
 
   @Test func emptyCustomConditionOnAdversaryIsRejected() {
     let session = makeSession()
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyCondition(.custom(""), to: slotID)
+    session.applyCondition(.custom(""), to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].conditions.isEmpty)
   }
 
   @Test func whitespaceCustomConditionOnAdversaryIsRejected() {
     let session = makeSession()
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyCondition(.custom("   "), to: slotID)
+    session.applyCondition(.custom("   "), to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].conditions.isEmpty)
   }
 
   @Test func customConditionOnAdversarySlot() {
     let session = makeSession()
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyCondition(.custom("Enraged"), to: slotID)
+    session.applyCondition(.custom("Enraged"), to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].conditions.contains(.custom("Enraged")))
   }
 
-  // MARK: Turn Order
 
-  @Test func advanceTurnSkipsDefeatedAdversary() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
-    session.add(adversary: makeSoldier())
-
-    let firstID = session.turnOrder[0]
-    let secondID = session.turnOrder[1]
-
-    // Defeat first adversary mid-round before taking a turn
-    session.applyDamage(999, to: firstID)
-
-    // First advanceTurn should skip the defeated slot
-    session.advanceTurn()
-    #expect(session.activeSlotID == secondID)
-  }
-
-  @Test func advanceTurnSkipsDefeatedMidRound() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
-    session.add(adversary: makeSoldier())
-    session.add(adversary: makeSoldier())
-
-    let firstID = session.turnOrder[0]
-    let secondID = session.turnOrder[1]
-    let thirdID = session.turnOrder[2]
-
-    // Advance to second slot
-    session.advanceTurn()
-    session.advanceTurn()
-    #expect(session.activeSlotID == secondID)
-
-    // Defeat the third slot mid-round
-    session.applyDamage(999, to: thirdID)
-
-    // Next advance should skip defeated third and wrap back to first
-    session.advanceTurn()
-    #expect(session.activeSlotID == firstID)
-  }
-
-  @Test func advanceTurnCyclesSlots() {
-    let session = makeSession()
-    let soldier = makeSoldier()
-    session.add(adversary: soldier)
-    session.add(adversary: soldier)
-
-    let first = session.turnOrder[0]
-    let second = session.turnOrder[1]
-
-    session.advanceTurn()
-    #expect(session.activeSlotID == first)
-
-    session.advanceTurn()
-    #expect(session.activeSlotID == second)
-
-    // Wraps back to first slot
-    session.advanceTurn()
-    #expect(session.activeSlotID == first)
-  }
 }
 
 // MARK: - PlayerSlot
@@ -493,8 +418,8 @@ struct PlayerSlotTests {
       id: "ironguard-soldier",
       name: "Ironguard Soldier",
       tier: 1,
-      type: .bruiser,
-      description: "A disciplined mercenary.",
+      role: .bruiser,
+      flavorText: "A disciplined mercenary.",
       difficulty: 11,
       thresholdMajor: 5,
       thresholdSevere: 10,
@@ -521,102 +446,76 @@ struct PlayerSlotTests {
 
   @Test func addPlayerSlotToSession() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
+    session.add(player: makePlayer())
     #expect(session.playerSlots.count == 1)
     #expect(session.playerSlots[0].name == "Aldric")
   }
 
-  @Test func turnOrderIncludesPlayersAndAdversaries() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
-    session.addPlayer(makePlayer())
-    #expect(session.turnOrder.count == 2)
-  }
-
-  @Test func advanceTurnCyclesThroughBothSlotTypes() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
-    session.addPlayer(makePlayer())
-
-    session.advanceTurn()
-    #expect(session.activeSlotID == session.turnOrder[0])
-
-    session.advanceTurn()
-    #expect(session.activeSlotID == session.turnOrder[1])
-  }
-
   @Test func applyDamageToPlayerSlot() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerDamage(2, to: slotID)
+    session.applyDamage(2, to: session.playerSlots[0])
     #expect(session.playerSlots[0].currentHP == 4)
   }
 
   @Test func playerDamageClampsToZero() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerDamage(100, to: slotID)
+    session.applyDamage(100, to: session.playerSlots[0])
     #expect(session.playerSlots[0].currentHP == 0)
   }
 
   @Test func applyStressToPlayerSlot() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerStress(3, to: slotID)
+    session.applyStress(3, to: session.playerSlots[0])
     #expect(session.playerSlots[0].currentStress == 3)
   }
 
   @Test func playerStressClampsToMax() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerStress(100, to: slotID)
+    session.applyStress(100, to: session.playerSlots[0])
     #expect(session.playerSlots[0].currentStress == 6)
   }
 
   @Test func healPlayerSlot() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerDamage(4, to: slotID)
-    session.healPlayer(2, slotID: slotID)
+    session.applyDamage(4, to: session.playerSlots[0])
+    session.heal(2, to: session.playerSlots[0])
     #expect(session.playerSlots[0].currentHP == 4)
   }
 
   @Test func healPlayerClampsToMax() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerDamage(2, to: slotID)
-    session.healPlayer(100, slotID: slotID)
+    session.applyDamage(2, to: session.playerSlots[0])
+    session.heal(100, to: session.playerSlots[0])
     #expect(session.playerSlots[0].currentHP == 6)
   }
 
   @Test func clearPlayerStress() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerStress(4, to: slotID)
-    session.clearPlayerStress(2, slotID: slotID)
+    session.applyStress(4, to: session.playerSlots[0])
+    session.reduceStress(2, from: session.playerSlots[0])
     #expect(session.playerSlots[0].currentStress == 2)
   }
 
   @Test func markArmorSlotOnPlayer() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
+    session.add(player: makePlayer())
     let slotID = session.playerSlots[0].id
 
-    session.markPlayerArmorSlot(slotID)
+    session.markArmorSlot(for: slotID)
     #expect(session.playerSlots[0].currentArmorSlots == 2)
   }
 
@@ -628,50 +527,46 @@ struct PlayerSlotTests {
       evasion: player.evasion, thresholdMajor: player.thresholdMajor,
       thresholdSevere: player.thresholdSevere, armorSlots: 1
     )
-    session.addPlayer(player)
+    session.add(player: player)
     let slotID = session.playerSlots[0].id
 
-    session.markPlayerArmorSlot(slotID)
-    session.markPlayerArmorSlot(slotID)  // already at 0
+    session.markArmorSlot(for: slotID)
+    session.markArmorSlot(for: slotID)  // already at 0
     #expect(session.playerSlots[0].currentArmorSlots == 0)
   }
 
   @Test func emptyCustomConditionOnPlayerIsRejected() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerCondition(.custom(""), to: slotID)
+    session.applyCondition(.custom(""), to: session.playerSlots[0])
     #expect(session.playerSlots[0].conditions.isEmpty)
   }
 
   @Test func applyConditionToPlayerSlot() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerCondition(.vulnerable, to: slotID)
+    session.applyCondition(.vulnerable, to: session.playerSlots[0])
     #expect(session.playerSlots[0].conditions.contains(.vulnerable))
   }
 
   @Test func removeConditionFromPlayerSlot() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
-    let slotID = session.playerSlots[0].id
+    session.add(player: makePlayer())
 
-    session.applyPlayerCondition(.hidden, to: slotID)
-    session.removePlayerCondition(.hidden, from: slotID)
+    session.applyCondition(.hidden, to: session.playerSlots[0])
+    session.removeCondition(.hidden, from: session.playerSlots[0])
     #expect(!session.playerSlots[0].conditions.contains(.hidden))
   }
 
   @Test func removePlayerFromSession() {
     let session = makeSession()
-    session.addPlayer(makePlayer())
+    session.add(player: makePlayer())
     let slotID = session.playerSlots[0].id
 
     session.removePlayer(id: slotID)
     #expect(session.playerSlots.isEmpty)
-    #expect(!session.turnOrder.contains(slotID))
   }
 }
 
@@ -763,7 +658,7 @@ struct EncounterDefinitionTests {
     comp.addAdversary(
       Adversary(
         id: "ironguard-soldier", name: "Ironguard Soldier",
-        tier: 1, type: .bruiser, description: "A disciplined mercenary.",
+        tier: 1, role: .bruiser, flavorText: "A disciplined mercenary.",
         difficulty: 11, thresholdMajor: 5, thresholdSevere: 10,
         hp: 6, stress: 3, attackModifier: "+3", attackName: "Longsword",
         attackRange: .veryClose, damage: "1d10+3 phy"
@@ -771,7 +666,7 @@ struct EncounterDefinitionTests {
     comp.addEnvironment(
       DaggerheartEnvironment(
         id: "collapsing-bridge", name: "Collapsing Bridge",
-        description: "A rope-and-plank bridge."
+        flavorText: "A rope-and-plank bridge."
       ))
     return comp
   }
@@ -788,7 +683,7 @@ struct EncounterDefinitionTests {
       )
     ]
 
-    let session = EncounterSession.start(from: def, using: compendium)
+    let session = EncounterSession.make(from: def, using: compendium)
 
     #expect(session.name == "Test Battle")
     #expect(session.adversarySlots.count == 2)
@@ -796,7 +691,6 @@ struct EncounterDefinitionTests {
     #expect(session.playerSlots.count == 1)
     #expect(session.playerSlots[0].name == "Aldric")
     #expect(session.environmentSlots.count == 1)
-    #expect(session.currentRound == 1)
     #expect(session.fearPool == 0)
   }
 
@@ -805,7 +699,7 @@ struct EncounterDefinitionTests {
     var def = EncounterDefinition(name: "Test")
     def.adversaryIDs = ["ironguard-soldier", "nonexistent-creature"]
 
-    let session = EncounterSession.start(from: def, using: compendium)
+    let session = EncounterSession.make(from: def, using: compendium)
     #expect(session.adversarySlots.count == 1)
   }
 
@@ -814,23 +708,8 @@ struct EncounterDefinitionTests {
     var def = EncounterDefinition(name: "Test")
     def.gmNotes = "Remember the secret door."
 
-    let session = EncounterSession.start(from: def, using: compendium)
+    let session = EncounterSession.make(from: def, using: compendium)
     #expect(session.gmNotes == "Remember the secret door.")
-  }
-
-  @Test func sessionFromDefinitionBuildsTurnOrder() {
-    let compendium = makeCompendium()
-    var def = EncounterDefinition(name: "Test")
-    def.adversaryIDs = ["ironguard-soldier"]
-    def.playerConfigs = [
-      PlayerConfig(
-        name: "Aldric", maxHP: 6, maxStress: 6,
-        evasion: 12, thresholdMajor: 8, thresholdSevere: 15, armorSlots: 3
-      )
-    ]
-
-    let session = EncounterSession.start(from: def, using: compendium)
-    #expect(session.turnOrder.count == 2)
   }
 }
 
@@ -1015,8 +894,8 @@ struct DifficultyBudgetTests {
     let compendium = Compendium()
     compendium.addAdversary(
       Adversary(
-        id: "test-creature", name: "Test", tier: 1, type: .minion,
-        description: "desc", difficulty: 8, thresholdMajor: 3, thresholdSevere: 6,
+        id: "test-creature", name: "Test", tier: 1, role: .minion,
+        flavorText: "desc", difficulty: 8, thresholdMajor: 3, thresholdSevere: 6,
         hp: 3, stress: 2, attackModifier: "+1", attackName: "Bite",
         attackRange: .veryClose, damage: "1d6 phy"
       ))
@@ -1035,8 +914,8 @@ struct DifficultyBudgetTests {
 
   private func makeSoldier(id: String = "ironguard-soldier") -> Adversary {
     Adversary(
-      id: id, name: "Ironguard Soldier", tier: 1, type: .bruiser,
-      description: "A disciplined mercenary.", difficulty: 11,
+      id: id, name: "Ironguard Soldier", tier: 1, role: .bruiser,
+      flavorText: "A disciplined mercenary.", difficulty: 11,
       thresholdMajor: 5, thresholdSevere: 10, hp: 6, stress: 3,
       attackModifier: "+3", attackName: "Longsword",
       attackRange: .veryClose, damage: "1d10+3 phy"
@@ -1044,7 +923,7 @@ struct DifficultyBudgetTests {
   }
 
   private func makeEnv(id: String = "bridge") -> DaggerheartEnvironment {
-    DaggerheartEnvironment(id: id, name: "Bridge", description: "A rope bridge.")
+    DaggerheartEnvironment(id: id, name: "Bridge", flavorText: "A rope bridge.")
   }
 
   @Test func homebrewAdversaryAppearsInHomebrewList() {
@@ -1075,8 +954,8 @@ struct DifficultyBudgetTests {
     var variant = makeSoldier()
     compendium.addAdversary(variant)
     variant = Adversary(
-      id: "ironguard-soldier", name: "Elite Ironguard", tier: 2, type: .bruiser,
-      description: "Upgraded.", difficulty: 14, thresholdMajor: 7, thresholdSevere: 14,
+      id: "ironguard-soldier", name: "Elite Ironguard", tier: 2, role: .bruiser,
+      flavorText: "Upgraded.", difficulty: 14, thresholdMajor: 7, thresholdSevere: 14,
       hp: 10, stress: 4, attackModifier: "+5", attackName: "Longsword",
       attackRange: .veryClose, damage: "2d10+5 phy"
     )
@@ -1114,8 +993,8 @@ struct DifficultyBudgetTests {
 
   private func makeSoldier() -> Adversary {
     Adversary(
-      id: "ironguard-soldier", name: "Ironguard Soldier", tier: 1, type: .bruiser,
-      description: "A disciplined mercenary.", difficulty: 11,
+      id: "ironguard-soldier", name: "Ironguard Soldier", tier: 1, role: .bruiser,
+      flavorText: "A disciplined mercenary.", difficulty: 11,
       thresholdMajor: 5, thresholdSevere: 10, hp: 6, stress: 3,
       attackModifier: "+3", attackName: "Longsword",
       attackRange: .veryClose, damage: "1d10+3 phy"
@@ -1123,7 +1002,7 @@ struct DifficultyBudgetTests {
   }
 
   @Test func slotSnapshotsMaxHPAndMaxStress() {
-    let slot = AdversarySlot.from(makeSoldier())
+    let slot = AdversarySlot.make(from: makeSoldier())
     #expect(slot.maxHP == 6)
     #expect(slot.maxStress == 3)
   }
@@ -1131,40 +1010,36 @@ struct DifficultyBudgetTests {
   @Test func applyStressClampedToSnapshotMax() {
     let session = EncounterSession(name: "Test")
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyStress(100, to: slotID)
+    session.applyStress(100, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].currentStress == 3)
   }
 
   @Test func applyStressAccumulatesCorrectly() {
     let session = EncounterSession(name: "Test")
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyStress(1, to: slotID)
-    session.applyStress(1, to: slotID)
+    session.applyStress(1, to: session.adversarySlots[0])
+    session.applyStress(1, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].currentStress == 2)
   }
 
   @Test func healClampedToSnapshotMaxHP() {
     let session = EncounterSession(name: "Test")
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyDamage(4, to: slotID)
-    session.heal(100, slotID: slotID)
+    session.applyDamage(4, to: session.adversarySlots[0])
+    session.heal(100, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].currentHP == 6)
   }
 
   @Test func healFromZeroUnsetsDefeated() {
     let session = EncounterSession(name: "Test")
     session.add(adversary: makeSoldier())
-    let slotID = session.adversarySlots[0].id
 
-    session.applyDamage(999, to: slotID)
+    session.applyDamage(999, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].isDefeated == true)
-    session.heal(6, slotID: slotID)
+    session.heal(6, to: session.adversarySlots[0])
     #expect(session.adversarySlots[0].isDefeated == false)
     #expect(session.adversarySlots[0].currentHP == 6)
   }
@@ -1521,6 +1396,6 @@ struct EnvironmentModelTests {
     let env = try JSONDecoder().decode(DaggerheartEnvironment.self, from: json)
     #expect(env.id == "arcane-storm")
     #expect(env.features.count == 1)
-    #expect(env.features[0].featType == FeatureType.passive)
+    #expect(env.features[0].kind == FeatureType.passive)
   }
 }

--- a/EncounterTests/SessionRegistryTests.swift
+++ b/EncounterTests/SessionRegistryTests.swift
@@ -6,8 +6,8 @@
 //  and resetSession behavior.
 //
 
-import DaggerheartKit
-import DaggerheartModels
+import DHKit
+import DHModels
 import Foundation
 import Testing
 
@@ -19,8 +19,8 @@ import Testing
     let c = Compendium()
     c.addAdversary(
       Adversary(
-        id: "goblin", name: "Goblin", tier: 1, type: .minion,
-        description: "Small and cunning.", difficulty: 10,
+        id: "goblin", name: "Goblin", tier: 1, role: .minion,
+        flavorText: "Small and cunning.", difficulty: 10,
         thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
         attackModifier: "+2", attackName: "Rusty Blade",
         attackRange: .veryClose, damage: "1d4 phy"
@@ -72,7 +72,7 @@ import Testing
 
     let s1 = registry.session(for: def1.id, definition: def1, compendium: compendium)
     // Apply damage so s1 has mutated state.
-    s1.applyDamage(2, to: s1.adversarySlots[0].id)
+    s1.applyDamage(2, to: s1.adversarySlots[0])
     #expect(s1.adversarySlots[0].currentHP == 1)
 
     let s2 = registry.resetSession(for: def1.id, definition: def1, compendium: compendium)

--- a/EncounterUITests/EncounterUITests.swift
+++ b/EncounterUITests/EncounterUITests.swift
@@ -2,7 +2,6 @@
 //  EncounterUITests.swift
 //  EncounterUITests
 //
-//  Created by Joe Heck on 3/14/26.
 //
 
 import XCTest

--- a/EncounterUITests/EncounterUITestsLaunchTests.swift
+++ b/EncounterUITests/EncounterUITestsLaunchTests.swift
@@ -2,7 +2,6 @@
 //  EncounterUITestsLaunchTests.swift
 //  EncounterUITests
 //
-//  Created by Joe Heck on 3/14/26.
 //
 
 import XCTest

--- a/NOTICE
+++ b/NOTICE
@@ -1,0 +1,41 @@
+Encounter
+
+---
+
+## App Source Code
+
+The Encounter application source code is licensed under the MIT License.
+See the LICENSE file in this repository for the full text.
+
+---
+
+## Bundled SRD Content
+
+This application bundles adversary and environment data derived from the
+Daggerheart System Reference Document 1.0. That content is used under the
+terms of the Darrington Press Community Gaming License (DPCGL).
+
+Required attribution (DPCGL §4):
+
+  This product includes materials from the Daggerheart System Reference
+  Document 1.0, © Critical Role, LLC. under the terms of the Darrington
+  Press Community Gaming (DPCGL) License. More information can be found
+  at https://www.daggerheart.com. There are no previous modifications
+  by others.
+
+The bundled SRD data originates from the seansbox/daggerheart-srd
+repository (https://github.com/seansbox/daggerheart-srd), which exports
+the SRD content as structured JSON. The data has not been modified beyond
+format normalization for decoding compatibility.
+
+Full DPCGL license text: https://darringtonpress.com/license/
+
+---
+
+## Disclaimer
+
+This application is not affiliated with, endorsed by, or sponsored by
+Darrington Press, LLC or Critical Role, LLC.
+
+Daggerheart is a trademark of Critical Role, LLC and is used here in
+accordance with the Darrington Press Community Gaming License.

--- a/README.md
+++ b/README.md
@@ -25,8 +25,8 @@ plain JSON file containing adversaries, environments, or both.
 - [Sharing and hosting](https://gwillish.github.io/encounter/documentation/encounter/sharingandhostingpacks) — AirDrop, URL sources, GitHub Releases, jsDelivr, Gist
 
 The JSON Schema for `.dhpack` is maintained in the
-[DaggerheartModels](https://github.com/gwillish/DaggerheartModels) repository.
-Add `"$schema": "https://raw.githubusercontent.com/gwillish/DaggerheartModels/main/schemas/dhpack.schema.json"`
+[DHModels](https://github.com/gwillish/DHModels) repository.
+Add `"$schema": "https://raw.githubusercontent.com/gwillish/DHModels/main/schemas/dhpack.schema.json"`
 to your pack file to enable validation and autocomplete in VS Code.
 
 ## Architecture Decision Records
@@ -39,3 +39,22 @@ When a decision turns out to be wrong or needs to change, a new ADR is written
 that supersedes the original. The original is never edited or deleted — the
 reasoning history is preserved. See `docs/decisions/README.md` for the full
 process.
+
+## License & Attribution
+
+The Encounter app source code is licensed under the [MIT License](LICENSE).
+
+This app bundles content from the Daggerheart System Reference Document 1.0,
+used under the Darrington Press Community Gaming License (DPCGL):
+
+> This product includes materials from the Daggerheart System Reference Document 1.0,
+> © Critical Role, LLC. under the terms of the Darrington Press Community Gaming (DPCGL)
+> License. More information can be found at https://www.daggerheart.com. There are no
+> previous modifications by others.
+
+Full DPCGL license text: https://darringtonpress.com/license/
+
+See [NOTICE](NOTICE) for the complete dual-license breakdown.
+
+This project is not affiliated with, endorsed by, or sponsored by Darrington Press, LLC
+or Critical Role, LLC. Daggerheart is a trademark of Critical Role, LLC.


### PR DESCRIPTION
## Summary

- **DPCGL compliance**: Add `NOTICE` dual-license file (MIT for source, DPCGL for bundled SRD data); add attribution section to `README.md`; add `AboutView.swift` with in-app attribution visible to users (required by DPCGL §4)
- **Package rename**: `DaggerheartModels` → `DHModels`, `DaggerheartKit` → `DHKit` across all 51 Swift files and the Xcode project — avoids using the DAGGERHEART Name Mark (DPCGL §2.5) in a title-like position
- **Upstream API migration**: Migrated to breaking changes in `gwillish/DHModels` (formerly `gwillish/DaggerheartModels`): unified `CombatParticipant` protocol for all damage/heal/stress/condition mutations; spotlight system replaces turn order; `EncounterSession.make(from:using:)` factory rename; `add(player:)` label; `spendFear/Hope(by:)` labels; `EncounterFeature.kind` replaces `.featType`

## Test plan

- [x] All 143 unit tests pass: `xcodebuild test -scheme Encounter -destination 'platform=macOS'`
- [ ] Manually verify About sheet appears on macOS (Help menu → About Encounter)
- [ ] Manually verify About sheet appears on iOS simulator (info toolbar button in library)
- [ ] Review `inquiry_email.md` in repo root before sending to Darrington Press

🤖 Generated with [Claude Code](https://claude.ai/claude-code)