### PR TITLE
feat: player condition toggles in popover and strip row (#38)

### DIFF
--- a/Encounter/Views/PlayerConditionsSection.swift
+++ b/Encounter/Views/PlayerConditionsSection.swift
@@ -36,12 +36,14 @@ struct PlayerConditionsSection: View {
             .font(.caption)
             .buttonStyle(.bordered)
             .tint(active ? .orange : nil)
-            .accessibilityAddTraits(active ? .isSelected : [])
+            .accessibilityValue(active ? "active" : "inactive")
+            .accessibilityHint(active ? "Removes this condition" : "Applies this condition")
             .accessibilityIdentifier(
               "runner.player-edit.condition.\(condition.displayName.lowercased())"
             )
           }
         }
+        .padding(.horizontal, 4)
       }
     }
   }

--- a/Encounter/Views/PlayerConditionsSection.swift
+++ b/Encounter/Views/PlayerConditionsSection.swift
@@ -1,0 +1,61 @@
+//
+//  PlayerConditionsSection.swift
+//  Encounter
+//
+//  Condition toggle strip for a player slot in the live encounter runner.
+//
+
+import DHKit
+import DHModels
+import SwiftUI
+
+/// Displays toggleable condition buttons for a player slot.
+///
+/// Active conditions are highlighted in orange. Tapping a condition applies
+/// or removes it from the slot via the session.
+struct PlayerConditionsSection: View {
+  let player: PlayerState
+  let session: EncounterSession
+
+  var body: some View {
+    VStack(alignment: .leading, spacing: 6) {
+      Text("Conditions")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      ScrollView(.horizontal, showsIndicators: false) {
+        HStack(spacing: 6) {
+          ForEach(Condition.standardConditions, id: \.self) { condition in
+            let active = player.conditions.contains(condition)
+            Button(condition.displayName) {
+              if active {
+                session.removeCondition(condition, from: player.id)
+              } else {
+                session.applyCondition(condition, to: player.id)
+              }
+            }
+            .font(.caption)
+            .buttonStyle(.bordered)
+            .tint(active ? .orange : nil)
+            .accessibilityAddTraits(active ? .isSelected : [])
+            .accessibilityIdentifier(
+              "runner.player-edit.condition.\(condition.displayName.lowercased())"
+            )
+          }
+        }
+      }
+    }
+  }
+}
+
+#Preview {
+  let session = EncounterSession(name: "Test")
+  session.add(
+    player: PlayerState(
+      name: "Aric Stonehammer",
+      maxHP: 6, maxStress: 6, evasion: 12,
+      thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3
+    ))
+  session.applyCondition(.hidden, to: session.playerSlots[0].id)
+  return PlayerConditionsSection(player: session.playerSlots[0], session: session)
+    .padding()
+}

--- a/Encounter/Views/PlayerEditPopover.swift
+++ b/Encounter/Views/PlayerEditPopover.swift
@@ -44,6 +44,10 @@ struct PlayerEditPopover: View {
           onIncrement: { session.restoreArmorSlot(for: player.id) }
         )
       }
+
+      Divider()
+
+      PlayerConditionsSection(player: player, session: session)
     }
     .padding()
     .frame(minWidth: 220)

