### PR TITLE
fix: make Encounters the default view, Party secondary

### DIFF
--- a/Encounter/ContentView.swift
+++ b/Encounter/ContentView.swift
@@ -4,9 +4,9 @@
 //
 //  Root navigation container.
 //
-//  iOS / visionOS: TabView — Party tab first, Encounters tab second.
-//  macOS: three-column NavigationSplitView — sidebar selects Party or
-//  Encounters, content column shows the corresponding list/overview,
+//  iOS / visionOS: TabView — Encounters tab first, Party tab second.
+//  macOS: three-column NavigationSplitView — sidebar selects Encounters or
+//  Party, content column shows the corresponding list/overview,
 //  detail column shows the encounter builder when an encounter is selected.
 //
 
@@ -162,25 +162,25 @@ struct ContentView: View {
   // MARK: - macOS
 
   #if os(macOS)
-    @State private var sidebarItem: SidebarItem? = .party
+    @State private var sidebarItem: SidebarItem? = .encounters
 
     private var macOSLayout: some View {
       NavigationSplitView {
         List(selection: $sidebarItem) {
-          Label("Party", systemImage: "person.2")
-            .tag(SidebarItem.party)
-            .accessibilityIdentifier("sidebar.party")
           Label("Encounters", systemImage: "list.bullet.clipboard")
             .tag(SidebarItem.encounters)
             .accessibilityIdentifier("sidebar.encounters")
+          Label("Party", systemImage: "person.2")
+            .tag(SidebarItem.party)
+            .accessibilityIdentifier("sidebar.party")
         }
         .navigationTitle("Encounter")
       } content: {
         switch sidebarItem {
-        case .party, nil:
-          PartyOverviewView()
-        case .encounters:
+        case .encounters, nil:
           EncounterLibraryView(selection: $encounterSelection)
+        case .party:
+          PartyOverviewView()
         }
       } detail: {
         NavigationStack {
@@ -204,19 +204,19 @@ struct ContentView: View {
   #if !os(macOS)
     private var iOSLayout: some View {
       TabView {
-        Tab("Party", systemImage: "person.2") {
-          NavigationStack {
-            PartyOverviewView()
-          }
-        }
-        .accessibilityIdentifier("tab.party")
-
         Tab("Encounters", systemImage: "list.bullet.clipboard") {
           NavigationStack {
             EncounterLibraryView(selection: $encounterSelection)
           }
         }
         .accessibilityIdentifier("tab.encounters")
+
+        Tab("Party", systemImage: "person.2") {
+          NavigationStack {
+            PartyOverviewView()
+          }
+        }
+        .accessibilityIdentifier("tab.party")
       }
     }
   #endif

--- a/Encounter/ContentView.swift
+++ b/Encounter/ContentView.swift
@@ -4,11 +4,6 @@
 //
 //  Root navigation container.
 //
-//  iOS / visionOS: TabView — Encounters tab first, Party tab second.
-//  macOS: three-column NavigationSplitView — sidebar selects Encounters or
-//  Party, content column shows the corresponding list/overview,
-//  detail column shows the encounter builder when an encounter is selected.
-//
 
 import DHKit
 import DHModels
@@ -177,7 +172,7 @@ struct ContentView: View {
         .navigationTitle("Encounter")
       } content: {
         switch sidebarItem {
-        case .encounters, nil:
+        case .encounters, nil:  // nil (sidebar deselected) falls through to Encounters
           EncounterLibraryView(selection: $encounterSelection)
         case .party:
           PartyOverviewView()

--- a/EncounterUITests/AccessibilityTreeDump.swift
+++ b/EncounterUITests/AccessibilityTreeDump.swift
@@ -27,11 +27,10 @@ final class AccessibilityTreeDump: XCTestCase {
 
   // MARK: - Library screen
 
-  /// Dumps the accessibility tree of the initial Party screen.
+  /// Dumps the accessibility tree of the initial Encounters screen.
   @MainActor
   func testDumpLibraryScreen() throws {
-    // Party tab is the first screen since the navigation restructure in PR #64.
-    _ = app.navigationBars["Party"].waitForExistence(timeout: 5)
+    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 5)
     printTree("Library screen")
   }
 
@@ -41,12 +40,7 @@ final class AccessibilityTreeDump: XCTestCase {
   /// Requires an encounter to exist — create one manually before running.
   @MainActor
   func testDumpBuilderScreen() throws {
-    // Wait for the app to finish loading and the tab bar to be ready.
-    _ = app.navigationBars["Party"].waitForExistence(timeout: 5)
-    _ = app.tabBars.buttons["Encounters"].waitForExistence(timeout: 3)
-    // Navigate to Encounters — Party tab is first since PR #64.
-    app.tabBars.buttons["Encounters"].tap()
-    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 3)
+    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 5)
     // Tap the first row if one exists
     let firstRow = app.buttons.matching(identifier: "library.row").firstMatch
     if firstRow.waitForExistence(timeout: 2) {
@@ -64,12 +58,7 @@ final class AccessibilityTreeDump: XCTestCase {
   /// Requires an encounter to exist — create one manually before running.
   @MainActor
   func testToggleDifficultyAdjustments() throws {
-    // Wait for the app to finish loading and the tab bar to be ready.
-    _ = app.navigationBars["Party"].waitForExistence(timeout: 5)
-    _ = app.tabBars.buttons["Encounters"].waitForExistence(timeout: 3)
-    // Navigate to Encounters — Party tab is first since PR #64.
-    app.tabBars.buttons["Encounters"].tap()
-    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 3)
+    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 5)
     let firstRow = app.buttons.matching(identifier: "library.row").firstMatch
     guard firstRow.waitForExistence(timeout: 2) else {
       throw XCTSkip("No encounter row found — create one first for this diagnostic test")
@@ -98,12 +87,7 @@ final class AccessibilityTreeDump: XCTestCase {
   /// Verifies the library 'New Encounter' button is accessible and tappable via XCUITest.
   @MainActor
   func testLibraryCreateButton() throws {
-    // Wait for the app to finish loading and the tab bar to be ready.
-    _ = app.navigationBars["Party"].waitForExistence(timeout: 5)
-    _ = app.tabBars.buttons["Encounters"].waitForExistence(timeout: 3)
-    // Navigate to Encounters — Party tab is first since PR #64.
-    app.tabBars.buttons["Encounters"].tap()
-    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 3)
+    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 5)
     // Use firstMatch — both the toolbar and empty-state CTA share this identifier.
     let createButton = app.buttons.matching(identifier: "library.create-button").firstMatch
     XCTAssertTrue(createButton.waitForExistence(timeout: 3), "library.create-button not found")
@@ -119,12 +103,7 @@ final class AccessibilityTreeDump: XCTestCase {
   /// Requires an encounter to exist — create one manually before running.
   @MainActor
   func testDumpCompendiumBrowser() throws {
-    // Wait for the app to finish loading and the tab bar to be ready.
-    _ = app.navigationBars["Party"].waitForExistence(timeout: 5)
-    _ = app.tabBars.buttons["Encounters"].waitForExistence(timeout: 3)
-    // Navigate to Encounters — Party tab is first since PR #64.
-    app.tabBars.buttons["Encounters"].tap()
-    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 3)
+    _ = app.navigationBars["Encounters"].waitForExistence(timeout: 5)
     let firstRow = app.buttons.matching(identifier: "library.row").firstMatch
     guard firstRow.waitForExistence(timeout: 2) else {
       throw XCTSkip("No encounter row found — create one first for this diagnostic test")

--- a/EncounterUITests/EncounterUITestCase.swift
+++ b/EncounterUITests/EncounterUITestCase.swift
@@ -18,22 +18,23 @@ class EncounterUITestCase: XCTestCase {
     app.launchArguments = ["-UITestResetState"]
     app.launch()
     XCTAssertTrue(
-      app.navigationBars["Party"].waitForExistence(timeout: 10),
-      "App should load and show Party screen within 10 seconds")
+      app.navigationBars["Encounters"].waitForExistence(timeout: 10),
+      "App should load and show Encounters screen within 10 seconds")
   }
 
   // MARK: - Top-level navigation flows
 
-  /// Navigates from the Party screen all the way into the live encounter runner.
+  /// Navigates from the Encounters screen all the way into the live encounter runner.
   ///
   /// Flow:
-  ///   1. Add one player (required for "Run Encounter" to be enabled).
+  ///   1. Switch to Party tab and add one player (required for "Run Encounter" to be enabled).
   ///   2. Switch to Encounters tab.
   ///   3. Create a new encounter.
   ///   4. Open the encounter in the builder.
   ///   5. Add one adversary from the compendium.
   ///   6. Tap "Run Encounter".
   func navigateToRunner() {
+    switchToPartyTab()
     addOnePlayer()
     switchToEncountersTab()
     createEncounter()
@@ -45,6 +46,7 @@ class EncounterUITestCase: XCTestCase {
   /// Same as `navigateToRunner`, but adds the same (first) adversary twice so
   /// both slots receive auto-assigned `customName` values ("Name 1", "Name 2").
   func navigateToRunnerWithTwoSameAdversaries() {
+    switchToPartyTab()
     addOnePlayer()
     switchToEncountersTab()
     createEncounter()
@@ -91,6 +93,15 @@ class EncounterUITestCase: XCTestCase {
     XCTAssertTrue(
       app.navigationBars["Encounters"].waitForExistence(timeout: 5),
       "Encounters screen should appear")
+  }
+
+  func switchToPartyTab() {
+    let tab = app.tabBars.buttons["Party"]
+    XCTAssertTrue(tab.waitForExistence(timeout: 3))
+    tab.tap()
+    XCTAssertTrue(
+      app.navigationBars["Party"].waitForExistence(timeout: 5),
+      "Party screen should appear")
   }
 
   func createEncounter() {

--- a/EncounterUITests/ExplorationUITestCase.swift
+++ b/EncounterUITests/ExplorationUITestCase.swift
@@ -40,8 +40,12 @@ class ExplorationUITestCase: XCTestCase {
     XCTAssertTrue(row.waitForExistence(timeout: 3), "Scene '\(sceneID)' not found in list")
     row.tap()
     // Wait for any navigation bar other than "Exploration" to confirm the destination loaded.
-    let destination = app.navigationBars.matching(NSPredicate(format: "identifier != 'Exploration'")).firstMatch
-    XCTAssertTrue(destination.waitForExistence(timeout: 5), "Scene destination should load after tapping '\(sceneID)'")
+    let destination = app.navigationBars.matching(
+      NSPredicate(format: "identifier != 'Exploration'")
+    ).firstMatch
+    XCTAssertTrue(
+      destination.waitForExistence(timeout: 5),
+      "Scene destination should load after tapping '\(sceneID)'")
   }
 
   // MARK: - Screenshots

--- a/EncounterUITests/PartyManagementUITests.swift
+++ b/EncounterUITests/PartyManagementUITests.swift
@@ -299,3 +299,29 @@ final class PartyManagementUITests: XCTestCase {
       .waitForExistence(timeout: 5)
   }
 }
+
+// MARK: - Launch default
+
+/// Verifies the raw launch default without the Party-navigation that
+/// PartyManagementUITests.setUp performs before every test.
+final class NavigationDefaultUITests: XCTestCase {
+
+  var app: XCUIApplication!
+
+  override func setUpWithError() throws {
+    continueAfterFailure = false
+    app = XCUIApplication()
+    app.launchArguments = ["-UITestResetState"]
+    app.launch()
+  }
+
+  @MainActor
+  func testEncountersIsDefaultTabOnFreshLaunch() throws {
+    XCTAssertTrue(
+      app.navigationBars["Encounters"].waitForExistence(timeout: 10),
+      "Encounters should be the active screen on launch")
+    XCTAssertFalse(
+      app.navigationBars["Party"].waitForExistence(timeout: 1),
+      "Party nav bar should not be visible without switching tabs")
+  }
+}

--- a/EncounterUITests/PartyManagementUITests.swift
+++ b/EncounterUITests/PartyManagementUITests.swift
@@ -34,17 +34,20 @@ final class PartyManagementUITests: XCTestCase {
     app = XCUIApplication()
     app.launchArguments = ["-UITestResetState"]
     app.launch()
-    // Wait for the app to fully load before any test step runs.
     XCTAssertTrue(
-      app.navigationBars["Party"].waitForExistence(timeout: 10),
-      "App should load and show Party screen within 10 seconds")
+      app.navigationBars["Encounters"].waitForExistence(timeout: 10),
+      "App should load and show Encounters screen within 10 seconds")
+    app.tabBars.buttons["Party"].tap()
+    XCTAssertTrue(
+      app.navigationBars["Party"].waitForExistence(timeout: 5),
+      "Party screen should appear after tapping Party tab")
   }
 
   // MARK: - Navigation structure
 
-  /// Party tab is the first screen on launch; empty-state CTA is visible.
+  /// Encounters is the default tab on launch; Party tab is accessible and shows its empty-state CTA.
   @MainActor
-  func testPartyTabFirstAndEmptyStateCTA() throws {
+  func testEncountersTabFirstAndPartyTabAccessible() throws {
     XCTAssertTrue(
       app.buttons["party.empty-add-button"].waitForExistence(timeout: 3),
       "Empty-state Add Player CTA should be visible when no players exist")

--- a/EncounterUITests/SessionResumeUITests.swift
+++ b/EncounterUITests/SessionResumeUITests.swift
@@ -95,8 +95,8 @@ import XCTest
         "App should show the Encounters screen after dismissing the resume prompt")
 
       // Navigate away and back to confirm the dismiss is sticky.
-      app.tabBars.firstMatch.buttons["Encounters"].tap()
-      app.tabBars.firstMatch.buttons["Party"].tap()
+      app.tabBars.buttons["Encounters"].tap()
+      app.tabBars.buttons["Party"].tap()
       XCTAssertFalse(
         app.navigationBars["In Progress"].waitForExistence(timeout: 3),
         "Resume sheet should not re-appear after navigating away and back")

--- a/EncounterUITests/SessionResumeUITests.swift
+++ b/EncounterUITests/SessionResumeUITests.swift
@@ -89,10 +89,10 @@ import XCTest
         app.navigationBars["In Progress"].waitForExistence(timeout: 3),
         "Resume sheet should dismiss after tapping 'Not Now'")
 
-      // Normal app state: Party tab is default
+      // Normal app state: Encounters tab is default
       XCTAssertTrue(
-        app.navigationBars["Party"].waitForExistence(timeout: 5),
-        "App should show the Party screen after dismissing the resume prompt")
+        app.navigationBars["Encounters"].waitForExistence(timeout: 5),
+        "App should show the Encounters screen after dismissing the resume prompt")
 
       // Navigate away and back to confirm the dismiss is sticky.
       app.tabBars.firstMatch.buttons["Encounters"].tap()

--- a/docs/decisions/0040-encounters-first-navigation.md
+++ b/docs/decisions/0040-encounters-first-navigation.md
@@ -1,0 +1,34 @@
+# ADR-0040: Encounters as the default landing screen
+
+**Status:** Accepted
+**Date:** 2026-04-25
+
+## Context
+
+The original tab order (iOS) and sidebar default (macOS) placed the Party screen first.
+Party management is setup work done before a session; during active use at the table the
+GM navigates to Encounters immediately. Leading with Party forced an extra tap on every
+app launch and buried the primary workflow.
+
+## Decision
+
+Encounters is now the default landing screen on all platforms:
+
+- **iOS/visionOS:** Encounters tab is first (left); Party tab is second.
+- **macOS:** sidebar defaults to the Encounters item; Party is listed below it.
+
+## Options Considered
+
+- **Party first (original):** Reflected the setup-before-run mental model but
+  front-loaded an extra navigation step for the most common session-start flow.
+- **Encounters first (chosen):** Matches GM intent at the table — encounters are the
+  focus, party management is secondary. Confirmed by issue #90.
+
+## Consequences
+
+- The app now opens directly into the encounter library, which is the correct default
+  for in-session use.
+- All UI test launch expectations and navigation helpers updated to reflect Encounters
+  as the arrival screen.
+- macOS: a nil sidebar selection (user presses Escape to deselect) falls through to the
+  Encounters content column, consistent with it being the primary view.


### PR DESCRIPTION
## Summary

- Swaps iOS tab order so Encounters is the first (default) tab; Party is second
- Changes macOS sidebar default selection from Party to Encounters; swaps sidebar label order
- Updates macOS `nil` content arm to show `EncounterLibraryView` instead of `PartyOverviewView`
- Updates all UI test launch expectations and navigation helpers to match the new default

## Test plan

- [x] Launch on iOS simulator — Encounters screen appears, not Party
- [x] Tap Party tab — Party screen loads normally
- [x] Launch on macOS — Encounters sidebar item selected, library visible in content column
- [x] Click Party in sidebar — PartyOverviewView loads
- [x] Unit test suite passes: `xcodebuild test -scheme Encounter -destination 'platform=macOS'`

Closes #90