### PR TITLE
feat: defeated adversaries collapse-only and sort to bottom (#35)

### DIFF
--- a/Encounter/Views/AdversaryRunnerSection.swift
+++ b/Encounter/Views/AdversaryRunnerSection.swift
@@ -19,14 +19,13 @@ struct AdversaryRunnerSection: View {
 
   var body: some View {
     ForEach(slots) { slot in
-      if expandedSlotID == slot.id {
+      if expandedSlotID == slot.id && !slot.isDefeated {
         AdversaryRunnerCard(
           slot: slot,
           session: session,
           compendium: compendium,
           onCollapse: { expandedSlotID = nil }
         )
-        .opacity(slot.isDefeated ? 0.4 : 1.0)
         .listRowSeparator(.hidden)
       } else {
         Button {
@@ -37,6 +36,7 @@ struct AdversaryRunnerSection: View {
             .contentShape(Rectangle())
         }
         .buttonStyle(.plain)
+        .disabled(slot.isDefeated)
         .accessibilityIdentifier("runner.adversary-row")
         .accessibilityValue(slot.customName ?? slot.adversaryID)
       }

--- a/Encounter/Views/AdversaryRunnerSection.swift
+++ b/Encounter/Views/AdversaryRunnerSection.swift
@@ -38,7 +38,12 @@ struct AdversaryRunnerSection: View {
         .buttonStyle(.plain)
         .disabled(slot.isDefeated)
         .accessibilityIdentifier("runner.adversary-row")
-        .accessibilityValue(slot.customName ?? slot.adversaryID)
+        .accessibilityLabel(
+          slot.isDefeated
+            ? "\(slot.customName ?? slot.adversaryID), defeated"
+            : (slot.customName ?? slot.adversaryID)
+        )
+        .accessibilityHint(slot.isDefeated ? "" : "Tap to expand")
       }
     }
   }


### PR DESCRIPTION
## Summary

- Defeated adversaries (HP = 0) are now collapsed-only: the expand condition gates on `!slot.isDefeated`, and the collapsed-row button is `.disabled` for defeated slots
- Sort to bottom and 40% opacity were already implemented; this completes the remaining acceptance criteria from #35

## Test plan

- [ ] All unit tests pass (`xcodebuild test -scheme Encounter -destination 'platform=macOS'`)
- [ ] Damage an adversary to 0 HP → row moves to bottom of list at 40% opacity
- [ ] Tapping a defeated row does nothing (cannot expand)
- [ ] Restore HP above 0 → adversary returns to active section and can be expanded again
- [ ] Active adversary order is otherwise stable (original encounter order preserved)

Closes #35