### PR TITLE
feat: UI exploration harness and scene content (#85)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,74 @@ CLI-driven iteration.
 
 ---
 
+## UI Exploration Harness
+
+A `#if DEBUG`-only mode for visual review of components and design proposals without
+navigating through live app state. Enabled by the `-UIExploration` launch argument;
+`ExplorationRootView` replaces `ContentView` entirely. Zero production footprint.
+
+### When to use it
+
+- Reviewing a new component in all its states before writing UI tests
+- Comparing design proposals side-by-side (e.g. icon sets, layout variants)
+- Taking deterministic screenshots for design or accessibility review
+- Validating how a component looks with extreme data (very long names, max stress, etc.)
+
+### How to invoke
+
+**From Xcode:** Edit Scheme → Run → Arguments → Launch Arguments → add `-UIExploration`.
+
+**From the terminal:**
+
+```bash
+# macOS
+xcodebuild run -scheme Encounter -destination 'platform=macOS' \
+  OTHER_SWIFT_FLAGS='-DDEBUG' \
+  INFOPLIST_OTHER_PREPROCESSOR_FLAGS='-UIExploration'
+```
+
+**From XCUITest** (preferred for screenshots and CI):
+
+```swift
+class MyExplorationTests: ExplorationUITestCase {
+  func testDesignLanguageScreenshot() throws {
+    navigate(to: "exploration.design-language")
+    screenshotScene(named: "design-language-ios")
+  }
+}
+```
+
+`ExplorationUITestCase` (in `EncounterUITests/`) sets `-UIExploration` automatically,
+waits for the "Exploration" nav bar, and provides `navigate(to:)` and
+`screenshotScene(named:)` helpers.
+
+### Adding a new scene
+
+1. Create the view in `Encounter/Views/Exploration/` inside `#if DEBUG`.
+2. Add an entry to `ExplorationScene.all` in `ExplorationScene.swift`:
+
+```swift
+ExplorationScene(
+  id: "exploration.my-scene",      // stable AX identifier for XCUITest
+  title: "My Scene",
+  subtitle: "One-line description"
+) {
+  MyExplorationView()
+}
+```
+
+The scene appears automatically in the list on both platforms. No other wiring needed.
+
+### Current scenes
+
+| Scene ID | Content |
+|---|---|
+| `exploration.design-language` | Four icon proposals (ADR-0039) at 20/28/44pt + mock rows |
+| `exploration.runner-row` | Adversary runner row states (stub — see issue #85) |
+| `exploration.player-strip` | Player strip states (stub — see issue #85) |
+
+---
+
 ## Code Changes 
 
 When making bulk renames or refactors, do NOT make unrequested additional renames. Only change what was explicitly asked for. If you think something else should be renamed, ask first.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -241,8 +241,8 @@ The scene appears automatically in the list on both platforms. No other wiring n
 | Scene ID | Content |
 |---|---|
 | `exploration.design-language` | Four icon proposals (ADR-0039) at 20/28/44pt + mock rows |
-| `exploration.runner-row` | Adversary runner row states (stub — see issue #85) |
-| `exploration.player-strip` | Player strip states (stub — see issue #85) |
+| `exploration.runner-row` | `AdversaryRunnerRow` in 9 states (normal, damaged, high-stress, single/multiple conditions, solo variants, defeated, unknown) |
+| `exploration.player-strip` | `PlayerStrip` with two `EncounterSession` galleries — 4-player varied states and edge-case long names |
 
 ---
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -236,8 +236,8 @@ need to inspect it further.
 | Scene ID | Content |
 |---|---|
 | `exploration.design-language` | All four icon/color proposals from ADR-0039 at 20/28/44pt, with mock adversary runner rows and player strip rows |
-| `exploration.runner-row` | `AdversaryRunnerRow` in all slot states (stub — to be completed, see issue #85) |
-| `exploration.player-strip` | `PlayerStrip` with varied player states (stub — to be completed, see issue #85) |
+| `exploration.runner-row` | `AdversaryRunnerRow` in 9 states (normal, damaged, high-stress, single/multiple conditions, solo variants, defeated, unknown) |
+| `exploration.player-strip` | `PlayerStrip` with two `EncounterSession` galleries — 4-player varied states and edge-case long names |
 
 ### Adding a new exploration scene
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -169,6 +169,102 @@ xcodebuild test \
 
 ---
 
+## UI exploration harness
+
+The app ships a `#if DEBUG`-only exploration harness for visual review of components
+and design proposals. It is invoked with the `-UIExploration` launch argument, which
+replaces the normal `ContentView` with `ExplorationRootView` — a navigation hub of
+named scenes. There is zero production footprint; the entire branch is excluded from
+release builds.
+
+### Why it exists
+
+- SwiftUI Previews cover atomic component work but can't be automated, can't show
+  cross-component interactions, and don't produce device screenshots.
+- The exploration harness fills that gap: deterministic, automatable, no live app
+  state required.
+- It is the designated home for design comparisons (e.g. icon proposals) and
+  component state galleries (all stress levels, all condition combinations, etc.).
+
+### Invoking the harness
+
+**In Xcode:**
+
+1. Product → Scheme → Edit Scheme (or ⌘<)
+2. Run → Arguments tab → Launch Arguments
+3. Add `-UIExploration`
+4. Run the app — the normal Party/Encounters UI is replaced by the exploration list
+
+**From the command line** (macOS target):
+
+```bash
+open -a Encounter --args -UIExploration
+```
+
+Or build and run a specific simulator:
+
+```bash
+xcrun simctl launch booted gwillish.Encounter -UIExploration
+```
+
+### Navigating scenes from XCUITest
+
+Subclass `ExplorationUITestCase` instead of `EncounterUITestCase`. It sets
+`-UIExploration` automatically and provides two helpers:
+
+```swift
+import XCTest
+
+class DesignLanguageScreenshotTests: ExplorationUITestCase {
+
+  func testScreenshotAllProposals() throws {
+    navigate(to: "exploration.design-language")
+    screenshotScene(named: "design-language")
+  }
+}
+```
+
+`navigate(to:)` taps the row with the given `accessibilityIdentifier` and
+asserts it exists within 3 seconds.
+
+`screenshotScene(named:)` captures a full-screen screenshot, attaches it to the
+test result with `lifetime: .keepAlways`, and returns the `XCUIScreenshot` if you
+need to inspect it further.
+
+### Scene catalogue
+
+| Scene ID | Content |
+|---|---|
+| `exploration.design-language` | All four icon/color proposals from ADR-0039 at 20/28/44pt, with mock adversary runner rows and player strip rows |
+| `exploration.runner-row` | `AdversaryRunnerRow` in all slot states (stub — to be completed, see issue #85) |
+| `exploration.player-strip` | `PlayerStrip` with varied player states (stub — to be completed, see issue #85) |
+
+### Adding a new exploration scene
+
+1. Create a SwiftUI view inside `Encounter/Views/Exploration/`, wrapped in `#if DEBUG`.
+2. Register it in `ExplorationScene.all` in `ExplorationScene.swift`:
+
+```swift
+ExplorationScene(
+  id: "exploration.my-scene",   // stable — used as accessibilityIdentifier
+  title: "My Scene",
+  subtitle: "Brief description shown in the list"
+) {
+  MyExplorationView()
+}
+```
+
+The scene appears automatically in the list on iOS, iPadOS, and macOS. No
+additional wiring is required.
+
+**Guidelines for scene content:**
+
+- Use hardcoded sample data, not live stores. The harness starts with no data loaded.
+- Cover edge cases: empty state, maximum values, long strings, all conditions active.
+- Keep the scene self-contained — import only `SwiftUI` where possible.
+
+---
+
 ## Architecture Decision Records
 
 Significant architectural, data-format, and UX decisions are recorded as ADRs in

--- a/Encounter/EncounterApp.swift
+++ b/Encounter/EncounterApp.swift
@@ -48,13 +48,13 @@ struct EncounterApp: App {
   var body: some Scene {
     WindowGroup {
       #if DEBUG
-      if CommandLine.arguments.contains("-UIExploration") {
-        ExplorationRootView()
-      } else {
-        mainContentView
-      }
+        if CommandLine.arguments.contains("-UIExploration") {
+          ExplorationRootView()
+        } else {
+          mainContentView
+        }
       #else
-      mainContentView
+        mainContentView
       #endif
     }
     #if os(macOS)
@@ -78,77 +78,77 @@ struct EncounterApp: App {
       .environment(playerStore)
       .environment(sessionStore)
       .task {
-          let dir = await EncounterStore.defaultDirectory()
-          store.relocate(to: dir)
+        let dir = await EncounterStore.defaultDirectory()
+        store.relocate(to: dir)
 
-          // Content lives alongside encounters in the same Application
-          // Support root, one level up from the Encounters subdirectory.
-          let contentDir = dir.deletingLastPathComponent()
-            .appending(path: "Content", directoryHint: .isDirectory)
+        // Content lives alongside encounters in the same Application
+        // Support root, one level up from the Encounters subdirectory.
+        let contentDir = dir.deletingLastPathComponent()
+          .appending(path: "Content", directoryHint: .isDirectory)
 
-          // Wire in the real Compendium and switch to the resolved directory.
-          // configure() avoids recreating ContentStore just to swap the reference.
-          contentStore.configure(compendium: compendium)
-          await contentStore.relocate(to: contentDir)
+        // Wire in the real Compendium and switch to the resolved directory.
+        // configure() avoids recreating ContentStore just to swap the reference.
+        contentStore.configure(compendium: compendium)
+        await contentStore.relocate(to: contentDir)
 
-          let playersDir = dir.deletingLastPathComponent()
-            .appending(path: "Players", directoryHint: .isDirectory)
-          playerStore.relocate(to: playersDir)
+        let playersDir = dir.deletingLastPathComponent()
+          .appending(path: "Players", directoryHint: .isDirectory)
+        playerStore.relocate(to: playersDir)
 
-          let sessionsDir = dir.deletingLastPathComponent()
-            .appending(path: "Sessions", directoryHint: .isDirectory)
-          sessionStore.relocate(to: sessionsDir)
+        let sessionsDir = dir.deletingLastPathComponent()
+          .appending(path: "Sessions", directoryHint: .isDirectory)
+        sessionStore.relocate(to: sessionsDir)
 
-          // All loads are independent — run concurrently.
-          async let compendiumLoad: Void = compendium.load()
-          async let storeLoad: Void = store.load()
-          async let contentLoad: Void = contentStore.loadOnStartup()
-          async let playerLoad: Void = playerStore.load()
-          async let sessionLoad: Void = sessionStore.load(into: sessionRegistry)
-          do { try await compendiumLoad } catch {}
-          await storeLoad
-          await contentLoad
-          await playerLoad
-          await sessionLoad
-        }
-        .onChange(of: scenePhase) { _, phase in
-          if phase == .background {
-            let registry = sessionRegistry
-            #if os(iOS) || os(visionOS)
-              // Request a background-execution extension so writes complete
-              // before iOS/visionOS suspends the process.
-              // The handler is called on an unspecified background thread;
-              // we block it with a semaphore until saveAll finishes so iOS
-              // does not suspend the process before the writes hit disk.
-              ProcessInfo.processInfo.performExpiringActivity(
-                withReason: "save-sessions"
-              ) { expired in
-                guard !expired else { return }
-                let sema = DispatchSemaphore(value: 0)
-                Task { @MainActor in
-                  await sessionStore.saveAll(from: registry)
-                  sema.signal()
-                }
-                sema.wait()
+        // All loads are independent — run concurrently.
+        async let compendiumLoad: Void = compendium.load()
+        async let storeLoad: Void = store.load()
+        async let contentLoad: Void = contentStore.loadOnStartup()
+        async let playerLoad: Void = playerStore.load()
+        async let sessionLoad: Void = sessionStore.load(into: sessionRegistry)
+        do { try await compendiumLoad } catch {}
+        await storeLoad
+        await contentLoad
+        await playerLoad
+        await sessionLoad
+      }
+      .onChange(of: scenePhase) { _, phase in
+        if phase == .background {
+          let registry = sessionRegistry
+          #if os(iOS) || os(visionOS)
+            // Request a background-execution extension so writes complete
+            // before iOS/visionOS suspends the process.
+            // The handler is called on an unspecified background thread;
+            // we block it with a semaphore until saveAll finishes so iOS
+            // does not suspend the process before the writes hit disk.
+            ProcessInfo.processInfo.performExpiringActivity(
+              withReason: "save-sessions"
+            ) { expired in
+              guard !expired else { return }
+              let sema = DispatchSemaphore(value: 0)
+              Task { @MainActor in
+                await sessionStore.saveAll(from: registry)
+                sema.signal()
               }
-            #else
-              Task { await sessionStore.saveAll(from: registry) }
-            #endif
-          }
+              sema.wait()
+            }
+          #else
+            Task { await sessionStore.saveAll(from: registry) }
+          #endif
         }
-        // onOpenURL on the root view handles .dhpack file opens on both
-        // iOS and macOS. contentStore is non-nil from first render, so
-        // there is no startup race.
-        .sheet(isPresented: $isShowingAbout) {
-          AboutView()
+      }
+      // onOpenURL on the root view handles .dhpack file opens on both
+      // iOS and macOS. contentStore is non-nil from first render, so
+      // there is no startup race.
+      .sheet(isPresented: $isShowingAbout) {
+        AboutView()
+      }
+      .onOpenURL { url in
+        guard url.pathExtension.lowercased() == "dhpack" else { return }
+        guard url.startAccessingSecurityScopedResource() else { return }
+        Task { @MainActor in
+          defer { url.stopAccessingSecurityScopedResource() }
+          await contentStore.importPack(from: url)
         }
-        .onOpenURL { url in
-          guard url.pathExtension.lowercased() == "dhpack" else { return }
-          guard url.startAccessingSecurityScopedResource() else { return }
-          Task { @MainActor in
-            defer { url.stopAccessingSecurityScopedResource() }
-            await contentStore.importPack(from: url)
-          }
-        }
+      }
   }
 }

--- a/Encounter/EncounterApp.swift
+++ b/Encounter/EncounterApp.swift
@@ -47,14 +47,37 @@ struct EncounterApp: App {
 
   var body: some Scene {
     WindowGroup {
-      ContentView()
-        .environment(compendium)
-        .environment(store)
-        .environment(sessionRegistry)
-        .environment(contentStore)
-        .environment(playerStore)
-        .environment(sessionStore)
-        .task {
+      #if DEBUG
+      if CommandLine.arguments.contains("-UIExploration") {
+        ExplorationRootView()
+      } else {
+        mainContentView
+      }
+      #else
+      mainContentView
+      #endif
+    }
+    #if os(macOS)
+      .commands {
+        CommandGroup(replacing: .appInfo) {
+          Button("About Encounter") {
+            isShowingAbout = true
+          }
+        }
+      }
+    #endif
+  }
+
+  @ViewBuilder
+  private var mainContentView: some View {
+    ContentView()
+      .environment(compendium)
+      .environment(store)
+      .environment(sessionRegistry)
+      .environment(contentStore)
+      .environment(playerStore)
+      .environment(sessionStore)
+      .task {
           let dir = await EncounterStore.defaultDirectory()
           store.relocate(to: dir)
 
@@ -127,15 +150,5 @@ struct EncounterApp: App {
             await contentStore.importPack(from: url)
           }
         }
-    }
-    #if os(macOS)
-      .commands {
-        CommandGroup(replacing: .appInfo) {
-          Button("About Encounter") {
-            isShowingAbout = true
-          }
-        }
-      }
-    #endif
   }
 }

--- a/Encounter/Views/Exploration/DesignLanguageExplorationView.swift
+++ b/Encounter/Views/Exploration/DesignLanguageExplorationView.swift
@@ -1,345 +1,350 @@
 #if DEBUG
-//
-//  DesignLanguageExplorationView.swift
-//  Encounter
-//
-//  Renders all four icon/color proposals from ADR-0039 side-by-side so the
-//  team can screenshot, compare, and confirm or revise the chosen set.
-//
-//  Proposal 1 "The Duality" is the adopted standard; the others are shown
-//  for comparison. See docs/decisions/0039-icon-color-design-language.md.
-//
+  //
+  //  DesignLanguageExplorationView.swift
+  //  Encounter
+  //
+  //  Renders all four icon/color proposals from ADR-0039 side-by-side so the
+  //  team can screenshot, compare, and confirm or revise the chosen set.
+  //
+  //  Proposal 1 "The Duality" is the adopted standard; the others are shown
+  //  for comparison. See docs/decisions/0039-icon-color-design-language.md.
+  //
 
-import SwiftUI
+  import SwiftUI
 
-// MARK: - Data model
+  // MARK: - Data model
 
-private struct SymbolSpec {
-  let symbol: String
-  let color: Color
-}
+  private struct SymbolSpec {
+    let symbol: String
+    let color: Color
+  }
 
-private struct IconProposal: Identifiable {
-  let id: Int
-  let name: String
-  let tagline: String
-  let hp: SymbolSpec
-  let armor: SymbolSpec
-  let stress: SymbolSpec
-  let fear: SymbolSpec
-  let hope: SymbolSpec
-  let isAdopted: Bool
-}
+  private struct IconProposal: Identifiable {
+    let id: Int
+    let name: String
+    let tagline: String
+    let hp: SymbolSpec
+    let armor: SymbolSpec
+    let stress: SymbolSpec
+    let fear: SymbolSpec
+    let hope: SymbolSpec
+    let isAdopted: Bool
+  }
 
-// MARK: - Proposals
+  // MARK: - Proposals
 
-private let proposals: [IconProposal] = [
-  IconProposal(
-    id: 1,
-    name: "1 — The Duality",
-    tagline: "Adopted · Direct expression of hope/fear resource economy",
-    hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.75, green: 0.22, blue: 0.17)),
-    armor: SymbolSpec(symbol: "shield.fill", color: .secondary),
-    stress: SymbolSpec(symbol: "bolt.fill", color: Color(red: 0.90, green: 0.49, blue: 0.13)),
-    fear: SymbolSpec(symbol: "flame.fill", color: .orange),
-    hope: SymbolSpec(symbol: "bolt.heart.fill", color: Color(red: 0.94, green: 0.75, blue: 0.25)),
-    isAdopted: true
-  ),
-  IconProposal(
-    id: 2,
-    name: "2 — Blade & Spirit",
-    tagline: "System colors · Classic RPG vocabulary",
-    hp: SymbolSpec(symbol: "heart.fill", color: .red),
-    armor: SymbolSpec(symbol: "shield.fill", color: .blue),
-    stress: SymbolSpec(symbol: "waveform.path.ecg", color: .purple),
-    fear: SymbolSpec(symbol: "flame.fill", color: .orange),
-    hope: SymbolSpec(symbol: "star.fill", color: .yellow),
-    isAdopted: false
-  ),
-  IconProposal(
-    id: 3,
-    name: "3 — Beacon & Storm",
-    tagline: "Atmospheric · Palette rendering · Hopepunk contrast",
-    hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.91, green: 0.31, blue: 0.42)),
-    armor: SymbolSpec(
-      symbol: "shield.lefthalf.filled",
-      color: Color(red: 0.63, green: 0.48, blue: 0.31)),
-    stress: SymbolSpec(symbol: "waveform", color: Color(red: 0.87, green: 0.63, blue: 0.18)),
-    fear: SymbolSpec(
-      symbol: "cloud.bolt.fill", color: Color(red: 0.35, green: 0.40, blue: 0.45)),
-    hope: SymbolSpec(symbol: "rays", color: Color(red: 0.94, green: 0.75, blue: 0.25)),
-    isAdopted: false
-  ),
-  IconProposal(
-    id: 4,
-    name: "4 — Signal Board",
-    tagline: "Two-color system · Maximum runner legibility",
-    hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
-    armor: SymbolSpec(symbol: "shield.fill", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
-    stress: SymbolSpec(symbol: "bolt.circle.fill", color: Color(red: 0.88, green: 0.56, blue: 0.13)),
-    fear: SymbolSpec(symbol: "flame.fill", color: .orange),
-    hope: SymbolSpec(symbol: "sparkles", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
-    isAdopted: false
-  ),
-]
-
-// MARK: - Sample data for mock rows
-
-private struct MockAdversary {
-  let name: String
-  let currentHP: Int
-  let maxHP: Int
-  let currentStress: Int
-  let maxStress: Int
-}
-
-private struct MockPlayer {
-  let name: String
-  let currentHP: Int
-  let maxHP: Int
-  let currentStress: Int
-  let maxStress: Int
-  let currentArmor: Int
-  let maxArmor: Int
-}
-
-private let sampleAdversary = MockAdversary(
-  name: "Goblin Brute", currentHP: 6, maxHP: 10, currentStress: 2, maxStress: 5)
-private let samplePlayers = [
-  MockPlayer(name: "Aria", currentHP: 8, maxHP: 12, currentStress: 1, maxStress: 6, currentArmor: 2, maxArmor: 3),
-  MockPlayer(name: "Theron", currentHP: 4, maxHP: 10, currentStress: 3, maxStress: 5, currentArmor: 0, maxArmor: 2),
-]
-
-// MARK: - View
-
-struct DesignLanguageExplorationView: View {
-  private let sizes: [(label: String, pt: CGFloat)] = [
-    ("20pt", 20), ("28pt", 28), ("44pt", 44),
+  private let proposals: [IconProposal] = [
+    IconProposal(
+      id: 1,
+      name: "1 — The Duality",
+      tagline: "Adopted · Direct expression of hope/fear resource economy",
+      hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.75, green: 0.22, blue: 0.17)),
+      armor: SymbolSpec(symbol: "shield.fill", color: .secondary),
+      stress: SymbolSpec(symbol: "bolt.fill", color: Color(red: 0.90, green: 0.49, blue: 0.13)),
+      fear: SymbolSpec(symbol: "flame.fill", color: .orange),
+      hope: SymbolSpec(symbol: "bolt.heart.fill", color: Color(red: 0.94, green: 0.75, blue: 0.25)),
+      isAdopted: true
+    ),
+    IconProposal(
+      id: 2,
+      name: "2 — Blade & Spirit",
+      tagline: "System colors · Classic RPG vocabulary",
+      hp: SymbolSpec(symbol: "heart.fill", color: .red),
+      armor: SymbolSpec(symbol: "shield.fill", color: .blue),
+      stress: SymbolSpec(symbol: "waveform.path.ecg", color: .purple),
+      fear: SymbolSpec(symbol: "flame.fill", color: .orange),
+      hope: SymbolSpec(symbol: "star.fill", color: .yellow),
+      isAdopted: false
+    ),
+    IconProposal(
+      id: 3,
+      name: "3 — Beacon & Storm",
+      tagline: "Atmospheric · Palette rendering · Hopepunk contrast",
+      hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.91, green: 0.31, blue: 0.42)),
+      armor: SymbolSpec(
+        symbol: "shield.lefthalf.filled",
+        color: Color(red: 0.63, green: 0.48, blue: 0.31)),
+      stress: SymbolSpec(symbol: "waveform", color: Color(red: 0.87, green: 0.63, blue: 0.18)),
+      fear: SymbolSpec(
+        symbol: "cloud.bolt.fill", color: Color(red: 0.35, green: 0.40, blue: 0.45)),
+      hope: SymbolSpec(symbol: "rays", color: Color(red: 0.94, green: 0.75, blue: 0.25)),
+      isAdopted: false
+    ),
+    IconProposal(
+      id: 4,
+      name: "4 — Signal Board",
+      tagline: "Two-color system · Maximum runner legibility",
+      hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
+      armor: SymbolSpec(symbol: "shield.fill", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
+      stress: SymbolSpec(
+        symbol: "bolt.circle.fill", color: Color(red: 0.88, green: 0.56, blue: 0.13)),
+      fear: SymbolSpec(symbol: "flame.fill", color: .orange),
+      hope: SymbolSpec(symbol: "sparkles", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
+      isAdopted: false
+    ),
   ]
 
-  var body: some View {
-    ScrollView {
-      VStack(alignment: .leading, spacing: 32) {
-        conditionSection
-        ForEach(proposals) { proposal in
-          proposalSection(proposal)
-          if proposal.id < proposals.count {
-            Divider()
-          }
-        }
-      }
-      .padding()
-    }
+  // MARK: - Sample data for mock rows
+
+  private struct MockAdversary {
+    let name: String
+    let currentHP: Int
+    let maxHP: Int
+    let currentStress: Int
+    let maxStress: Int
   }
 
-  // MARK: - Condition icons
-
-  private var conditionSection: some View {
-    VStack(alignment: .leading, spacing: 12) {
-      sectionHeader("Condition Icons", subtitle: "Shared across all proposals")
-      HStack(spacing: 24) {
-        conditionIcon(symbol: "eye.slash.fill", label: "Hidden")
-        conditionIcon(symbol: "tag.fill", label: "Restrained")
-        conditionIcon(symbol: "shield.slash.fill", label: "Vulnerable")
-      }
-    }
+  private struct MockPlayer {
+    let name: String
+    let currentHP: Int
+    let maxHP: Int
+    let currentStress: Int
+    let maxStress: Int
+    let currentArmor: Int
+    let maxArmor: Int
   }
 
-  private func conditionIcon(symbol: String, label: String) -> some View {
-    VStack(spacing: 4) {
-      HStack(spacing: 8) {
-        Image(systemName: symbol)
-          .font(.system(size: 20))
-          .foregroundStyle(.orange)
-        Image(systemName: symbol)
-          .font(.system(size: 20))
-          .foregroundStyle(.secondary)
-      }
-      Text(label)
-        .font(.caption2)
-        .foregroundStyle(.secondary)
-    }
-  }
+  private let sampleAdversary = MockAdversary(
+    name: "Goblin Brute", currentHP: 6, maxHP: 10, currentStress: 2, maxStress: 5)
+  private let samplePlayers = [
+    MockPlayer(
+      name: "Aria", currentHP: 8, maxHP: 12, currentStress: 1, maxStress: 6, currentArmor: 2,
+      maxArmor: 3),
+    MockPlayer(
+      name: "Theron", currentHP: 4, maxHP: 10, currentStress: 3, maxStress: 5, currentArmor: 0,
+      maxArmor: 2),
+  ]
 
-  // MARK: - Proposal section
+  // MARK: - View
 
-  private func proposalSection(_ proposal: IconProposal) -> some View {
-    VStack(alignment: .leading, spacing: 16) {
-      // Header
-      VStack(alignment: .leading, spacing: 4) {
-        HStack(spacing: 8) {
-          Text(proposal.name)
-            .font(.headline)
-          if proposal.isAdopted {
-            Text("ADOPTED")
-              .font(.caption2)
-              .fontWeight(.semibold)
-              .padding(.horizontal, 6)
-              .padding(.vertical, 2)
-              .background(.teal.opacity(0.2))
-              .foregroundStyle(.teal)
-              .clipShape(.capsule)
-          }
-        }
-        Text(proposal.tagline)
-          .font(.caption)
-          .foregroundStyle(.secondary)
-      }
+  struct DesignLanguageExplorationView: View {
+    private let sizes: [(label: String, pt: CGFloat)] = [
+      ("20pt", 20), ("28pt", 28), ("44pt", 44),
+    ]
 
-      // Icon grid at each size
-      VStack(alignment: .leading, spacing: 12) {
-        ForEach(sizes, id: \.label) { size in
-          iconRow(proposal: proposal, size: size)
-        }
-      }
-
-      // Mock adversary runner row
-      VStack(alignment: .leading, spacing: 6) {
-        Text("Adversary row")
-          .font(.caption2)
-          .foregroundStyle(.tertiary)
-          .textCase(.uppercase)
-        mockAdversaryRow(proposal: proposal, adversary: sampleAdversary)
-      }
-
-      // Mock player strip rows
-      VStack(alignment: .leading, spacing: 6) {
-        Text("Player strip")
-          .font(.caption2)
-          .foregroundStyle(.tertiary)
-          .textCase(.uppercase)
-        VStack(spacing: 0) {
-          ForEach(samplePlayers, id: \.name) { player in
-            mockPlayerRow(proposal: proposal, player: player)
-            if player.name != samplePlayers.last?.name {
+    var body: some View {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 32) {
+          conditionSection
+          ForEach(proposals) { proposal in
+            proposalSection(proposal)
+            if proposal.id < proposals.count {
               Divider()
-                .padding(.leading, 8)
             }
           }
         }
-        .background(.regularMaterial)
-        .clipShape(.rect(cornerRadius: 8))
+        .padding()
       }
     }
-  }
 
-  // MARK: - Icon row
+    // MARK: - Condition icons
 
-  private func iconRow(proposal: IconProposal, size: (label: String, pt: CGFloat)) -> some View {
-    HStack(spacing: 0) {
-      Text(size.label)
-        .font(.caption2)
-        .foregroundStyle(.tertiary)
-        .frame(width: 36, alignment: .leading)
-      HStack(spacing: 20) {
-        iconCell(spec: proposal.hp, label: "HP", size: size.pt)
-        iconCell(spec: proposal.armor, label: "Armor", size: size.pt)
-        iconCell(spec: proposal.stress, label: "Stress", size: size.pt)
-        iconCell(spec: proposal.fear, label: "Fear", size: size.pt)
-        iconCell(spec: proposal.hope, label: "Hope", size: size.pt)
+    private var conditionSection: some View {
+      VStack(alignment: .leading, spacing: 12) {
+        sectionHeader("Condition Icons", subtitle: "Shared across all proposals")
+        HStack(spacing: 24) {
+          conditionIcon(symbol: "eye.slash.fill", label: "Hidden")
+          conditionIcon(symbol: "tag.fill", label: "Restrained")
+          conditionIcon(symbol: "shield.slash.fill", label: "Vulnerable")
+        }
       }
     }
-  }
 
-  private func iconCell(spec: SymbolSpec, label: String, size: CGFloat) -> some View {
-    VStack(spacing: 3) {
-      Image(systemName: spec.symbol)
-        .font(.system(size: size))
-        .foregroundStyle(spec.color)
-        .frame(width: size + 4, height: size + 4)
-      if size == 20 {
+    private func conditionIcon(symbol: String, label: String) -> some View {
+      VStack(spacing: 4) {
+        HStack(spacing: 8) {
+          Image(systemName: symbol)
+            .font(.system(size: 20))
+            .foregroundStyle(.orange)
+          Image(systemName: symbol)
+            .font(.system(size: 20))
+            .foregroundStyle(.secondary)
+        }
         Text(label)
-          .font(.system(size: 9))
-          .foregroundStyle(.tertiary)
+          .font(.caption2)
+          .foregroundStyle(.secondary)
       }
     }
-  }
 
-  // MARK: - Mock adversary row
+    // MARK: - Proposal section
 
-  private func mockAdversaryRow(proposal: IconProposal, adversary: MockAdversary) -> some View {
-    HStack(spacing: 8) {
-      VStack(alignment: .leading, spacing: 2) {
-        Text(adversary.name)
-          .font(.subheadline)
-        HStack(spacing: 6) {
-          Image(systemName: proposal.hp.symbol)
-            .foregroundStyle(proposal.hp.color)
-          Text("\(adversary.currentHP)/\(adversary.maxHP)")
-          Image(systemName: proposal.stress.symbol)
-            .foregroundStyle(proposal.stress.color)
-          Text("\(adversary.currentStress)/\(adversary.maxStress)")
+    private func proposalSection(_ proposal: IconProposal) -> some View {
+      VStack(alignment: .leading, spacing: 16) {
+        // Header
+        VStack(alignment: .leading, spacing: 4) {
+          HStack(spacing: 8) {
+            Text(proposal.name)
+              .font(.headline)
+            if proposal.isAdopted {
+              Text("ADOPTED")
+                .font(.caption2)
+                .fontWeight(.semibold)
+                .padding(.horizontal, 6)
+                .padding(.vertical, 2)
+                .background(.teal.opacity(0.2))
+                .foregroundStyle(.teal)
+                .clipShape(.capsule)
+            }
+          }
+          Text(proposal.tagline)
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
-        .font(.caption)
-        .foregroundStyle(.secondary)
-      }
-      Spacer()
-      Text("Minion · T1")
-        .font(.caption)
-        .foregroundStyle(.secondary)
-        .padding(.horizontal, 8)
-        .padding(.vertical, 3)
-        .background(.secondary.opacity(0.12))
-        .clipShape(.capsule)
-    }
-    .padding(10)
-    .background(.background.secondary)
-    .clipShape(.rect(cornerRadius: 8))
-  }
 
-  // MARK: - Mock player strip row
-
-  private func mockPlayerRow(proposal: IconProposal, player: MockPlayer) -> some View {
-    HStack(spacing: 8) {
-      Text(player.name)
-        .font(.caption)
-        .fontWeight(.medium)
-        .lineLimit(1)
-        .frame(width: 60, alignment: .leading)
-      Spacer()
-      HStack(spacing: 12) {
-        HStack(spacing: 3) {
-          Image(systemName: proposal.hp.symbol)
-            .foregroundStyle(proposal.hp.color)
-          Text("\(player.currentHP)/\(player.maxHP)")
-        }
-        HStack(spacing: 3) {
-          Image(systemName: proposal.stress.symbol)
-            .foregroundStyle(proposal.stress.color)
-          Text("\(player.currentStress)/\(player.maxStress)")
-        }
-        if player.maxArmor > 0 {
-          HStack(spacing: 3) {
-            Image(systemName: proposal.armor.symbol)
-              .foregroundStyle(proposal.armor.color)
-            Text("\(player.currentArmor)/\(player.maxArmor)")
+        // Icon grid at each size
+        VStack(alignment: .leading, spacing: 12) {
+          ForEach(sizes, id: \.label) { size in
+            iconRow(proposal: proposal, size: size)
           }
         }
+
+        // Mock adversary runner row
+        VStack(alignment: .leading, spacing: 6) {
+          Text("Adversary row")
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .textCase(.uppercase)
+          mockAdversaryRow(proposal: proposal, adversary: sampleAdversary)
+        }
+
+        // Mock player strip rows
+        VStack(alignment: .leading, spacing: 6) {
+          Text("Player strip")
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+            .textCase(.uppercase)
+          VStack(spacing: 0) {
+            ForEach(samplePlayers, id: \.name) { player in
+              mockPlayerRow(proposal: proposal, player: player)
+              if player.name != samplePlayers.last?.name {
+                Divider()
+                  .padding(.leading, 8)
+              }
+            }
+          }
+          .background(.regularMaterial)
+          .clipShape(.rect(cornerRadius: 8))
+        }
       }
-      .font(.caption)
-      .foregroundStyle(.secondary)
     }
-    .padding(.horizontal, 12)
-    .padding(.vertical, 8)
-  }
 
-  // MARK: - Helpers
+    // MARK: - Icon row
 
-  private func sectionHeader(_ title: String, subtitle: String) -> some View {
-    VStack(alignment: .leading, spacing: 2) {
-      Text(title)
-        .font(.headline)
-      Text(subtitle)
+    private func iconRow(proposal: IconProposal, size: (label: String, pt: CGFloat)) -> some View {
+      HStack(spacing: 0) {
+        Text(size.label)
+          .font(.caption2)
+          .foregroundStyle(.tertiary)
+          .frame(width: 36, alignment: .leading)
+        HStack(spacing: 20) {
+          iconCell(spec: proposal.hp, label: "HP", size: size.pt)
+          iconCell(spec: proposal.armor, label: "Armor", size: size.pt)
+          iconCell(spec: proposal.stress, label: "Stress", size: size.pt)
+          iconCell(spec: proposal.fear, label: "Fear", size: size.pt)
+          iconCell(spec: proposal.hope, label: "Hope", size: size.pt)
+        }
+      }
+    }
+
+    private func iconCell(spec: SymbolSpec, label: String, size: CGFloat) -> some View {
+      VStack(spacing: 3) {
+        Image(systemName: spec.symbol)
+          .font(.system(size: size))
+          .foregroundStyle(spec.color)
+          .frame(width: size + 4, height: size + 4)
+        if size == 20 {
+          Text(label)
+            .font(.system(size: 9))
+            .foregroundStyle(.tertiary)
+        }
+      }
+    }
+
+    // MARK: - Mock adversary row
+
+    private func mockAdversaryRow(proposal: IconProposal, adversary: MockAdversary) -> some View {
+      HStack(spacing: 8) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(adversary.name)
+            .font(.subheadline)
+          HStack(spacing: 6) {
+            Image(systemName: proposal.hp.symbol)
+              .foregroundStyle(proposal.hp.color)
+            Text("\(adversary.currentHP)/\(adversary.maxHP)")
+            Image(systemName: proposal.stress.symbol)
+              .foregroundStyle(proposal.stress.color)
+            Text("\(adversary.currentStress)/\(adversary.maxStress)")
+          }
+          .font(.caption)
+          .foregroundStyle(.secondary)
+        }
+        Spacer()
+        Text("Minion · T1")
+          .font(.caption)
+          .foregroundStyle(.secondary)
+          .padding(.horizontal, 8)
+          .padding(.vertical, 3)
+          .background(.secondary.opacity(0.12))
+          .clipShape(.capsule)
+      }
+      .padding(10)
+      .background(.background.secondary)
+      .clipShape(.rect(cornerRadius: 8))
+    }
+
+    // MARK: - Mock player strip row
+
+    private func mockPlayerRow(proposal: IconProposal, player: MockPlayer) -> some View {
+      HStack(spacing: 8) {
+        Text(player.name)
+          .font(.caption)
+          .fontWeight(.medium)
+          .lineLimit(1)
+          .frame(width: 60, alignment: .leading)
+        Spacer()
+        HStack(spacing: 12) {
+          HStack(spacing: 3) {
+            Image(systemName: proposal.hp.symbol)
+              .foregroundStyle(proposal.hp.color)
+            Text("\(player.currentHP)/\(player.maxHP)")
+          }
+          HStack(spacing: 3) {
+            Image(systemName: proposal.stress.symbol)
+              .foregroundStyle(proposal.stress.color)
+            Text("\(player.currentStress)/\(player.maxStress)")
+          }
+          if player.maxArmor > 0 {
+            HStack(spacing: 3) {
+              Image(systemName: proposal.armor.symbol)
+                .foregroundStyle(proposal.armor.color)
+              Text("\(player.currentArmor)/\(player.maxArmor)")
+            }
+          }
+        }
         .font(.caption)
         .foregroundStyle(.secondary)
+      }
+      .padding(.horizontal, 12)
+      .padding(.vertical, 8)
+    }
+
+    // MARK: - Helpers
+
+    private func sectionHeader(_ title: String, subtitle: String) -> some View {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(title)
+          .font(.headline)
+        Text(subtitle)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
     }
   }
-}
 
-#Preview {
-  NavigationStack {
-    DesignLanguageExplorationView()
-      .navigationTitle("Icon Design Language")
+  #Preview {
+    NavigationStack {
+      DesignLanguageExplorationView()
+        .navigationTitle("Icon Design Language")
+    }
   }
-}
 #endif

--- a/Encounter/Views/Exploration/DesignLanguageExplorationView.swift
+++ b/Encounter/Views/Exploration/DesignLanguageExplorationView.swift
@@ -1,0 +1,345 @@
+#if DEBUG
+//
+//  DesignLanguageExplorationView.swift
+//  Encounter
+//
+//  Renders all four icon/color proposals from ADR-0039 side-by-side so the
+//  team can screenshot, compare, and confirm or revise the chosen set.
+//
+//  Proposal 1 "The Duality" is the adopted standard; the others are shown
+//  for comparison. See docs/decisions/0039-icon-color-design-language.md.
+//
+
+import SwiftUI
+
+// MARK: - Data model
+
+private struct SymbolSpec {
+  let symbol: String
+  let color: Color
+}
+
+private struct IconProposal: Identifiable {
+  let id: Int
+  let name: String
+  let tagline: String
+  let hp: SymbolSpec
+  let armor: SymbolSpec
+  let stress: SymbolSpec
+  let fear: SymbolSpec
+  let hope: SymbolSpec
+  let isAdopted: Bool
+}
+
+// MARK: - Proposals
+
+private let proposals: [IconProposal] = [
+  IconProposal(
+    id: 1,
+    name: "1 — The Duality",
+    tagline: "Adopted · Direct expression of hope/fear resource economy",
+    hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.75, green: 0.22, blue: 0.17)),
+    armor: SymbolSpec(symbol: "shield.fill", color: .secondary),
+    stress: SymbolSpec(symbol: "bolt.fill", color: Color(red: 0.90, green: 0.49, blue: 0.13)),
+    fear: SymbolSpec(symbol: "flame.fill", color: .orange),
+    hope: SymbolSpec(symbol: "bolt.heart.fill", color: Color(red: 0.94, green: 0.75, blue: 0.25)),
+    isAdopted: true
+  ),
+  IconProposal(
+    id: 2,
+    name: "2 — Blade & Spirit",
+    tagline: "System colors · Classic RPG vocabulary",
+    hp: SymbolSpec(symbol: "heart.fill", color: .red),
+    armor: SymbolSpec(symbol: "shield.fill", color: .blue),
+    stress: SymbolSpec(symbol: "waveform.path.ecg", color: .purple),
+    fear: SymbolSpec(symbol: "flame.fill", color: .orange),
+    hope: SymbolSpec(symbol: "star.fill", color: .yellow),
+    isAdopted: false
+  ),
+  IconProposal(
+    id: 3,
+    name: "3 — Beacon & Storm",
+    tagline: "Atmospheric · Palette rendering · Hopepunk contrast",
+    hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.91, green: 0.31, blue: 0.42)),
+    armor: SymbolSpec(
+      symbol: "shield.lefthalf.filled",
+      color: Color(red: 0.63, green: 0.48, blue: 0.31)),
+    stress: SymbolSpec(symbol: "waveform", color: Color(red: 0.87, green: 0.63, blue: 0.18)),
+    fear: SymbolSpec(
+      symbol: "cloud.bolt.fill", color: Color(red: 0.35, green: 0.40, blue: 0.45)),
+    hope: SymbolSpec(symbol: "rays", color: Color(red: 0.94, green: 0.75, blue: 0.25)),
+    isAdopted: false
+  ),
+  IconProposal(
+    id: 4,
+    name: "4 — Signal Board",
+    tagline: "Two-color system · Maximum runner legibility",
+    hp: SymbolSpec(symbol: "heart.fill", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
+    armor: SymbolSpec(symbol: "shield.fill", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
+    stress: SymbolSpec(symbol: "bolt.circle.fill", color: Color(red: 0.88, green: 0.56, blue: 0.13)),
+    fear: SymbolSpec(symbol: "flame.fill", color: .orange),
+    hope: SymbolSpec(symbol: "sparkles", color: Color(red: 0.17, green: 0.69, blue: 0.63)),
+    isAdopted: false
+  ),
+]
+
+// MARK: - Sample data for mock rows
+
+private struct MockAdversary {
+  let name: String
+  let currentHP: Int
+  let maxHP: Int
+  let currentStress: Int
+  let maxStress: Int
+}
+
+private struct MockPlayer {
+  let name: String
+  let currentHP: Int
+  let maxHP: Int
+  let currentStress: Int
+  let maxStress: Int
+  let currentArmor: Int
+  let maxArmor: Int
+}
+
+private let sampleAdversary = MockAdversary(
+  name: "Goblin Brute", currentHP: 6, maxHP: 10, currentStress: 2, maxStress: 5)
+private let samplePlayers = [
+  MockPlayer(name: "Aria", currentHP: 8, maxHP: 12, currentStress: 1, maxStress: 6, currentArmor: 2, maxArmor: 3),
+  MockPlayer(name: "Theron", currentHP: 4, maxHP: 10, currentStress: 3, maxStress: 5, currentArmor: 0, maxArmor: 2),
+]
+
+// MARK: - View
+
+struct DesignLanguageExplorationView: View {
+  private let sizes: [(label: String, pt: CGFloat)] = [
+    ("20pt", 20), ("28pt", 28), ("44pt", 44),
+  ]
+
+  var body: some View {
+    ScrollView {
+      VStack(alignment: .leading, spacing: 32) {
+        conditionSection
+        ForEach(proposals) { proposal in
+          proposalSection(proposal)
+          if proposal.id < proposals.count {
+            Divider()
+          }
+        }
+      }
+      .padding()
+    }
+  }
+
+  // MARK: - Condition icons
+
+  private var conditionSection: some View {
+    VStack(alignment: .leading, spacing: 12) {
+      sectionHeader("Condition Icons", subtitle: "Shared across all proposals")
+      HStack(spacing: 24) {
+        conditionIcon(symbol: "eye.slash.fill", label: "Hidden")
+        conditionIcon(symbol: "tag.fill", label: "Restrained")
+        conditionIcon(symbol: "shield.slash.fill", label: "Vulnerable")
+      }
+    }
+  }
+
+  private func conditionIcon(symbol: String, label: String) -> some View {
+    VStack(spacing: 4) {
+      HStack(spacing: 8) {
+        Image(systemName: symbol)
+          .font(.system(size: 20))
+          .foregroundStyle(.orange)
+        Image(systemName: symbol)
+          .font(.system(size: 20))
+          .foregroundStyle(.secondary)
+      }
+      Text(label)
+        .font(.caption2)
+        .foregroundStyle(.secondary)
+    }
+  }
+
+  // MARK: - Proposal section
+
+  private func proposalSection(_ proposal: IconProposal) -> some View {
+    VStack(alignment: .leading, spacing: 16) {
+      // Header
+      VStack(alignment: .leading, spacing: 4) {
+        HStack(spacing: 8) {
+          Text(proposal.name)
+            .font(.headline)
+          if proposal.isAdopted {
+            Text("ADOPTED")
+              .font(.caption2)
+              .fontWeight(.semibold)
+              .padding(.horizontal, 6)
+              .padding(.vertical, 2)
+              .background(.teal.opacity(0.2))
+              .foregroundStyle(.teal)
+              .clipShape(.capsule)
+          }
+        }
+        Text(proposal.tagline)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+
+      // Icon grid at each size
+      VStack(alignment: .leading, spacing: 12) {
+        ForEach(sizes, id: \.label) { size in
+          iconRow(proposal: proposal, size: size)
+        }
+      }
+
+      // Mock adversary runner row
+      VStack(alignment: .leading, spacing: 6) {
+        Text("Adversary row")
+          .font(.caption2)
+          .foregroundStyle(.tertiary)
+          .textCase(.uppercase)
+        mockAdversaryRow(proposal: proposal, adversary: sampleAdversary)
+      }
+
+      // Mock player strip rows
+      VStack(alignment: .leading, spacing: 6) {
+        Text("Player strip")
+          .font(.caption2)
+          .foregroundStyle(.tertiary)
+          .textCase(.uppercase)
+        VStack(spacing: 0) {
+          ForEach(samplePlayers, id: \.name) { player in
+            mockPlayerRow(proposal: proposal, player: player)
+            if player.name != samplePlayers.last?.name {
+              Divider()
+                .padding(.leading, 8)
+            }
+          }
+        }
+        .background(.regularMaterial)
+        .clipShape(.rect(cornerRadius: 8))
+      }
+    }
+  }
+
+  // MARK: - Icon row
+
+  private func iconRow(proposal: IconProposal, size: (label: String, pt: CGFloat)) -> some View {
+    HStack(spacing: 0) {
+      Text(size.label)
+        .font(.caption2)
+        .foregroundStyle(.tertiary)
+        .frame(width: 36, alignment: .leading)
+      HStack(spacing: 20) {
+        iconCell(spec: proposal.hp, label: "HP", size: size.pt)
+        iconCell(spec: proposal.armor, label: "Armor", size: size.pt)
+        iconCell(spec: proposal.stress, label: "Stress", size: size.pt)
+        iconCell(spec: proposal.fear, label: "Fear", size: size.pt)
+        iconCell(spec: proposal.hope, label: "Hope", size: size.pt)
+      }
+    }
+  }
+
+  private func iconCell(spec: SymbolSpec, label: String, size: CGFloat) -> some View {
+    VStack(spacing: 3) {
+      Image(systemName: spec.symbol)
+        .font(.system(size: size))
+        .foregroundStyle(spec.color)
+        .frame(width: size + 4, height: size + 4)
+      if size == 20 {
+        Text(label)
+          .font(.system(size: 9))
+          .foregroundStyle(.tertiary)
+      }
+    }
+  }
+
+  // MARK: - Mock adversary row
+
+  private func mockAdversaryRow(proposal: IconProposal, adversary: MockAdversary) -> some View {
+    HStack(spacing: 8) {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(adversary.name)
+          .font(.subheadline)
+        HStack(spacing: 6) {
+          Image(systemName: proposal.hp.symbol)
+            .foregroundStyle(proposal.hp.color)
+          Text("\(adversary.currentHP)/\(adversary.maxHP)")
+          Image(systemName: proposal.stress.symbol)
+            .foregroundStyle(proposal.stress.color)
+          Text("\(adversary.currentStress)/\(adversary.maxStress)")
+        }
+        .font(.caption)
+        .foregroundStyle(.secondary)
+      }
+      Spacer()
+      Text("Minion · T1")
+        .font(.caption)
+        .foregroundStyle(.secondary)
+        .padding(.horizontal, 8)
+        .padding(.vertical, 3)
+        .background(.secondary.opacity(0.12))
+        .clipShape(.capsule)
+    }
+    .padding(10)
+    .background(.background.secondary)
+    .clipShape(.rect(cornerRadius: 8))
+  }
+
+  // MARK: - Mock player strip row
+
+  private func mockPlayerRow(proposal: IconProposal, player: MockPlayer) -> some View {
+    HStack(spacing: 8) {
+      Text(player.name)
+        .font(.caption)
+        .fontWeight(.medium)
+        .lineLimit(1)
+        .frame(width: 60, alignment: .leading)
+      Spacer()
+      HStack(spacing: 12) {
+        HStack(spacing: 3) {
+          Image(systemName: proposal.hp.symbol)
+            .foregroundStyle(proposal.hp.color)
+          Text("\(player.currentHP)/\(player.maxHP)")
+        }
+        HStack(spacing: 3) {
+          Image(systemName: proposal.stress.symbol)
+            .foregroundStyle(proposal.stress.color)
+          Text("\(player.currentStress)/\(player.maxStress)")
+        }
+        if player.maxArmor > 0 {
+          HStack(spacing: 3) {
+            Image(systemName: proposal.armor.symbol)
+              .foregroundStyle(proposal.armor.color)
+            Text("\(player.currentArmor)/\(player.maxArmor)")
+          }
+        }
+      }
+      .font(.caption)
+      .foregroundStyle(.secondary)
+    }
+    .padding(.horizontal, 12)
+    .padding(.vertical, 8)
+  }
+
+  // MARK: - Helpers
+
+  private func sectionHeader(_ title: String, subtitle: String) -> some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(title)
+        .font(.headline)
+      Text(subtitle)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+  }
+}
+
+#Preview {
+  NavigationStack {
+    DesignLanguageExplorationView()
+      .navigationTitle("Icon Design Language")
+  }
+}
+#endif

--- a/Encounter/Views/Exploration/ExplorationRootView.swift
+++ b/Encounter/Views/Exploration/ExplorationRootView.swift
@@ -1,0 +1,86 @@
+#if DEBUG
+//
+//  ExplorationRootView.swift
+//  Encounter
+//
+//  Root of the debug exploration harness. Shown when the app is launched
+//  with -UIExploration. Platform-adaptive: NavigationSplitView on macOS,
+//  NavigationStack + List on iOS/iPadOS.
+//
+//  Each scene row carries a stable accessibilityIdentifier so XCUITest
+//  can navigate directly without traversing real app state.
+//
+
+import SwiftUI
+
+struct ExplorationRootView: View {
+  private let scenes = ExplorationScene.all
+
+  var body: some View {
+    #if os(macOS)
+      macOSLayout
+    #else
+      iOSLayout
+    #endif
+  }
+
+  // MARK: - iOS / iPadOS
+
+  #if !os(macOS)
+    private var iOSLayout: some View {
+      NavigationStack {
+        List(scenes) { scene in
+          NavigationLink(destination: scene.destination.navigationTitle(scene.title)) {
+            sceneRow(scene)
+          }
+          .accessibilityIdentifier(scene.id)
+        }
+        .navigationTitle("Exploration")
+        .navigationBarTitleDisplayMode(.large)
+      }
+    }
+  #endif
+
+  // MARK: - macOS
+
+  #if os(macOS)
+    @State private var selectedID: String?
+
+    private var macOSLayout: some View {
+      NavigationSplitView {
+        List(scenes, selection: $selectedID) { scene in
+          sceneRow(scene)
+            .tag(scene.id)
+            .accessibilityIdentifier(scene.id)
+        }
+        .navigationTitle("Exploration")
+      } detail: {
+        if let id = selectedID, let scene = scenes.first(where: { $0.id == id }) {
+          scene.destination
+            .navigationTitle(scene.title)
+        } else {
+          Text("Select a scene")
+            .foregroundStyle(.secondary)
+        }
+      }
+    }
+  #endif
+
+  // MARK: - Shared row
+
+  private func sceneRow(_ scene: ExplorationScene) -> some View {
+    VStack(alignment: .leading, spacing: 2) {
+      Text(scene.title)
+        .font(.body)
+      Text(scene.subtitle)
+        .font(.caption)
+        .foregroundStyle(.secondary)
+    }
+    .padding(.vertical, 2)
+  }
+}
+
+#Preview {
+  ExplorationRootView()
+}
+#endif

--- a/Encounter/Views/Exploration/ExplorationRootView.swift
+++ b/Encounter/Views/Exploration/ExplorationRootView.swift
@@ -1,86 +1,86 @@
 #if DEBUG
-//
-//  ExplorationRootView.swift
-//  Encounter
-//
-//  Root of the debug exploration harness. Shown when the app is launched
-//  with -UIExploration. Platform-adaptive: NavigationSplitView on macOS,
-//  NavigationStack + List on iOS/iPadOS.
-//
-//  Each scene row carries a stable accessibilityIdentifier so XCUITest
-//  can navigate directly without traversing real app state.
-//
+  //
+  //  ExplorationRootView.swift
+  //  Encounter
+  //
+  //  Root of the debug exploration harness. Shown when the app is launched
+  //  with -UIExploration. Platform-adaptive: NavigationSplitView on macOS,
+  //  NavigationStack + List on iOS/iPadOS.
+  //
+  //  Each scene row carries a stable accessibilityIdentifier so XCUITest
+  //  can navigate directly without traversing real app state.
+  //
 
-import SwiftUI
+  import SwiftUI
 
-struct ExplorationRootView: View {
-  private let scenes = ExplorationScene.all
+  struct ExplorationRootView: View {
+    private let scenes = ExplorationScene.all
 
-  var body: some View {
-    #if os(macOS)
-      macOSLayout
-    #else
-      iOSLayout
-    #endif
-  }
-
-  // MARK: - iOS / iPadOS
-
-  #if !os(macOS)
-    private var iOSLayout: some View {
-      NavigationStack {
-        List(scenes) { scene in
-          NavigationLink(destination: scene.destination.navigationTitle(scene.title)) {
-            sceneRow(scene)
-          }
-          .accessibilityIdentifier(scene.id)
-        }
-        .navigationTitle("Exploration")
-        .navigationBarTitleDisplayMode(.large)
-      }
+    var body: some View {
+      #if os(macOS)
+        macOSLayout
+      #else
+        iOSLayout
+      #endif
     }
-  #endif
 
-  // MARK: - macOS
+    // MARK: - iOS / iPadOS
 
-  #if os(macOS)
-    @State private var selectedID: String?
-
-    private var macOSLayout: some View {
-      NavigationSplitView {
-        List(scenes, selection: $selectedID) { scene in
-          sceneRow(scene)
-            .tag(scene.id)
+    #if !os(macOS)
+      private var iOSLayout: some View {
+        NavigationStack {
+          List(scenes) { scene in
+            NavigationLink(destination: scene.destination.navigationTitle(scene.title)) {
+              sceneRow(scene)
+            }
             .accessibilityIdentifier(scene.id)
-        }
-        .navigationTitle("Exploration")
-      } detail: {
-        if let id = selectedID, let scene = scenes.first(where: { $0.id == id }) {
-          scene.destination
-            .navigationTitle(scene.title)
-        } else {
-          Text("Select a scene")
-            .foregroundStyle(.secondary)
+          }
+          .navigationTitle("Exploration")
+          .navigationBarTitleDisplayMode(.large)
         }
       }
-    }
-  #endif
+    #endif
 
-  // MARK: - Shared row
+    // MARK: - macOS
 
-  private func sceneRow(_ scene: ExplorationScene) -> some View {
-    VStack(alignment: .leading, spacing: 2) {
-      Text(scene.title)
-        .font(.body)
-      Text(scene.subtitle)
-        .font(.caption)
-        .foregroundStyle(.secondary)
+    #if os(macOS)
+      @State private var selectedID: String?
+
+      private var macOSLayout: some View {
+        NavigationSplitView {
+          List(scenes, selection: $selectedID) { scene in
+            sceneRow(scene)
+              .tag(scene.id)
+              .accessibilityIdentifier(scene.id)
+          }
+          .navigationTitle("Exploration")
+        } detail: {
+          if let id = selectedID, let scene = scenes.first(where: { $0.id == id }) {
+            scene.destination
+              .navigationTitle(scene.title)
+          } else {
+            Text("Select a scene")
+              .foregroundStyle(.secondary)
+          }
+        }
+      }
+    #endif
+
+    // MARK: - Shared row
+
+    private func sceneRow(_ scene: ExplorationScene) -> some View {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(scene.title)
+          .font(.body)
+        Text(scene.subtitle)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
+      .padding(.vertical, 2)
     }
-    .padding(.vertical, 2)
   }
-}
 
-#Preview {
-  ExplorationRootView()
-}
+  #Preview {
+    ExplorationRootView()
+  }
 #endif

--- a/Encounter/Views/Exploration/ExplorationScene.swift
+++ b/Encounter/Views/Exploration/ExplorationScene.swift
@@ -1,54 +1,54 @@
 #if DEBUG
-//
-//  ExplorationScene.swift
-//  Encounter
-//
-//  Catalogue of named exploration scenes. Each scene has a stable
-//  accessibilityIdentifier so XCUITest can navigate directly without
-//  traversing real app state.
-//
+  //
+  //  ExplorationScene.swift
+  //  Encounter
+  //
+  //  Catalogue of named exploration scenes. Each scene has a stable
+  //  accessibilityIdentifier so XCUITest can navigate directly without
+  //  traversing real app state.
+  //
 
-import SwiftUI
+  import SwiftUI
 
-struct ExplorationScene: Identifiable {
-  let id: String
-  let title: String
-  let subtitle: String
-  let destination: AnyView
+  struct ExplorationScene: Identifiable {
+    let id: String
+    let title: String
+    let subtitle: String
+    let destination: AnyView
 
-  init<V: View>(id: String, title: String, subtitle: String, @ViewBuilder destination: () -> V) {
-    self.id = id
-    self.title = title
-    self.subtitle = subtitle
-    self.destination = AnyView(destination())
+    init<V: View>(id: String, title: String, subtitle: String, @ViewBuilder destination: () -> V) {
+      self.id = id
+      self.title = title
+      self.subtitle = subtitle
+      self.destination = AnyView(destination())
+    }
   }
-}
 
-extension ExplorationScene {
-  static var all: [ExplorationScene] {
-    [
-      ExplorationScene(
-        id: "exploration.design-language",
-        title: "Icon Design Language",
-        subtitle: "Four proposals side-by-side at 20/28/44pt"
-      ) {
-        DesignLanguageExplorationView()
-      },
-      ExplorationScene(
-        id: "exploration.runner-row",
-        title: "Adversary Runner Row",
-        subtitle: "All slot states: normal, stressed, conditioned, defeated"
-      ) {
-        RunnerRowExplorationView()
-      },
-      ExplorationScene(
-        id: "exploration.player-strip",
-        title: "Player Strip",
-        subtitle: "Strip with four players in varied states"
-      ) {
-        PlayerStripExplorationView()
-      },
-    ]
+  extension ExplorationScene {
+    static var all: [ExplorationScene] {
+      [
+        ExplorationScene(
+          id: "exploration.design-language",
+          title: "Icon Design Language",
+          subtitle: "Four proposals side-by-side at 20/28/44pt"
+        ) {
+          DesignLanguageExplorationView()
+        },
+        ExplorationScene(
+          id: "exploration.runner-row",
+          title: "Adversary Runner Row",
+          subtitle: "All slot states: normal, stressed, conditioned, defeated"
+        ) {
+          RunnerRowExplorationView()
+        },
+        ExplorationScene(
+          id: "exploration.player-strip",
+          title: "Player Strip",
+          subtitle: "Strip with four players in varied states"
+        ) {
+          PlayerStripExplorationView()
+        },
+      ]
+    }
   }
-}
 #endif

--- a/Encounter/Views/Exploration/ExplorationScene.swift
+++ b/Encounter/Views/Exploration/ExplorationScene.swift
@@ -1,0 +1,54 @@
+#if DEBUG
+//
+//  ExplorationScene.swift
+//  Encounter
+//
+//  Catalogue of named exploration scenes. Each scene has a stable
+//  accessibilityIdentifier so XCUITest can navigate directly without
+//  traversing real app state.
+//
+
+import SwiftUI
+
+struct ExplorationScene: Identifiable {
+  let id: String
+  let title: String
+  let subtitle: String
+  let destination: AnyView
+
+  init<V: View>(id: String, title: String, subtitle: String, @ViewBuilder destination: () -> V) {
+    self.id = id
+    self.title = title
+    self.subtitle = subtitle
+    self.destination = AnyView(destination())
+  }
+}
+
+extension ExplorationScene {
+  static var all: [ExplorationScene] {
+    [
+      ExplorationScene(
+        id: "exploration.design-language",
+        title: "Icon Design Language",
+        subtitle: "Four proposals side-by-side at 20/28/44pt"
+      ) {
+        DesignLanguageExplorationView()
+      },
+      ExplorationScene(
+        id: "exploration.runner-row",
+        title: "Adversary Runner Row",
+        subtitle: "All slot states: normal, stressed, conditioned, defeated"
+      ) {
+        RunnerRowExplorationView()
+      },
+      ExplorationScene(
+        id: "exploration.player-strip",
+        title: "Player Strip",
+        subtitle: "Strip with four players in varied states"
+      ) {
+        PlayerStripExplorationView()
+      },
+    ]
+  }
+}
+#endif

--- a/Encounter/Views/Exploration/PlayerStripExplorationView.swift
+++ b/Encounter/Views/Exploration/PlayerStripExplorationView.swift
@@ -1,25 +1,116 @@
 #if DEBUG
-//
-//  PlayerStripExplorationView.swift
-//  Encounter
-//
-//  Exploration scene showing PlayerStrip with varied player states.
-//  Stub — content will be filled in as part of issue #85 follow-up work.
-//
+  //
+  //  PlayerStripExplorationView.swift
+  //  Encounter
+  //
+  //  Exploration scene showing PlayerStrip and PlayerStripRow in varied states.
+  //  Uses real components with hardcoded sample data — no live stores needed.
+  //
 
-import SwiftUI
+  import DHKit
+  import DHModels
+  import SwiftUI
 
-struct PlayerStripExplorationView: View {
-  var body: some View {
-    ContentUnavailableView(
-      "Coming Soon",
-      systemImage: "hammer",
-      description: Text("Player strip state exploration — see issue #85")
-    )
+  // MARK: - Sample sessions
+
+  private let fullSession: EncounterSession = EncounterSession(
+    name: "Four-player party",
+    playerSlots: [
+      PlayerState(
+        name: "Aria Dawnwhisper",
+        maxHP: 12, maxStress: 6,
+        evasion: 14, thresholdMajor: 6, thresholdSevere: 12,
+        armorSlots: 3
+      ),
+      PlayerState(
+        name: "Theron Ashvale",
+        maxHP: 10, currentHP: 4,
+        maxStress: 5, currentStress: 3,
+        evasion: 12, thresholdMajor: 5, thresholdSevere: 10,
+        armorSlots: 2
+      ),
+      PlayerState(
+        name: "Zira Coldbrook",
+        maxHP: 8, currentHP: 2,
+        maxStress: 7, currentStress: 5,
+        evasion: 16, thresholdMajor: 4, thresholdSevere: 8,
+        armorSlots: 0,
+        conditions: [.vulnerable]
+      ),
+      PlayerState(
+        name: "Bramwell the Unbroken",
+        maxHP: 14, currentHP: 14,
+        maxStress: 4, currentStress: 0,
+        evasion: 11, thresholdMajor: 8, thresholdSevere: 15,
+        armorSlots: 3, currentArmorSlots: 1,
+        conditions: [.restrained, .hidden]
+      ),
+    ]
+  )
+
+  private let longNameSession: EncounterSession = EncounterSession(
+    name: "Long name stress test",
+    playerSlots: [
+      PlayerState(
+        name: "Bartholomew Nightshade-Quincey",
+        maxHP: 10, maxStress: 5,
+        evasion: 12, thresholdMajor: 5, thresholdSevere: 10,
+        armorSlots: 2
+      ),
+      PlayerState(
+        name: "A",
+        maxHP: 6, currentHP: 1,
+        maxStress: 6, currentStress: 6,
+        evasion: 10, thresholdMajor: 4, thresholdSevere: 8,
+        armorSlots: 0,
+        conditions: [.vulnerable, .restrained]
+      ),
+    ]
+  )
+
+  // MARK: - View
+
+  struct PlayerStripExplorationView: View {
+    var body: some View {
+      ScrollView {
+        VStack(alignment: .leading, spacing: 32) {
+          stripSection(
+            label: "Four players — varied states",
+            subtitle:
+              "Full HP · Damaged · Critical + condition · Full HP + depleted armor + conditions",
+            session: fullSession
+          )
+          stripSection(
+            label: "Edge cases",
+            subtitle: "Very long name · Minimum HP + max stress + multiple conditions",
+            session: longNameSession
+          )
+        }
+        .padding()
+      }
+    }
+
+    private func stripSection(label: String, subtitle: String, session: EncounterSession)
+      -> some View
+    {
+      VStack(alignment: .leading, spacing: 8) {
+        VStack(alignment: .leading, spacing: 2) {
+          Text(label)
+            .font(.headline)
+          Text(subtitle)
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+        PlayerStrip(session: session)
+          .clipShape(.rect(cornerRadius: 10))
+      }
+    }
   }
-}
 
-#Preview {
-  PlayerStripExplorationView()
-}
+  #Preview {
+    NavigationStack {
+      PlayerStripExplorationView()
+        .navigationTitle("Player Strip")
+    }
+  }
 #endif

--- a/Encounter/Views/Exploration/PlayerStripExplorationView.swift
+++ b/Encounter/Views/Exploration/PlayerStripExplorationView.swift
@@ -1,0 +1,25 @@
+#if DEBUG
+//
+//  PlayerStripExplorationView.swift
+//  Encounter
+//
+//  Exploration scene showing PlayerStrip with varied player states.
+//  Stub — content will be filled in as part of issue #85 follow-up work.
+//
+
+import SwiftUI
+
+struct PlayerStripExplorationView: View {
+  var body: some View {
+    ContentUnavailableView(
+      "Coming Soon",
+      systemImage: "hammer",
+      description: Text("Player strip state exploration — see issue #85")
+    )
+  }
+}
+
+#Preview {
+  PlayerStripExplorationView()
+}
+#endif

--- a/Encounter/Views/Exploration/RunnerRowExplorationView.swift
+++ b/Encounter/Views/Exploration/RunnerRowExplorationView.swift
@@ -1,0 +1,25 @@
+#if DEBUG
+//
+//  RunnerRowExplorationView.swift
+//  Encounter
+//
+//  Exploration scene showing AdversaryRunnerRow in all slot states.
+//  Stub — content will be filled in as part of issue #85 follow-up work.
+//
+
+import SwiftUI
+
+struct RunnerRowExplorationView: View {
+  var body: some View {
+    ContentUnavailableView(
+      "Coming Soon",
+      systemImage: "hammer",
+      description: Text("Adversary runner row state exploration — see issue #85")
+    )
+  }
+}
+
+#Preview {
+  RunnerRowExplorationView()
+}
+#endif

--- a/Encounter/Views/Exploration/RunnerRowExplorationView.swift
+++ b/Encounter/Views/Exploration/RunnerRowExplorationView.swift
@@ -1,25 +1,164 @@
 #if DEBUG
-//
-//  RunnerRowExplorationView.swift
-//  Encounter
-//
-//  Exploration scene showing AdversaryRunnerRow in all slot states.
-//  Stub — content will be filled in as part of issue #85 follow-up work.
-//
+  //
+  //  RunnerRowExplorationView.swift
+  //  Encounter
+  //
+  //  Exploration scene showing AdversaryRunnerRow in all slot states.
+  //  Uses the real component with hardcoded sample data — no live stores needed.
+  //
 
-import SwiftUI
+  import DHKit
+  import DHModels
+  import SwiftUI
 
-struct RunnerRowExplorationView: View {
-  var body: some View {
-    ContentUnavailableView(
-      "Coming Soon",
-      systemImage: "hammer",
-      description: Text("Adversary runner row state exploration — see issue #85")
-    )
+  // MARK: - Sample data
+
+  private let sampleCompendium: Compendium = {
+    let c = Compendium()
+    c.addAdversary(
+      Adversary(
+        id: "goblin-brute",
+        name: "Goblin Brute",
+        tier: 1,
+        role: .minion,
+        flavorText: "Tough and mean.",
+        difficulty: 8,
+        thresholdMajor: 5,
+        thresholdSevere: 10,
+        hp: 10,
+        stress: 5,
+        attackModifier: "+2",
+        attackName: "Club",
+        attackRange: .melee,
+        damage: "1d8 phy"
+      ))
+    c.addAdversary(
+      Adversary(
+        id: "shadow-stalker",
+        name: "Shadow Stalker",
+        tier: 2,
+        role: .solo,
+        flavorText: "Moves unseen.",
+        difficulty: 14,
+        thresholdMajor: 8,
+        thresholdSevere: 15,
+        hp: 18,
+        stress: 8,
+        attackModifier: "+5",
+        attackName: "Shadow Claw",
+        attackRange: .veryClose,
+        damage: "2d6+3 phy"
+      ))
+    return c
+  }()
+
+  private struct RowState {
+    let label: String
+    let slot: AdversaryState
   }
-}
 
-#Preview {
-  RunnerRowExplorationView()
-}
+  private let rowStates: [RowState] = [
+    RowState(
+      label: "Normal — full HP, no stress",
+      slot: AdversaryState(
+        adversaryID: "goblin-brute",
+        maxHP: 10, maxStress: 5
+      )
+    ),
+    RowState(
+      label: "Damaged — ~50% HP",
+      slot: AdversaryState(
+        adversaryID: "goblin-brute",
+        maxHP: 10, maxStress: 5,
+        currentHP: 5
+      )
+    ),
+    RowState(
+      label: "High stress",
+      slot: AdversaryState(
+        adversaryID: "goblin-brute",
+        maxHP: 10, maxStress: 5,
+        currentHP: 8, currentStress: 4
+      )
+    ),
+    RowState(
+      label: "Single condition — Vulnerable",
+      slot: AdversaryState(
+        adversaryID: "goblin-brute",
+        maxHP: 10, maxStress: 5,
+        currentHP: 7,
+        conditions: [.vulnerable]
+      )
+    ),
+    RowState(
+      label: "Multiple conditions",
+      slot: AdversaryState(
+        adversaryID: "goblin-brute",
+        maxHP: 10, maxStress: 5,
+        currentHP: 6, currentStress: 2,
+        conditions: [.restrained, .vulnerable]
+      )
+    ),
+    RowState(
+      label: "Solo adversary — full HP",
+      slot: AdversaryState(
+        adversaryID: "shadow-stalker",
+        maxHP: 18, maxStress: 8
+      )
+    ),
+    RowState(
+      label: "Solo adversary — low HP, stressed, conditioned",
+      slot: AdversaryState(
+        adversaryID: "shadow-stalker",
+        maxHP: 18, maxStress: 8,
+        currentHP: 4, currentStress: 6,
+        conditions: [.hidden, .vulnerable]
+      )
+    ),
+    RowState(
+      label: "Defeated",
+      slot: AdversaryState(
+        adversaryID: "goblin-brute",
+        maxHP: 10, maxStress: 5,
+        currentHP: 0, isDefeated: true
+      )
+    ),
+    RowState(
+      label: "Unknown adversary (not in compendium)",
+      slot: AdversaryState(
+        adversaryID: "unknown-beast",
+        maxHP: 8, maxStress: 3,
+        currentHP: 5
+      )
+    ),
+  ]
+
+  // MARK: - View
+
+  struct RunnerRowExplorationView: View {
+    var body: some View {
+      List {
+        ForEach(rowStates, id: \.label) { state in
+          Section {
+            if state.slot.isDefeated {
+              AdversaryRunnerRow(slot: state.slot, compendium: sampleCompendium)
+                .opacity(0.4)
+            } else {
+              AdversaryRunnerRow(slot: state.slot, compendium: sampleCompendium)
+            }
+          } header: {
+            Text(state.label)
+          }
+        }
+      }
+      .environment(sampleCompendium)
+    }
+  }
+
+  #Preview {
+    NavigationStack {
+      RunnerRowExplorationView()
+        .navigationTitle("Adversary Runner Row")
+    }
+  }
 #endif

--- a/EncounterUITests/EncounterUITestCase.swift
+++ b/EncounterUITests/EncounterUITestCase.swift
@@ -157,7 +157,8 @@ class EncounterUITestCase: XCTestCase {
       "Overflow button should be in runner toolbar")
     overflow.tap()
     let resetButton = app.buttons["Reset Session"]
-    XCTAssertTrue(resetButton.waitForExistence(timeout: 3), "Reset Session should appear in overflow")
+    XCTAssertTrue(
+      resetButton.waitForExistence(timeout: 3), "Reset Session should appear in overflow")
     resetButton.tap()
     // confirmationDialog on iOS 26 exposes its buttons in two places in the AX tree
     // (action sheet layer + source view hierarchy), so use firstMatch to avoid ambiguity.

--- a/EncounterUITests/ExplorationScreenshotTests.swift
+++ b/EncounterUITests/ExplorationScreenshotTests.swift
@@ -1,0 +1,44 @@
+//
+//  ExplorationScreenshotTests.swift
+//  EncounterUITests
+//
+//  Screenshot tests for all exploration harness scenes.
+//  Navigates to each scene via accessibilityIdentifier and attaches a
+//  full-screen screenshot to the test result (lifetime: keepAlways).
+//
+//  These tests fulfill the acceptance criteria for issue #85 and produce
+//  the visual record needed for issue #84 (icon design language review).
+//
+
+import XCTest
+
+class ExplorationScreenshotTests: ExplorationUITestCase {
+
+  func testDesignLanguageScene() throws {
+    navigate(to: "exploration.design-language")
+    screenshotScene(named: "design-language")
+  }
+
+  func testRunnerRowScene() throws {
+    navigate(to: "exploration.runner-row")
+    screenshotScene(named: "runner-row")
+  }
+
+  func testPlayerStripScene() throws {
+    navigate(to: "exploration.player-strip")
+    screenshotScene(named: "player-strip")
+  }
+
+  func testAllScenesVisible() throws {
+    XCTAssertTrue(
+      app.buttons["exploration.design-language"].waitForExistence(timeout: 3),
+      "Design language scene should be listed")
+    XCTAssertTrue(
+      app.buttons["exploration.runner-row"].waitForExistence(timeout: 3),
+      "Runner row scene should be listed")
+    XCTAssertTrue(
+      app.buttons["exploration.player-strip"].waitForExistence(timeout: 3),
+      "Player strip scene should be listed")
+    screenshotScene(named: "exploration-root")
+  }
+}

--- a/EncounterUITests/ExplorationUITestCase.swift
+++ b/EncounterUITests/ExplorationUITestCase.swift
@@ -1,0 +1,57 @@
+//
+//  ExplorationUITestCase.swift
+//  EncounterUITests
+//
+//  Base class for tests that use the debug exploration harness.
+//  Launches the app with -UIExploration so ExplorationRootView replaces
+//  ContentView — no live app state, no data loading required.
+//
+//  Usage:
+//    class MyExplorationTests: ExplorationUITestCase {
+//      func testDesignLanguageScreenshot() throws {
+//        navigate(to: "exploration.design-language")
+//        screenshotScene(named: "design-language")
+//      }
+//    }
+//
+
+import XCTest
+
+class ExplorationUITestCase: XCTestCase {
+
+  var app: XCUIApplication!
+
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+    app = XCUIApplication()
+    app.launchArguments = ["-UIExploration"]
+    app.launch()
+    XCTAssertTrue(
+      app.navigationBars["Exploration"].waitForExistence(timeout: 10),
+      "Exploration root should appear within 10 seconds")
+  }
+
+  // MARK: - Navigation
+
+  /// Taps the scene row with the given accessibilityIdentifier and waits for
+  /// the scene's content to appear (identified by nav bar title).
+  func navigate(to sceneID: String) {
+    let row = app.buttons[sceneID]
+    XCTAssertTrue(row.waitForExistence(timeout: 3), "Scene '\(sceneID)' not found in list")
+    row.tap()
+  }
+
+  // MARK: - Screenshots
+
+  /// Captures a full-screen screenshot, attaches it to the test result with
+  /// the given name, and keeps it regardless of pass/fail.
+  @discardableResult
+  func screenshotScene(named name: String) -> XCUIScreenshot {
+    let screenshot = XCUIScreen.main.screenshot()
+    let attachment = XCTAttachment(screenshot: screenshot)
+    attachment.name = name
+    attachment.lifetime = .keepAlways
+    add(attachment)
+    return screenshot
+  }
+}

--- a/EncounterUITests/ExplorationUITestCase.swift
+++ b/EncounterUITests/ExplorationUITestCase.swift
@@ -34,11 +34,14 @@ class ExplorationUITestCase: XCTestCase {
   // MARK: - Navigation
 
   /// Taps the scene row with the given accessibilityIdentifier and waits for
-  /// the scene's content to appear (identified by nav bar title).
+  /// the destination navigation bar to appear before returning.
   func navigate(to sceneID: String) {
     let row = app.buttons[sceneID]
     XCTAssertTrue(row.waitForExistence(timeout: 3), "Scene '\(sceneID)' not found in list")
     row.tap()
+    // Wait for any navigation bar other than "Exploration" to confirm the destination loaded.
+    let destination = app.navigationBars.matching(NSPredicate(format: "identifier != 'Exploration'")).firstMatch
+    XCTAssertTrue(destination.waitForExistence(timeout: 5), "Scene destination should load after tapping '\(sceneID)'")
   }
 
   // MARK: - Screenshots

--- a/EncounterUITests/SessionResumeUITests.swift
+++ b/EncounterUITests/SessionResumeUITests.swift
@@ -18,99 +18,99 @@ import XCTest
 // Home-button backgrounding is iOS-only; macOS apps do not get reaped the same way.
 #if os(iOS)
 
-final class SessionResumeUITests: EncounterUITestCase {
+  final class SessionResumeUITests: EncounterUITestCase {
 
     // MARK: - Resume after relaunch
 
     /// Background the app while in the runner, relaunch without resetting state,
     /// and verify the resume prompt appears and leads back into the runner.
     func testResumePromptAppearsAfterRelaunch() throws {
-        navigateToRunner()
-        XCTAssertTrue(
-            app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5),
-            "Should be in the runner before backgrounding")
+      navigateToRunner()
+      XCTAssertTrue(
+        app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5),
+        "Should be in the runner before backgrounding")
 
-        // Background triggers scenePhase == .background → saveAll via performExpiringActivity
-        XCUIDevice.shared.press(.home)
-        XCTAssertTrue(
-            app.wait(for: .runningBackground, timeout: 5),
-            "App should enter background state so saveAll can fire")
-        // .runningBackground confirms process state, not I/O completion.
-        // performExpiringActivity blocks the handler until saveAll finishes,
-        // but a brief pause reduces CI flakiness on slower devices or builds.
-        Thread.sleep(forTimeInterval: 1)
+      // Background triggers scenePhase == .background → saveAll via performExpiringActivity
+      XCUIDevice.shared.press(.home)
+      XCTAssertTrue(
+        app.wait(for: .runningBackground, timeout: 5),
+        "App should enter background state so saveAll can fire")
+      // .runningBackground confirms process state, not I/O completion.
+      // performExpiringActivity blocks the handler until saveAll finishes,
+      // but a brief pause reduces CI flakiness on slower devices or builds.
+      Thread.sleep(forTimeInterval: 1)
 
-        // Relaunch without resetting — persisted session survives
-        app.launchArguments = []
-        app.launch()
+      // Relaunch without resetting — persisted session survives
+      app.launchArguments = []
+      app.launch()
 
-        // Resume sheet should appear automatically
-        XCTAssertTrue(
-            app.navigationBars["In Progress"].waitForExistence(timeout: 10),
-            "Resume sheet ('In Progress' nav bar) should appear when an in-flight session is found")
-        XCTAssertTrue(
-            app.buttons["resume.resume-button"].waitForExistence(timeout: 5),
-            "Resume button should be visible in the single-session resume sheet")
+      // Resume sheet should appear automatically
+      XCTAssertTrue(
+        app.navigationBars["In Progress"].waitForExistence(timeout: 10),
+        "Resume sheet ('In Progress' nav bar) should appear when an in-flight session is found")
+      XCTAssertTrue(
+        app.buttons["resume.resume-button"].waitForExistence(timeout: 5),
+        "Resume button should be visible in the single-session resume sheet")
 
-        // Tapping Resume dismisses the sheet and presents the runner full-screen
-        app.buttons["resume.resume-button"].tap()
-        XCTAssertTrue(
-            app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5),
-            "Runner adversary list should be visible after resuming")
-        XCTAssertTrue(
-            app.buttons["runner.done-button"].waitForExistence(timeout: 3),
-            "Done button should be visible in the full-screen runner cover")
+      // Tapping Resume dismisses the sheet and presents the runner full-screen
+      app.buttons["resume.resume-button"].tap()
+      XCTAssertTrue(
+        app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5),
+        "Runner adversary list should be visible after resuming")
+      XCTAssertTrue(
+        app.buttons["runner.done-button"].waitForExistence(timeout: 3),
+        "Done button should be visible in the full-screen runner cover")
     }
 
     // MARK: - Dismiss resume prompt
 
     /// Tapping "Not Now" dismisses the sheet; the prompt does not re-appear.
     func testDismissingResumePromptDoesNotReprompt() throws {
-        navigateToRunner()
-        XCTAssertTrue(
-            app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5))
+      navigateToRunner()
+      XCTAssertTrue(
+        app.collectionViews["runner.adversary-list"].waitForExistence(timeout: 5))
 
-        XCUIDevice.shared.press(.home)
-        XCTAssertTrue(
-            app.wait(for: .runningBackground, timeout: 5),
-            "App should enter background state so saveAll can fire")
-        Thread.sleep(forTimeInterval: 1)
+      XCUIDevice.shared.press(.home)
+      XCTAssertTrue(
+        app.wait(for: .runningBackground, timeout: 5),
+        "App should enter background state so saveAll can fire")
+      Thread.sleep(forTimeInterval: 1)
 
-        app.launchArguments = []
-        app.launch()
+      app.launchArguments = []
+      app.launch()
 
-        XCTAssertTrue(
-            app.buttons["resume.dismiss-button"].waitForExistence(timeout: 10),
-            "Resume sheet should appear on relaunch")
-        app.buttons["resume.dismiss-button"].tap()
+      XCTAssertTrue(
+        app.buttons["resume.dismiss-button"].waitForExistence(timeout: 10),
+        "Resume sheet should appear on relaunch")
+      app.buttons["resume.dismiss-button"].tap()
 
-        // Sheet should be gone
-        XCTAssertFalse(
-            app.navigationBars["In Progress"].waitForExistence(timeout: 3),
-            "Resume sheet should dismiss after tapping 'Not Now'")
+      // Sheet should be gone
+      XCTAssertFalse(
+        app.navigationBars["In Progress"].waitForExistence(timeout: 3),
+        "Resume sheet should dismiss after tapping 'Not Now'")
 
-        // Normal app state: Party tab is default
-        XCTAssertTrue(
-            app.navigationBars["Party"].waitForExistence(timeout: 5),
-            "App should show the Party screen after dismissing the resume prompt")
+      // Normal app state: Party tab is default
+      XCTAssertTrue(
+        app.navigationBars["Party"].waitForExistence(timeout: 5),
+        "App should show the Party screen after dismissing the resume prompt")
 
-        // Navigate away and back to confirm the dismiss is sticky.
-        app.tabBars.firstMatch.buttons["Encounters"].tap()
-        app.tabBars.firstMatch.buttons["Party"].tap()
-        XCTAssertFalse(
-            app.navigationBars["In Progress"].waitForExistence(timeout: 3),
-            "Resume sheet should not re-appear after navigating away and back")
+      // Navigate away and back to confirm the dismiss is sticky.
+      app.tabBars.firstMatch.buttons["Encounters"].tap()
+      app.tabBars.firstMatch.buttons["Party"].tap()
+      XCTAssertFalse(
+        app.navigationBars["In Progress"].waitForExistence(timeout: 3),
+        "Resume sheet should not re-appear after navigating away and back")
     }
 
     // MARK: - No resume prompt on fresh launch
 
     /// A fresh launch with no in-flight sessions should not show the resume prompt.
     func testNoResumePromptOnFreshLaunch() throws {
-        // setUp already launched with -UITestResetState; no sessions exist.
-        XCTAssertFalse(
-            app.navigationBars["In Progress"].waitForExistence(timeout: 3),
-            "Resume sheet should not appear on a clean launch with no in-flight sessions")
+      // setUp already launched with -UITestResetState; no sessions exist.
+      XCTAssertFalse(
+        app.navigationBars["In Progress"].waitForExistence(timeout: 3),
+        "Resume sheet should not appear on a clean launch with no in-flight sessions")
     }
-}
+  }
 
 #endif  // os(iOS)


### PR DESCRIPTION
Closes #85. Also fulfils the visual exploration goal from #84.

## Summary

- **Exploration harness** (`-UIExploration` launch arg): replaces `ContentView` with `ExplorationRootView` in `#if DEBUG` builds, giving a deterministic, XCUITest-navigable home for component state galleries and design reviews. Zero production footprint.
- **`ExplorationScene` / `ExplorationRootView`**: `NavigationStack` on iOS, `NavigationSplitView` on macOS; each scene registered by stable `accessibilityIdentifier` for automated navigation.
- **`DesignLanguageExplorationView`**: all four ADR-0039 icon/color proposals side-by-side at 20/28/44pt with mock rows — visual record for #84.
- **`RunnerRowExplorationView`**: real `AdversaryRunnerRow` in 9 states (normal, damaged, high-stress, single/multiple conditions, solo variants, defeated, unknown adversary).
- **`PlayerStripExplorationView`**: real `PlayerStrip` with two `EncounterSession` galleries — 4-player varied states and edge-case long names.
- **`ExplorationUITestCase`**: XCTestCase base class; sets `-UIExploration`, waits for nav bar, provides `navigate(to:)` and `screenshotScene(named:)`.
- **`ExplorationScreenshotTests`**: 4 UI tests capturing `keepAlways` screenshots for all three scenes; all pass on iPhone 17 Pro simulator.
- **CLAUDE.md / CONTRIBUTING.md**: harness documented for both Claude sessions and human developers.

## Test plan

- [x] Run `ExplorationScreenshotTests` on iOS simulator — 4/4 pass
- [x] Verify `exploration.design-language` scene renders all four icon proposals
- [x] Verify `exploration.runner-row` scene shows all 9 adversary states
- [x] Verify `exploration.player-strip` scene shows both sessions with correct player data
- [x] Run macOS unit test suite: `xcodebuild test -scheme Encounter -destination 'platform=macOS'`