### PR TITLE
feat: end encounter and reset session (#40)

### DIFF
--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -140,7 +140,7 @@ struct EncounterBuilderView: View {
           Task { await sessionStore.delete(sessionID: sessionID) }
         }
       }
-      Button("Cancel", role: .cancel) {}
+      .accessibilityIdentifier("builder.reset-confirm-button")
     } message: {
       Text("The current session will be cleared. The encounter definition is not changed.")
     }
@@ -176,9 +176,9 @@ struct EncounterBuilderView: View {
       }
       .accessibilityIdentifier("builder.browse-compendium-button")
     }
-    if hasActiveSession {
-      ToolbarItem(placement: .secondaryAction) {
-        Button("Reset Session", role: .destructive) {
+    ToolbarItem(placement: .secondaryAction) {
+      if hasActiveSession {
+        Button("Reset Session") {
           showResetConfirmation = true
         }
         .accessibilityIdentifier("builder.reset-button")

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -21,6 +21,7 @@ struct EncounterBuilderView: View {
   @Environment(EncounterStore.self) private var store
   @Environment(Compendium.self) private var compendium
   @Environment(SessionRegistry.self) private var sessionRegistry
+  @Environment(SessionStore.self) private var sessionStore
   @Environment(PlayerStore.self) private var playerStore
 
   @State private var showCompendium = false
@@ -29,10 +30,17 @@ struct EncounterBuilderView: View {
   @State private var saveError: String?
   @State private var runSession: EncounterSession?
   @State private var saveTask: Task<Void, Never>?
+  @State private var showResetConfirmation = false
 
   init(definition: EncounterDefinition) {
     self.definition = definition
     _draft = State(initialValue: definition)
+  }
+
+  // MARK: - Session state
+
+  private var hasActiveSession: Bool {
+    sessionRegistry.sessions[draft.id] != nil
   }
 
   // MARK: - Computed difficulty
@@ -120,6 +128,22 @@ struct EncounterBuilderView: View {
     .navigationDestination(item: $runSession) { session in
       EncounterRunnerView(session: session, definition: draft)
     }
+    .confirmationDialog(
+      "Reset Session?",
+      isPresented: $showResetConfirmation,
+      titleVisibility: .visible
+    ) {
+      Button("Reset Session", role: .destructive) {
+        let sessionID = sessionRegistry.sessions[draft.id]?.id
+        sessionRegistry.clearSession(for: draft.id)
+        if let sessionID {
+          Task { await sessionStore.delete(sessionID: sessionID) }
+        }
+      }
+      Button("Cancel", role: .cancel) {}
+    } message: {
+      Text("The current session will be cleared. The encounter definition is not changed.")
+    }
     .onChange(of: definition) { _, newDefinition in
       if newDefinition.modifiedAt > draft.modifiedAt {
         draft = newDefinition
@@ -151,6 +175,14 @@ struct EncounterBuilderView: View {
         showCompendium = true
       }
       .accessibilityIdentifier("builder.browse-compendium-button")
+    }
+    if hasActiveSession {
+      ToolbarItem(placement: .secondaryAction) {
+        Button("Reset Session", role: .destructive) {
+          showResetConfirmation = true
+        }
+        .accessibilityIdentifier("builder.reset-button")
+      }
     }
   }
 
@@ -230,6 +262,7 @@ struct EncounterBuilderView: View {
   .environment(store)
   .environment(compendium)
   .environment(SessionRegistry())
+  .environment(SessionStore(directory: .temporaryDirectory))
   .environment(playerStore)
 }
 

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -21,7 +21,7 @@ struct EncounterRunnerView: View {
 
   @Environment(Compendium.self) private var compendium
   @Environment(SessionRegistry.self) private var sessionRegistry
-  @Environment(SessionStore.self) private var sessionStore
+  @Environment(\.dismiss) private var dismiss
   @State private var expandedSlotID: UUID?
 
   // MARK: - Sorted slots (computed, non-mutating)
@@ -51,12 +51,10 @@ struct EncounterRunnerView: View {
           .accessibilityIdentifier("runner.fear-tracker-button")
       }
       ToolbarItem(placement: .secondaryAction) {
-        Button("Reset Session") {
-          let oldSessionID = session.id
-          sessionRegistry.resetSession(for: definition, compendium: compendium)
-          Task { await sessionStore.delete(sessionID: oldSessionID) }
+        Button("End Encounter") {
+          dismiss()
         }
-        .accessibilityIdentifier("runner.reset-button")
+        .accessibilityIdentifier("runner.end-button")
       }
     }
     .safeAreaInset(edge: .bottom) {

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -21,8 +21,10 @@ struct EncounterRunnerView: View {
 
   @Environment(Compendium.self) private var compendium
   @Environment(SessionRegistry.self) private var sessionRegistry
+  @Environment(SessionStore.self) private var sessionStore
   @Environment(\.dismiss) private var dismiss
   @State private var expandedSlotID: UUID?
+  @State private var showResetConfirmation = false
 
   // MARK: - Sorted slots (computed, non-mutating)
   // Active adversaries preserve original insertion order (stable sort).
@@ -56,6 +58,27 @@ struct EncounterRunnerView: View {
         }
         .accessibilityIdentifier("runner.end-button")
       }
+      ToolbarItem(placement: .secondaryAction) {
+        Button("Reset Session") {
+          showResetConfirmation = true
+        }
+        .accessibilityIdentifier("runner.reset-button")
+      }
+    }
+    .confirmationDialog(
+      "Reset Session?",
+      isPresented: $showResetConfirmation,
+      titleVisibility: .visible
+    ) {
+      Button("Reset Session", role: .destructive) {
+        let sessionID = session.id
+        sessionRegistry.clearSession(for: definition.id)
+        Task { await sessionStore.delete(sessionID: sessionID) }
+        dismiss()
+      }
+      .accessibilityIdentifier("runner.reset-confirm-button")
+    } message: {
+      Text("The current session will be cleared. The encounter definition is not changed.")
     }
     .safeAreaInset(edge: .bottom) {
       PlayerStrip(session: session)

--- a/EncounterTests/SessionStoreTests.swift
+++ b/EncounterTests/SessionStoreTests.swift
@@ -151,6 +151,26 @@ import Testing
     #expect(registry.sessions.isEmpty)
   }
 
+  @Test func clearRegistryAndDeleteLeavesNoPersistedSession() async throws {
+    let dir = tempDir()
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store = SessionStore(directory: dir)
+    let compendium = makeCompendium()
+    let def = EncounterDefinition(name: "Battle", adversaryIDs: ["goblin"])
+    let registry = SessionRegistry()
+    let session = registry.session(for: def, compendium: compendium)
+    await store.save(session)
+
+    // Simulate the reset flow: capture ID, clear registry entry, delete file.
+    let sessionID = session.id
+    registry.clearSession(for: def.id)
+    await store.delete(sessionID: sessionID)
+
+    let fresh = SessionRegistry()
+    await store.load(into: fresh)
+    #expect(fresh.sessions.isEmpty)
+  }
+
   @Test func deleteNeverSavedSessionIsNoop() async {
     let dir = tempDir()
     defer { try? FileManager.default.removeItem(at: dir) }

--- a/EncounterUITests/EncounterUITestCase.swift
+++ b/EncounterUITests/EncounterUITestCase.swift
@@ -134,6 +134,38 @@ class EncounterUITestCase: XCTestCase {
       "Builder should be visible after compendium sheet dismisses")
   }
 
+  /// Taps "End Encounter" from the runner's secondary-action overflow menu.
+  func tapEndEncounter() {
+    let overflow = app.buttons["OverflowBarButtonItem"]
+    XCTAssertTrue(
+      overflow.waitForExistence(timeout: 5),
+      "Overflow button should be in runner toolbar")
+    overflow.tap()
+    let endButton = app.buttons["End Encounter"]
+    XCTAssertTrue(endButton.waitForExistence(timeout: 3), "End Encounter should appear in overflow")
+    endButton.tap()
+    XCTAssertTrue(
+      app.buttons["builder.add-adversary-button"].waitForExistence(timeout: 5),
+      "Should return to builder after ending encounter")
+  }
+
+  /// Taps "Reset Session" from the runner's secondary-action overflow and confirms the dialog.
+  func tapResetSessionFromRunner() {
+    let overflow = app.buttons["OverflowBarButtonItem"]
+    XCTAssertTrue(
+      overflow.waitForExistence(timeout: 5),
+      "Overflow button should be in runner toolbar")
+    overflow.tap()
+    let resetButton = app.buttons["Reset Session"]
+    XCTAssertTrue(resetButton.waitForExistence(timeout: 3), "Reset Session should appear in overflow")
+    resetButton.tap()
+    let confirmButton = app.buttons["runner.reset-confirm-button"]
+    XCTAssertTrue(
+      confirmButton.waitForExistence(timeout: 3),
+      "Reset Session confirmation button should appear")
+    confirmButton.tap()
+  }
+
   func tapRunEncounter() {
     // On iOS 26 with .toolbarRole(.editor), toolbar items collapse into an
     // OverflowBarButtonItem ("More") menu. AX identifiers are NOT preserved

--- a/EncounterUITests/EncounterUITestCase.swift
+++ b/EncounterUITests/EncounterUITestCase.swift
@@ -159,7 +159,9 @@ class EncounterUITestCase: XCTestCase {
     let resetButton = app.buttons["Reset Session"]
     XCTAssertTrue(resetButton.waitForExistence(timeout: 3), "Reset Session should appear in overflow")
     resetButton.tap()
-    let confirmButton = app.buttons["runner.reset-confirm-button"]
+    // confirmationDialog on iOS 26 exposes its buttons in two places in the AX tree
+    // (action sheet layer + source view hierarchy), so use firstMatch to avoid ambiguity.
+    let confirmButton = app.buttons.matching(identifier: "runner.reset-confirm-button").firstMatch
     XCTAssertTrue(
       confirmButton.waitForExistence(timeout: 3),
       "Reset Session confirmation button should appear")

--- a/EncounterUITests/RunnerUITests.swift
+++ b/EncounterUITests/RunnerUITests.swift
@@ -131,7 +131,9 @@ final class RunnerUITests: EncounterUITestCase {
     app.buttons["Reset Session"].tap()
 
     // Confirm the destruction.
-    let confirmButton = app.buttons["builder.reset-confirm-button"]
+    // confirmationDialog on iOS 26 exposes its buttons in two places in the AX tree
+    // (action sheet layer + source view hierarchy), so use firstMatch to avoid ambiguity.
+    let confirmButton = app.buttons.matching(identifier: "builder.reset-confirm-button").firstMatch
     XCTAssertTrue(confirmButton.waitForExistence(timeout: 3), "Confirmation button should appear")
     confirmButton.tap()
 

--- a/EncounterUITests/RunnerUITests.swift
+++ b/EncounterUITests/RunnerUITests.swift
@@ -68,6 +68,82 @@ final class RunnerUITests: EncounterUITestCase {
     )
   }
 
+  // MARK: - End Encounter / Reset Session
+
+  /// Tapping "End Encounter" returns to the builder; the session stays alive
+  /// (Reset Session appears in the builder toolbar overflow).
+  func testEndEncounterReturnsToBuilderWithActiveSession() throws {
+    navigateToRunner()
+    XCTAssertTrue(
+      app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5),
+      "Should be in the runner")
+
+    tapEndEncounter()
+
+    // Builder is visible and the overflow contains "Reset Session" (active session present).
+    let overflow = app.buttons["OverflowBarButtonItem"]
+    XCTAssertTrue(overflow.waitForExistence(timeout: 3), "Builder toolbar overflow should be present")
+    overflow.tap()
+    XCTAssertTrue(
+      app.buttons["Reset Session"].waitForExistence(timeout: 3),
+      "Reset Session should appear in builder toolbar when a session is active")
+    // Dismiss the overflow without tapping Reset.
+    app.buttons["Reset Session"].tap()  // will show dialog
+    // Dismiss dialog by tapping cancel (swipe down on action sheet).
+    app.navigationBars.firstMatch.tap()
+  }
+
+  /// Tapping "Reset Session" from the runner, then confirming, clears the session
+  /// and returns to the builder; "Reset Session" does not appear in the builder toolbar.
+  func testResetSessionFromRunner() throws {
+    navigateToRunner()
+    XCTAssertTrue(
+      app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5),
+      "Should be in the runner")
+
+    tapResetSessionFromRunner()
+
+    // Back in builder with no active session — Reset Session should not appear in overflow.
+    let overflow = app.buttons["OverflowBarButtonItem"]
+    XCTAssertTrue(overflow.waitForExistence(timeout: 3))
+    overflow.tap()
+    XCTAssertFalse(
+      app.buttons["Reset Session"].waitForExistence(timeout: 2),
+      "Reset Session should not appear in builder toolbar after session was reset")
+  }
+
+  /// After ending an encounter, the builder's "Reset Session" clears the session;
+  /// tapping "Run Encounter" again starts a fresh session.
+  func testResetSessionFromBuilder() throws {
+    navigateToRunner()
+    XCTAssertTrue(
+      app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5))
+
+    tapEndEncounter()
+
+    // Tap Reset Session from the builder toolbar overflow.
+    let overflow = app.buttons["OverflowBarButtonItem"]
+    XCTAssertTrue(overflow.waitForExistence(timeout: 3))
+    overflow.tap()
+    XCTAssertTrue(
+      app.buttons["Reset Session"].waitForExistence(timeout: 3),
+      "Reset Session should be in builder toolbar overflow")
+    app.buttons["Reset Session"].tap()
+
+    // Confirm the destruction.
+    let confirmButton = app.buttons["builder.reset-confirm-button"]
+    XCTAssertTrue(confirmButton.waitForExistence(timeout: 3), "Confirmation button should appear")
+    confirmButton.tap()
+
+    // Session is cleared — Reset Session should no longer appear in the overflow.
+    let overflow2 = app.buttons["OverflowBarButtonItem"]
+    XCTAssertTrue(overflow2.waitForExistence(timeout: 3))
+    overflow2.tap()
+    XCTAssertFalse(
+      app.buttons["Reset Session"].waitForExistence(timeout: 2),
+      "Reset Session should disappear after confirming reset")
+  }
+
   // MARK: - Stress button
 
   /// Tapping +1 Stress in the expanded card is reflected in the stress pip track.


### PR DESCRIPTION
## Summary

- **Runner**: replaced the in-place "Reset Session" button with "End Encounter", which calls `dismiss()` and returns to the builder while leaving the session intact in `SessionRegistry`
- **Builder**: added a "Reset Session" secondary toolbar button that appears only when an active session exists (`sessionRegistry.sessions[draft.id] != nil`); tapping it shows a `confirmationDialog`, and confirming clears the registry entry and deletes the persisted `.session.json` file
- After reset, tapping "Run Encounter" starts a fresh session from scratch; the `EncounterDefinition` (roster, players, notes) is unchanged

Closes #40

## Test plan

- [x] Run an encounter, tap "End Encounter" → returns to builder; tap "Run Encounter" again → resumes the same session
- [x] Run an encounter, tap "End Encounter" → builder shows "Reset Session" in the toolbar menu
- [x] Tap "Reset Session", confirm → session cleared; tap "Run Encounter" → new session starts from scratch (all HP/stress reset)
- [x] Tap "Reset Session", cancel → session still active
- [x] Check that the encounter definition (adversary roster, players, notes) is unchanged after reset
- [x] Unit tests pass: `xcodebuild test -scheme Encounter -destination 'platform=macOS'`