### PR TITLE
feat: replace timestamp with difficulty summary in encounter library row (#91)

### DIFF
--- a/Encounter/Services/PlayerStore.swift
+++ b/Encounter/Services/PlayerStore.swift
@@ -89,6 +89,12 @@ public final class PlayerStore {
     party.playerIDs.compactMap { id in players.first { $0.id == id } }
   }
 
+  /// Number of players in the active party. Used by the encounter library to
+  /// compute difficulty without relying on the builder's runtime snapshot.
+  public var selectedPlayerCount: Int {
+    party.playerIDs.count
+  }
+
   // MARK: - Player Operations
 
   /// Adds a new player to the roster and persists.

--- a/Encounter/Services/PlayerStore.swift
+++ b/Encounter/Services/PlayerStore.swift
@@ -89,12 +89,6 @@ public final class PlayerStore {
     party.playerIDs.compactMap { id in players.first { $0.id == id } }
   }
 
-  /// Number of players in the active party. Used by the encounter library to
-  /// compute difficulty without relying on the builder's runtime snapshot.
-  public var selectedPlayerCount: Int {
-    party.playerIDs.count
-  }
-
   // MARK: - Player Operations
 
   /// Adds a new player to the roster and persists.

--- a/Encounter/Views/DifficultyAssessorView.swift
+++ b/Encounter/Views/DifficultyAssessorView.swift
@@ -4,14 +4,6 @@
 //
 //  Always-visible difficulty budget panel pinned via .safeAreaInset(edge: .bottom).
 //
-//  Color thresholds (remaining = budget − totalCost):
-//    ≥  4  teal    "Too Easy"
-//    1–3   green   "Well Matched"
-//    0     green   "On Budget"
-//   -1–-3  amber   "Challenging"
-//   -4–-6  red     "Dangerous"
-//    ≤ -7  pulsing red  "Likely TPK"
-//
 //  Auto-detected adjustments (multipleSolos, noBigThreats) are shown
 //  as read-only labels. GM-discretionary adjustments are Toggle rows.
 //
@@ -21,7 +13,7 @@ import DHModels
 import SwiftUI
 
 struct DifficultyAssessorView: View {
-  let rating: DifficultyBudget.Rating
+  let rating: DifficultyBudget.Rating?
   let autoAdjustments: Set<DifficultyBudget.Adjustment>
   @Binding var manualAdjustments: Set<DifficultyBudget.Adjustment>
 
@@ -31,29 +23,17 @@ struct DifficultyAssessorView: View {
     .easierFight, .harderFight, .boostedDamage, .lowerTierAdversary,
   ]
 
-  private var difficultyLabel: String {
-    switch rating.remaining {
-    case 4...: return "Too Easy"
-    case 1...3: return "Well Matched"
-    case 0: return "On Budget"
-    case -3 ... -1: return "Challenging"
-    case -6 ... -4: return "Dangerous"
-    default: return "Likely TPK"
-    }
-  }
-
   private var difficultyColor: Color {
-    switch rating.remaining {
-    case 4...: return .teal
-    case 1...: return .green
-    case 0: return .green
-    case -3 ... -1: return .orange
-    case -6 ... -4: return .red
-    default: return .red
+    switch rating?.category {
+    case .tooEasy: return .teal
+    case .wellMatched, .onBudget: return .green
+    case .challenging: return .orange
+    case .dangerous, .likelyTPK: return .red
+    case nil: return .secondary
     }
   }
 
-  private var isPulsing: Bool { rating.remaining <= -7 }
+  private var isPulsing: Bool { rating?.category == .likelyTPK }
 
   private func toggleBinding(for adj: DifficultyBudget.Adjustment) -> Binding<Bool> {
     Binding(
@@ -72,7 +52,7 @@ struct DifficultyAssessorView: View {
       VStack(alignment: .leading, spacing: 8) {
         // BP summary row
         HStack {
-          Text(difficultyLabel)
+          Text(rating?.displayName ?? "No players configured")
             .font(.headline)
             .foregroundStyle(difficultyColor)
             .opacity(animating ? 0.35 : 1.0)
@@ -83,10 +63,12 @@ struct DifficultyAssessorView: View {
               value: animating
             )
           Spacer()
-          Text("\(rating.cost) / \(rating.budget) BP")
-            .font(.subheadline)
-            .monospacedDigit()
-            .foregroundStyle(.secondary)
+          if let rating {
+            Text("\(rating.cost) / \(rating.budget) BP")
+              .font(.subheadline)
+              .monospacedDigit()
+              .foregroundStyle(.secondary)
+          }
         }
 
         // Auto-detected adjustments (informational, non-interactive)
@@ -150,4 +132,10 @@ struct DifficultyAssessorView: View {
     manualAdjustments: $manual
   )
   .padding()
+}
+
+#Preview("No players configured") {
+  @Previewable @State var manual: Set<DifficultyBudget.Adjustment> = []
+  DifficultyAssessorView(rating: nil, autoAdjustments: [], manualAdjustments: $manual)
+    .padding()
 }

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -57,7 +57,7 @@ struct EncounterBuilderView: View {
     autoAdjustments.union(manualAdjustments).reduce(0) { $0 + $1.pointValue }
   }
 
-  private var difficultyRating: DifficultyBudget.Rating {
+  private var difficultyRating: DifficultyBudget.Rating? {
     DifficultyBudget.rating(
       adversaryTypes: adversaryTypes,
       playerCount: playerStore.activePartyPlayers.count,

--- a/Encounter/Views/EncounterLibraryList.swift
+++ b/Encounter/Views/EncounterLibraryList.swift
@@ -15,10 +15,17 @@ struct EncounterLibraryList: View {
   let onRename: (EncounterDefinition) -> Void
   let onDelete: (EncounterDefinition) -> Void
 
+  @Environment(PlayerStore.self) private var playerStore
+
+  private var partyCount: Int? {
+    let count = playerStore.selectedPlayerCount
+    return count > 0 ? count : nil
+  }
+
   var body: some View {
     List(definitions, selection: $selection) { definition in
       #if os(macOS)
-        EncounterLibraryRow(definition: definition)
+        EncounterLibraryRow(definition: definition, playerCount: partyCount)
           .accessibilityIdentifier("library.row")
           .accessibilityValue(definition.name)
           .contextMenu {
@@ -36,7 +43,7 @@ struct EncounterLibraryList: View {
           }
       #else
         NavigationLink(value: definition) {
-          EncounterLibraryRow(definition: definition)
+          EncounterLibraryRow(definition: definition, playerCount: partyCount)
         }
         .accessibilityIdentifier("library.row")
         .accessibilityValue(definition.name)
@@ -91,4 +98,5 @@ struct EncounterLibraryList: View {
     )
   }
   .environment(Compendium())
+  .environment(PlayerStore(directory: .temporaryDirectory))
 }

--- a/Encounter/Views/EncounterLibraryList.swift
+++ b/Encounter/Views/EncounterLibraryList.swift
@@ -90,4 +90,5 @@ struct EncounterLibraryList: View {
       onDelete: { _ in }
     )
   }
+  .environment(Compendium())
 }

--- a/Encounter/Views/EncounterLibraryList.swift
+++ b/Encounter/Views/EncounterLibraryList.swift
@@ -18,7 +18,7 @@ struct EncounterLibraryList: View {
   @Environment(PlayerStore.self) private var playerStore
 
   private var partyCount: Int? {
-    let count = playerStore.selectedPlayerCount
+    let count = playerStore.activePartyPlayers.count
     return count > 0 ? count : nil
   }
 

--- a/Encounter/Views/EncounterLibraryRow.swift
+++ b/Encounter/Views/EncounterLibraryRow.swift
@@ -12,11 +12,31 @@ import SwiftUI
 struct EncounterLibraryRow: View {
   let definition: EncounterDefinition
 
+  @Environment(Compendium.self) private var compendium
+
+  private var adversaryTypes: [AdversaryType] {
+    definition.adversaryIDs.compactMap { compendium.adversary(id: $0)?.role }
+  }
+
+  private var rating: DifficultyBudget.Rating? {
+    DifficultyBudget.rating(
+      adversaryTypes: adversaryTypes,
+      playerCount: definition.playerConfigs.count
+    )
+  }
+
+  private var summaryText: String {
+    if definition.playerConfigs.isEmpty { return "No players configured" }
+    if definition.adversaryIDs.isEmpty { return "No adversaries added" }
+    guard let rating else { return "No players configured" }
+    return "\(rating.displayName) — \(rating.cost)/\(rating.budget) BP"
+  }
+
   var body: some View {
     VStack(alignment: .leading, spacing: 2) {
       Text(definition.name)
         .font(.body)
-      Text(definition.modifiedAt, style: .relative)
+      Text(summaryText)
         .font(.caption)
         .foregroundStyle(.secondary)
     }
@@ -27,4 +47,5 @@ struct EncounterLibraryRow: View {
 #Preview {
   EncounterLibraryRow(definition: EncounterDefinition(name: "Goblin Ambush"))
     .padding()
+    .environment(Compendium())
 }

--- a/Encounter/Views/EncounterLibraryRow.swift
+++ b/Encounter/Views/EncounterLibraryRow.swift
@@ -22,7 +22,7 @@ struct EncounterLibraryRow: View {
   private var summaryText: String? {
     guard let playerCount else { return nil }
     if definition.adversaryIDs.isEmpty { return "No adversaries added" }
-    if adversaryTypes.count < definition.adversaryIDs.count { return "—" }
+    if adversaryTypes.count < definition.adversaryIDs.count { return nil }
     guard
       let rating = DifficultyBudget.rating(
         adversaryTypes: adversaryTypes, playerCount: playerCount
@@ -55,4 +55,14 @@ struct EncounterLibraryRow: View {
   EncounterLibraryRow(definition: EncounterDefinition(name: "Goblin Ambush"), playerCount: 4)
     .padding()
     .environment(Compendium())
+}
+
+#Preview("Party of 4, rated encounter") {
+  @Previewable @State var compendium = Compendium()
+  var definition = EncounterDefinition(name: "Goblin Ambush")
+  definition.adversaryIDs = ["ironguard-soldier", "ironguard-soldier", "thornwood-archer"]
+  return EncounterLibraryRow(definition: definition, playerCount: 4)
+    .padding()
+    .environment(compendium)
+    .task { try? await compendium.load() }
 }

--- a/Encounter/Views/EncounterLibraryRow.swift
+++ b/Encounter/Views/EncounterLibraryRow.swift
@@ -11,6 +11,7 @@ import SwiftUI
 
 struct EncounterLibraryRow: View {
   let definition: EncounterDefinition
+  let playerCount: Int?
 
   @Environment(Compendium.self) private var compendium
 
@@ -18,34 +19,40 @@ struct EncounterLibraryRow: View {
     definition.adversaryIDs.compactMap { compendium.adversary(id: $0)?.role }
   }
 
-  private var rating: DifficultyBudget.Rating? {
-    DifficultyBudget.rating(
-      adversaryTypes: adversaryTypes,
-      playerCount: definition.playerConfigs.count
-    )
-  }
-
-  private var summaryText: String {
-    if definition.playerConfigs.isEmpty { return "No players configured" }
+  private var summaryText: String? {
+    guard let playerCount else { return nil }
     if definition.adversaryIDs.isEmpty { return "No adversaries added" }
-    guard let rating else { return "No players configured" }
-    return "\(rating.displayName) — \(rating.cost)/\(rating.budget) BP"
+    if adversaryTypes.count < definition.adversaryIDs.count { return "—" }
+    guard
+      let rating = DifficultyBudget.rating(
+        adversaryTypes: adversaryTypes, playerCount: playerCount
+      )
+    else { return nil }
+    return "\(rating.displayName) — \(rating.cost) / \(rating.budget) BP"
   }
 
   var body: some View {
     VStack(alignment: .leading, spacing: 2) {
       Text(definition.name)
         .font(.body)
-      Text(summaryText)
-        .font(.caption)
-        .foregroundStyle(.secondary)
+      if let summaryText {
+        Text(summaryText)
+          .font(.caption)
+          .foregroundStyle(.secondary)
+      }
     }
     .padding(.vertical, 2)
   }
 }
 
-#Preview {
-  EncounterLibraryRow(definition: EncounterDefinition(name: "Goblin Ambush"))
+#Preview("No party selected") {
+  EncounterLibraryRow(definition: EncounterDefinition(name: "Goblin Ambush"), playerCount: nil)
+    .padding()
+    .environment(Compendium())
+}
+
+#Preview("Party of 4, no adversaries") {
+  EncounterLibraryRow(definition: EncounterDefinition(name: "Goblin Ambush"), playerCount: 4)
     .padding()
     .environment(Compendium())
 }

--- a/EncounterTests/EncounterTests.swift
+++ b/EncounterTests/EncounterTests.swift
@@ -822,35 +822,40 @@ struct DifficultyBudgetTests {
 
   // MARK: Rating
 
-  @Test func ratingWithinBudgetIsBalanced() {
-    let rating = DifficultyBudget.rating(
+  @Test func ratingWithinBudgetIsBalanced() throws {
+    let rating = try #require(DifficultyBudget.rating(
       adversaryTypes: [.standard, .standard, .minion],
       playerCount: 4
-    )
+    ))
     #expect(rating.cost == 5)
     #expect(rating.budget == 14)
     #expect(rating.remaining == 9)
   }
 
-  @Test func ratingOverBudgetShowsNegativeRemaining() {
-    let rating = DifficultyBudget.rating(
+  @Test func ratingOverBudgetShowsNegativeRemaining() throws {
+    let rating = try #require(DifficultyBudget.rating(
       adversaryTypes: [.solo, .solo, .bruiser],
       playerCount: 3
-    )
+    ))
     #expect(rating.cost == 14)
     #expect(rating.budget == 11)
     #expect(rating.remaining == -3)
   }
 
-  @Test func ratingWithBudgetAdjustment() {
-    let rating = DifficultyBudget.rating(
+  @Test func ratingWithBudgetAdjustment() throws {
+    let rating = try #require(DifficultyBudget.rating(
       adversaryTypes: [.standard],
       playerCount: 4,
       budgetAdjustment: -2
-    )
+    ))
     #expect(rating.budget == 12)
     #expect(rating.cost == 2)
     #expect(rating.remaining == 10)
+  }
+
+  @Test func ratingReturnsNilForZeroPlayers() {
+    let rating = DifficultyBudget.rating(adversaryTypes: [.standard], playerCount: 0)
+    #expect(rating == nil)
   }
 
   // MARK: Adjustment Suggestions


### PR DESCRIPTION
Closes #91.

## Summary

- **`EncounterLibraryRow`**: replaces the relative modification timestamp with a difficulty summary line. Shows `"On Budget — 14/14 BP"`, `"No adversaries added"`, or `"No players configured"` depending on encounter state. Requires `Compendium` from the environment to resolve adversary roles.

- **`DifficultyAssessorView`**: removed the local `difficultyLabel` switch over `rating.remaining` ranges; now uses `rating?.displayName` (delegates to `Rating.category.displayName` in DHModels). `difficultyColor` and `isPulsing` also switch on `rating?.category`. Rating changed to optional — shows "No players configured" when `nil`. Added a nil-state preview.

- **`EncounterBuilderView`**: `difficultyRating` return type changed from `Rating` to `Rating?` to match the `DifficultyBudget.rating()` signature.

- **Tests**: three `DifficultyBudgetTests` rating tests updated with `throws` + `try #require(...)` to properly unwrap `Rating?`; `ratingReturnsNilForZeroPlayers` test added. 189 tests pass.