### PR TITLE
fix: replace Toggle with checkbox rows in difficulty panel

### DIFF
--- a/Encounter/Views/DifficultyAssessorView.swift
+++ b/Encounter/Views/DifficultyAssessorView.swift
@@ -101,13 +101,25 @@ struct DifficultyAssessorView: View {
         }
 
         // Manual GM-discretionary toggles
-        VStack(alignment: .leading, spacing: 2) {
+        VStack(alignment: .leading, spacing: 4) {
           ForEach(Self.manualCases, id: \.self) { adj in
-            Toggle(adj.displayName, isOn: toggleBinding(for: adj))
-              .font(.caption)
-              .accessibilityIdentifier(
-                "builder.difficulty.toggle.\(String(describing: adj))"
-              )
+            let isOn = manualAdjustments.contains(adj)
+            HStack(spacing: 6) {
+              Image(systemName: isOn ? "checkmark.square.fill" : "square")
+                .font(.caption)
+                .foregroundStyle(isOn ? difficultyColor : .secondary)
+              Text(adj.displayName)
+                .font(.caption)
+            }
+            .contentShape(Rectangle())
+            .onTapGesture {
+              if isOn { manualAdjustments.remove(adj) } else { manualAdjustments.insert(adj) }
+            }
+            .accessibilityElement(children: .ignore)
+            .accessibilityLabel(adj.displayName)
+            .accessibilityValue(isOn ? "on" : "off")
+            .accessibilityAddTraits(.isButton)
+            .accessibilityIdentifier("builder.difficulty.toggle.\(String(describing: adj))")
           }
         }
       }

--- a/EncounterUITests/RunnerUITests.swift
+++ b/EncounterUITests/RunnerUITests.swift
@@ -80,6 +80,13 @@ final class RunnerUITests: EncounterUITestCase {
 
     tapEndEncounter()
 
+    // Capture the builder with the difficulty panel visible for visual verification.
+    let screenshot = app.screenshot()
+    let attachment = XCTAttachment(screenshot: screenshot)
+    attachment.name = "builder-difficulty-panel"
+    attachment.lifetime = .keepAlways
+    add(attachment)
+
     // Builder is visible and the overflow contains "Reset Session" (active session present).
     let overflow = app.buttons["OverflowBarButtonItem"]
     XCTAssertTrue(overflow.waitForExistence(timeout: 3), "Builder toolbar overflow should be present")


### PR DESCRIPTION
## Summary

- iOS `Toggle` renders as a UISwitch with a fixed minimum height (~31 pt), which overflows and overlaps adjacent rows at caption-text density — four switches stacked with 2 pt spacing produced a visual pile-up that clipped at the right edge of the panel
- Replaced all four manual-adjustment `Toggle` rows in `DifficultyAssessorView` with compact `HStack` rows using `checkmark.square.fill` / `square` SF Symbols; tap semantics and the full accessibility surface (label, value, button trait, AX identifier) are preserved
- Layout is now caption-appropriate on both iOS and macOS — verified via Xcode Preview (macOS) and an XCUITest screenshot attachment (iOS)
- Added `XCTAttachment` screenshot capture to `testEndEncounterReturnsToBuilderWithActiveSession` so the builder difficulty panel state is permanently recorded in the xcresult for future visual regression checks

## Test plan

- [x] Difficulty panel rows are compact and non-overlapping on iOS (screenshot attachment in xcresult)
- [x] macOS Xcode Preview shows clean checkbox rows
- [x] All 5 `RunnerUITests` pass on iPhone 17 Pro simulator
- [x] All unit tests pass on macOS (`xcodebuild test -scheme Encounter -destination 'platform=macOS'`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)