### PR TITLE
fix: player strip AX collapse on iOS 26 (#82)

### DIFF
--- a/Encounter/Services/PlayerStore.swift
+++ b/Encounter/Services/PlayerStore.swift
@@ -76,6 +76,7 @@ public final class PlayerStore {
   /// Switches the storage directory and resets in-memory state.
   /// Call `load()` afterwards to populate from the new location.
   public func relocate(to newDirectory: URL) {
+    guard newDirectory.path != directory.path else { return }
     directory = newDirectory
     players = []
     party = Party(name: "Active Party")

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -43,6 +43,9 @@ struct EncounterRunnerView: View {
       )
     }
     .accessibilityIdentifier("runner.adversary-list")
+    .safeAreaInset(edge: .bottom) {
+      PlayerStrip(session: session)
+    }
     .navigationTitle(session.name)
     #if os(iOS)
       .navigationBarTitleDisplayMode(.inline)
@@ -79,10 +82,6 @@ struct EncounterRunnerView: View {
       .accessibilityIdentifier("runner.reset-confirm-button")
     } message: {
       Text("The current session will be cleared. The encounter definition is not changed.")
-    }
-    .safeAreaInset(edge: .bottom) {
-      PlayerStrip(session: session)
-        .accessibilityIdentifier("runner.player-strip")
     }
   }
 }


### PR DESCRIPTION
## Summary

- Removes `.accessibilityIdentifier("runner.player-strip")` from the `PlayerStrip` call in `EncounterRunnerView`. On iOS 26, applying an AX identifier to a custom view _from outside_ collapses its child elements into a single opaque accessibility node — the `PlayerStripRow` buttons become invisible to XCTest even though they render correctly on screen.
- Guards `PlayerStore.relocate(to:)` against clearing in-memory state when the target directory is unchanged. `EncounterStore.defaultDirectory()` probes CloudKit and can be slow on the simulator, so `relocate()` was occasionally firing after `addOnePlayer()` had already populated the store, wiping the party before "Run Encounter" was tapped and leaving `session.playerSlots` empty.

## Test plan

- [x] `testPlayerConditionToggleShowsAndHidesInStripRow` passes on iPhone 17 Pro simulator
- [x] Full `RunnerUITests` suite passes (6/6)
- [x] Unit tests pass on macOS (187 tests)

Closes #82
