### PR TITLE
feat: complete Phase 4 — direct HP override and custom fear value

### DIFF
--- a/Encounter/Views/AdversaryRunnerCard.swift
+++ b/Encounter/Views/AdversaryRunnerCard.swift
@@ -76,12 +76,13 @@ struct AdversaryRunnerCard: View {
           .accessibilityIdentifier("runner.adversary-card.name-error")
       }
 
-      // HP pip track
+      // HP pip track with direct ±1 override buttons
       HStack(spacing: 4) {
         Text("HP")
           .font(.caption)
           .foregroundStyle(.secondary)
         PipTrack(current: slot.currentHP, maximum: slot.maxHP)
+        Spacer()
         if slot.isDefeated {
           Text("Defeated")
             .font(.caption)
@@ -90,6 +91,30 @@ struct AdversaryRunnerCard: View {
             .padding(.vertical, 2)
             .background(.red.opacity(0.12))
             .clipShape(.capsule)
+        } else {
+          Button("Decrease HP", systemImage: "minus.circle") {
+            session.applyDamage(1, to: slot.id)
+          }
+          .labelStyle(.iconOnly)
+          .font(.title3)
+          .buttonStyle(.borderless)
+          .disabled(slot.currentHP <= 0)
+          .accessibilityIdentifier("runner.adversary-card.hp.decrement")
+
+          Text("\(slot.currentHP)/\(slot.maxHP)")
+            .font(.caption)
+            .monospacedDigit()
+            .frame(minWidth: 36, alignment: .center)
+            .accessibilityIdentifier("runner.adversary-card.hp.label")
+
+          Button("Increase HP", systemImage: "plus.circle") {
+            session.applyHealing(1, to: slot.id)
+          }
+          .labelStyle(.iconOnly)
+          .font(.title3)
+          .buttonStyle(.borderless)
+          .disabled(slot.currentHP >= slot.maxHP)
+          .accessibilityIdentifier("runner.adversary-card.hp.increment")
         }
       }
 

--- a/Encounter/Views/FearTrackerButton.swift
+++ b/Encounter/Views/FearTrackerButton.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct FearTrackerButton: View {
   let session: EncounterSession
   @State private var showPopover = false
+  @State private var customFearText = ""
 
   var body: some View {
     Button {
@@ -49,11 +50,34 @@ struct FearTrackerButton: View {
             .disabled(session.fearPool < 3)
             .accessibilityIdentifier("runner.fear.spend-3")
         }
+
+        Divider()
+
+        HStack(spacing: 8) {
+          TextField("Set to…", text: $customFearText)
+            .textFieldStyle(.roundedBorder)
+            #if os(iOS)
+              .keyboardType(.numberPad)
+            #endif
+            .frame(width: 80)
+            .accessibilityIdentifier("runner.fear.custom-field")
+            .onSubmit { commitCustomFear() }
+          Button("Set") { commitCustomFear() }
+            .buttonStyle(.bordered)
+            .disabled(Int(customFearText) == nil)
+            .accessibilityIdentifier("runner.fear.custom-set")
+        }
       }
       .padding()
       .frame(minWidth: 180)
       .presentationCompactAdaptation(.popover)
     }
+  }
+
+  private func commitCustomFear() {
+    guard let value = Int(customFearText), value >= 0 else { return }
+    session.fearPool = value
+    customFearText = ""
   }
 }
 


### PR DESCRIPTION
## Summary

Closes #33, closes #36.

The Phase 4 runner was substantially complete. Two acceptance criteria were unmet:

- **#33** required a direct HP adjustment path (GM override) beyond the Minor/Major/Severe threshold buttons
- **#36** required the GM to type a custom fear value directly

### Changes

**`AdversaryRunnerCard`** — adds ±1 HP stepper buttons inline with the HP pip track, matching the `PlayerEditPopover` pattern. Buttons are hidden when the adversary is already defeated. Identifiers: `runner.adversary-card.hp.decrement`, `runner.adversary-card.hp.label`, `runner.adversary-card.hp.increment`.

**`FearTrackerButton`** — adds a "Set to…" text field + Set button below the ±1/2/3 controls. Accepts a non-negative integer, sets `session.fearPool` directly, and clears on commit. Uses `.keyboardType(.numberPad)` on iOS. Identifiers: `runner.fear.custom-field`, `runner.fear.custom-set`.

Issues #31, #32, #37 were also closed as already-implemented (no code changes needed).

## Test plan

- [x] Expand an adversary card; verify − and + HP buttons adjust pip track immediately
- [x] Verify − is disabled at HP 0 and + is disabled at max HP
- [x] Verify ± buttons are hidden on a defeated adversary
- [x] Open Fear popover; type a value in "Set to…" and tap Set — fear pool updates
- [x] Verify Return key also commits the custom value
- [x] Verify non-numeric input keeps the Set button disabled
- [x] Verify fear cannot be set below 0 (field rejects negative integers)