--- a/Encounter/Views/PlayerStripRow.swift
+++ b/Encounter/Views/PlayerStripRow.swift
@@ -20,38 +20,61 @@ struct PlayerStripRow: View {
     Button {
       showPopover = true
     } label: {
-      HStack(spacing: 8) {
-        Text(player.name)
-          .font(.caption)
-          .fontWeight(.medium)
-          .frame(minWidth: 60, alignment: .leading)
-          .lineLimit(1)
-          .truncationMode(.tail)
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 8) {
+          Text(player.name)
+            .font(.caption)
+            .fontWeight(.medium)
+            .frame(minWidth: 60, alignment: .leading)
+            .lineLimit(1)
+            .truncationMode(.tail)
 
-        Spacer()
+          Spacer()
 
-        HStack(spacing: 4) {
-          Text("HP")
-            .font(.caption2)
-            .foregroundStyle(.secondary)
-          PipTrack(current: player.currentHP, maximum: player.maxHP)
-        }
-
-        HStack(spacing: 4) {
-          Text("St")
-            .font(.caption2)
-            .foregroundStyle(.secondary)
-          PipTrack(current: player.currentStress, maximum: player.maxStress)
-        }
-
-        if player.armorSlots > 0 {
           HStack(spacing: 4) {
-            Text("Arm")
+            Text("HP")
               .font(.caption2)
               .foregroundStyle(.secondary)
-            Text("\(player.currentArmorSlots)/\(player.armorSlots)")
-              .font(.caption)
-              .monospacedDigit()
+            PipTrack(current: player.currentHP, maximum: player.maxHP)
+          }
+
+          HStack(spacing: 4) {
+            Text("St")
+              .font(.caption2)
+              .foregroundStyle(.secondary)
+            PipTrack(current: player.currentStress, maximum: player.maxStress)
+          }
+
+          if player.armorSlots > 0 {
+            HStack(spacing: 4) {
+              Text("Arm")
+                .font(.caption2)
+                .foregroundStyle(.secondary)
+              Text("\(player.currentArmorSlots)/\(player.armorSlots)")
+                .font(.caption)
+                .monospacedDigit()
+            }
+          }
+        }
+
+        if !player.conditions.isEmpty {
+          HStack(spacing: 6) {
+            ForEach(
+              player.conditions.sorted { $0.displayName < $1.displayName }, id: \.self
+            ) { condition in
+              HStack(spacing: 3) {
+                Image(systemName: "circle.fill")
+                  .font(.system(size: 5))
+                Text(condition.displayName)
+                  .font(.caption2)
+              }
+              .foregroundStyle(.orange)
+              .accessibilityElement(children: .ignore)
+              .accessibilityLabel(condition.displayName)
+              .accessibilityIdentifier(
+                "runner.player-row.condition.\(condition.displayName.lowercased())"
+              )
+            }
           }
         }
       }
@@ -59,7 +82,11 @@ struct PlayerStripRow: View {
     }
     .buttonStyle(.plain)
     .accessibilityIdentifier("runner.player-row")
-    .accessibilityLabel(player.name)
+    .accessibilityLabel(
+      player.conditions.isEmpty
+        ? player.name
+        : player.name + ", " + player.conditions.map(\.displayName).sorted().joined(separator: ", ")
+    )
     .popover(isPresented: $showPopover) {
       PlayerEditPopover(player: player, session: session)
         .presentationCompactAdaptation(.popover)

--- a/Encounter/Views/PlayerStripRow.swift
+++ b/Encounter/Views/PlayerStripRow.swift
@@ -16,6 +16,10 @@ struct PlayerStripRow: View {
   let session: EncounterSession
   @State private var showPopover = false
 
+  private var sortedConditions: [Condition] {
+    player.conditions.sorted { $0.displayName < $1.displayName }
+  }
+
   var body: some View {
     Button {
       showPopover = true
@@ -57,23 +61,15 @@ struct PlayerStripRow: View {
           }
         }
 
-        if !player.conditions.isEmpty {
+        if !sortedConditions.isEmpty {
           HStack(spacing: 6) {
-            ForEach(
-              player.conditions.sorted { $0.displayName < $1.displayName }, id: \.self
-            ) { condition in
-              HStack(spacing: 3) {
-                Image(systemName: "circle.fill")
-                  .font(.system(size: 5))
-                Text(condition.displayName)
-                  .font(.caption2)
-              }
-              .foregroundStyle(.orange)
-              .accessibilityElement(children: .ignore)
-              .accessibilityLabel(condition.displayName)
-              .accessibilityIdentifier(
-                "runner.player-row.condition.\(condition.displayName.lowercased())"
-              )
+            ForEach(sortedConditions, id: \.self) { condition in
+              Text("• \(condition.displayName)")
+                .font(.caption2)
+                .foregroundStyle(.orange)
+                .accessibilityIdentifier(
+                  "runner.player-row.condition.\(condition.displayName.lowercased())"
+                )
             }
           }
         }
@@ -83,10 +79,11 @@ struct PlayerStripRow: View {
     .buttonStyle(.plain)
     .accessibilityIdentifier("runner.player-row")
     .accessibilityLabel(
-      player.conditions.isEmpty
+      sortedConditions.isEmpty
         ? player.name
-        : player.name + ", " + player.conditions.map(\.displayName).sorted().joined(separator: ", ")
+        : player.name + ", " + sortedConditions.map(\.displayName).joined(separator: ", ")
     )
+    .accessibilityHint("Opens player details")
     .popover(isPresented: $showPopover) {
       PlayerEditPopover(player: player, session: session)
         .presentationCompactAdaptation(.popover)

--- a/EncounterTests/PlayerConditionsTests.swift
+++ b/EncounterTests/PlayerConditionsTests.swift
@@ -15,6 +15,8 @@ import Testing
 
 @MainActor struct PlayerConditionsTests {
 
+  // Returns a session and a snapshot of playerSlots[0] at creation time.
+  // Post-mutation assertions must use session.playerSlots[0], not the returned player.
   private func makeSession() -> (EncounterSession, PlayerState) {
     let session = EncounterSession(name: "Test")
     session.add(

--- a/EncounterTests/PlayerConditionsTests.swift
+++ b/EncounterTests/PlayerConditionsTests.swift
@@ -1,0 +1,101 @@
+//
+//  PlayerConditionsTests.swift
+//  EncounterTests
+//
+//  Unit tests for player condition apply/remove via EncounterSession,
+//  covering the logic exercised by PlayerConditionsSection.
+//
+
+import DHKit
+import DHModels
+import Foundation
+import Testing
+
+@testable import Encounter
+
+@MainActor struct PlayerConditionsTests {
+
+  private func makeSession() -> (EncounterSession, PlayerState) {
+    let session = EncounterSession(name: "Test")
+    session.add(
+      player: PlayerState(
+        name: "Aric", maxHP: 6, maxStress: 6, evasion: 12,
+        thresholdMajor: 5, thresholdSevere: 10, armorSlots: 3
+      ))
+    let player = session.playerSlots[0]
+    return (session, player)
+  }
+
+  // MARK: - applyCondition
+
+  @Test func applyConditionAddsToPlayerSlot() {
+    let (session, player) = makeSession()
+    session.applyCondition(.hidden, to: player.id)
+    #expect(session.playerSlots[0].conditions.contains(.hidden))
+  }
+
+  @Test func applyConditionIsIdempotent() {
+    let (session, player) = makeSession()
+    session.applyCondition(.restrained, to: player.id)
+    session.applyCondition(.restrained, to: player.id)
+    #expect(session.playerSlots[0].conditions.count == 1)
+  }
+
+  @Test func applyMultipleConditions() {
+    let (session, player) = makeSession()
+    session.applyCondition(.hidden, to: player.id)
+    session.applyCondition(.vulnerable, to: player.id)
+    #expect(session.playerSlots[0].conditions.count == 2)
+    #expect(session.playerSlots[0].conditions.contains(.hidden))
+    #expect(session.playerSlots[0].conditions.contains(.vulnerable))
+  }
+
+  // MARK: - removeCondition
+
+  @Test func removeConditionClearsFromPlayerSlot() {
+    let (session, player) = makeSession()
+    session.applyCondition(.restrained, to: player.id)
+    session.removeCondition(.restrained, from: player.id)
+    #expect(session.playerSlots[0].conditions.isEmpty)
+  }
+
+  @Test func removeConditionOnlyRemovesTarget() {
+    let (session, player) = makeSession()
+    session.applyCondition(.hidden, to: player.id)
+    session.applyCondition(.vulnerable, to: player.id)
+    session.removeCondition(.hidden, from: player.id)
+    #expect(!session.playerSlots[0].conditions.contains(.hidden))
+    #expect(session.playerSlots[0].conditions.contains(.vulnerable))
+  }
+
+  @Test func removeConditionNotPresentIsNoOp() {
+    let (session, player) = makeSession()
+    session.removeCondition(.restrained, from: player.id)
+    #expect(session.playerSlots[0].conditions.isEmpty)
+  }
+
+  // MARK: - Strip row accessibility label
+
+  @Test func conditionNamesIncludedInAccessibilityLabelWhenActive() {
+    let (session, player) = makeSession()
+    session.applyCondition(.restrained, to: player.id)
+    let updated = session.playerSlots[0]
+    let label =
+      updated.conditions.isEmpty
+      ? updated.name
+      : updated.name + ", "
+        + updated.conditions.map(\.displayName).sorted().joined(separator: ", ")
+    #expect(label.contains("Restrained"))
+    #expect(label.contains("Aric"))
+  }
+
+  @Test func accessibilityLabelIsNameOnlyWhenNoConditions() {
+    let (_, player) = makeSession()
+    let label =
+      player.conditions.isEmpty
+      ? player.name
+      : player.name + ", "
+        + player.conditions.map(\.displayName).sorted().joined(separator: ", ")
+    #expect(label == "Aric")
+  }
+}

--- a/EncounterUITests/RunnerUITests.swift
+++ b/EncounterUITests/RunnerUITests.swift
@@ -89,7 +89,8 @@ final class RunnerUITests: EncounterUITestCase {
 
     // Builder is visible and the overflow contains "Reset Session" (active session present).
     let overflow = app.buttons["OverflowBarButtonItem"]
-    XCTAssertTrue(overflow.waitForExistence(timeout: 3), "Builder toolbar overflow should be present")
+    XCTAssertTrue(
+      overflow.waitForExistence(timeout: 3), "Builder toolbar overflow should be present")
     overflow.tap()
     XCTAssertTrue(
       app.buttons["Reset Session"].waitForExistence(timeout: 3),
@@ -151,6 +152,57 @@ final class RunnerUITests: EncounterUITestCase {
     XCTAssertFalse(
       app.buttons["Reset Session"].waitForExistence(timeout: 2),
       "Reset Session should disappear after confirming reset")
+  }
+
+  // MARK: - Player condition toggles
+
+  /// Tapping a player row opens the popover; toggling a condition updates the
+  /// strip row indicator and is removed when toggled again.
+  func testPlayerConditionToggleShowsAndHidesInStripRow() throws {
+    navigateToRunner()
+
+    // Open the player popover.
+    let playerRow = app.buttons.matching(identifier: "runner.player-row").firstMatch
+    XCTAssertTrue(playerRow.waitForExistence(timeout: 5), "Player row should be visible in strip")
+    playerRow.tap()
+
+    // Apply the Hidden condition.
+    let hiddenButton = app.buttons["runner.player-edit.condition.hidden"]
+    XCTAssertTrue(
+      hiddenButton.waitForExistence(timeout: 3), "Hidden condition button should be in popover")
+    hiddenButton.tap()
+
+    // Dismiss the popover by tapping outside (tap the adversary list area).
+    app.collectionViews["runner.adversary-list"].firstMatch.tap()
+
+    // The strip row label should now include "Hidden".
+    let rowAfterApply = app.buttons.matching(identifier: "runner.player-row").firstMatch
+    XCTAssertTrue(rowAfterApply.waitForExistence(timeout: 3), "Player row should reappear")
+    XCTAssertTrue(
+      rowAfterApply.label.contains("Hidden"),
+      "Strip row label '\(rowAfterApply.label)' should contain 'Hidden' after applying condition")
+
+    // The dot+label indicator should be visible.
+    let indicator = app.staticTexts.matching(identifier: "runner.player-row.condition.hidden")
+      .firstMatch
+    XCTAssertTrue(
+      indicator.waitForExistence(timeout: 3),
+      "Hidden condition indicator should appear in strip row")
+
+    // Re-open the popover and remove the condition.
+    rowAfterApply.tap()
+    let hiddenButtonAgain = app.buttons["runner.player-edit.condition.hidden"]
+    XCTAssertTrue(hiddenButtonAgain.waitForExistence(timeout: 3))
+    hiddenButtonAgain.tap()
+
+    app.collectionViews["runner.adversary-list"].firstMatch.tap()
+
+    // The strip row label should no longer include "Hidden".
+    let rowAfterRemove = app.buttons.matching(identifier: "runner.player-row").firstMatch
+    XCTAssertTrue(rowAfterRemove.waitForExistence(timeout: 3), "Player row should reappear")
+    XCTAssertFalse(
+      rowAfterRemove.label.contains("Hidden"),
+      "Strip row label '\(rowAfterRemove.label)' should not contain 'Hidden' after removal")
   }
 
   // MARK: - Stress button

--- a/docs/decisions/0038-condition-indicator-style-strip.md
+++ b/docs/decisions/0038-condition-indicator-style-strip.md
@@ -1,0 +1,41 @@
+# ADR-0038 — Condition Indicator Style in Player Strip Row
+
+**Status:** Accepted
+
+## Context
+
+The player strip row (`PlayerStripRow`) needs to surface active conditions at a glance
+during a live encounter. Three options were considered:
+
+1. **SF Symbol icons** — per-condition icons (e.g. `eye.slash` for Hidden). Compact but
+   requires icon-to-meaning mapping that isn't obvious mid-game.
+2. **Filled dots, always shown** — three fixed dot slots, grayed when inactive. Makes the
+   presence of three condition slots visible at all times.
+3. **Filled dot + text label, active only** — a small dot paired with the condition name,
+   rendered only when the condition is applied. Nothing shown when no conditions are active.
+
+The strip row is already dense (name, HP pip track, stress pip track, armor count). Adding
+three always-visible dots would consume horizontal space even when no conditions are active,
+which is the common case.
+
+SF Symbol icons are not chosen because their meaning is not immediately legible without
+prior learning, and consistency with the popover toggle labels (which use text) matters
+more than icon compactness at this size.
+
+## Decision
+
+Active conditions in the player strip row are shown as a **filled dot + text label**,
+rendered **only when the condition is applied**. When no conditions are active, no
+indicator appears and no space is reserved.
+
+The same convention applies to any future strip-style compact row (e.g. adversary compact
+view, if one is added).
+
+## Consequences
+
+- Strip rows are visually clean when no conditions are active (the common case).
+- At most three small pill-style indicators appear; unlikely to overflow at typical name
+  lengths with 2–6 players.
+- Future custom conditions follow the same dot + label pattern automatically.
+- Contrast: the popover toggle buttons use full bordered button style with orange tint —
+  the dot + label is intentionally lighter, read-only at a glance.


### PR DESCRIPTION
## Summary

- Adds `PlayerConditionsSection` — a dedicated view for condition toggles in the player edit popover (mirrors `AdversaryConditionsSection`, orange-highlighted when active)
- Wires `PlayerConditionsSection` into `PlayerEditPopover` below the Armor stepper with a `Divider`
- Updates `PlayerStripRow` to display active conditions as dot + label indicators (orange, active-only per ADR-0038); accessibility label on the row button also includes active condition names
- Records ADR-0038: dot+label, active-only condition indicator style for strip rows

## Tests

- `PlayerConditionsTests` — 8 unit tests covering apply, remove, idempotency, multiple conditions, and accessibility label logic
- `RunnerUITests.testPlayerConditionToggleShowsAndHidesInStripRow` — UI test opening the player popover, toggling Hidden, dismissing, verifying the strip row indicator appears and disappears

## Acceptance criteria

- [x] Tapping player row opens popover without leaving runner
- [x] HP/Stress/Armor steppers clamp to valid range (existing, unchanged)
- [x] Condition toggles apply and remove conditions
- [x] Strip row updates immediately after changes
- [x] Session state persists after popover dismissal

Closes #38