### PR TITLE
refactor: codebase simplification pass

### DIFF
--- a/Encounter/Services/ContentWriter.swift
+++ b/Encounter/Services/ContentWriter.swift
@@ -127,13 +127,8 @@ public struct ContentWriter: Sendable {
   /// Read adversaries for a source pack from disk. Returns `[]` if not yet written.
   @concurrent
   nonisolated public func readAdversaries(sourceID: String) async throws -> [Adversary] {
-    let url = sourcesDirectory.appending(path: "\(sourceID)/adversaries.json")
-    guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return [] }
-    do {
-      return try JSONDecoder().decode([Adversary].self, from: Data(contentsOf: url))
-    } catch {
-      throw ContentStoreError.readFailed(sourceID: sourceID, underlying: error)
-    }
+    try readSourcePackFile(
+      at: sourcesDirectory.appending(path: "\(sourceID)/adversaries.json"), sourceID: sourceID)
   }
 
   /// Read environments for a source pack from disk. Returns `[]` if not yet written.
@@ -141,10 +136,16 @@ public struct ContentWriter: Sendable {
   nonisolated public func readEnvironments(sourceID: String) async throws
     -> [DaggerheartEnvironment]
   {
-    let url = sourcesDirectory.appending(path: "\(sourceID)/environments.json")
+    try readSourcePackFile(
+      at: sourcesDirectory.appending(path: "\(sourceID)/environments.json"), sourceID: sourceID)
+  }
+
+  nonisolated private func readSourcePackFile<T: Decodable>(at url: URL, sourceID: String) throws
+    -> [T]
+  {
     guard FileManager.default.fileExists(atPath: url.path(percentEncoded: false)) else { return [] }
     do {
-      return try JSONDecoder().decode([DaggerheartEnvironment].self, from: Data(contentsOf: url))
+      return try JSONDecoder().decode([T].self, from: Data(contentsOf: url))
     } catch {
       throw ContentStoreError.readFailed(sourceID: sourceID, underlying: error)
     }

--- a/Encounter/Views/AdversaryConditionsSection.swift
+++ b/Encounter/Views/AdversaryConditionsSection.swift
@@ -36,12 +36,14 @@ struct AdversaryConditionsSection: View {
             .font(.caption)
             .buttonStyle(.bordered)
             .tint(active ? .orange : nil)
-            .accessibilityAddTraits(active ? .isSelected : [])
+            .accessibilityValue(active ? "active" : "inactive")
+            .accessibilityHint(active ? "Removes this condition" : "Applies this condition")
             .accessibilityIdentifier(
               "runner.adversary-card.condition.\(condition.displayName.lowercased())"
             )
           }
         }
+        .padding(.horizontal, 4)
       }
     }
   }

--- a/Encounter/Views/AdversaryDetailView.swift
+++ b/Encounter/Views/AdversaryDetailView.swift
@@ -33,13 +33,7 @@ struct AdversaryDetailView: View {
               .font(.caption)
               .foregroundStyle(.secondary)
             if adversary.source != "srd" {
-              Text(adversary.source)
-                .font(.caption2)
-                .foregroundStyle(.white)
-                .padding(.horizontal, 5)
-                .padding(.vertical, 2)
-                .background(.blue)
-                .clipShape(.capsule)
+              SourceBadgeView(label: adversary.source)
             }
           }
           Text(adversary.description)

--- a/Encounter/Views/AdversaryRow.swift
+++ b/Encounter/Views/AdversaryRow.swift
@@ -18,13 +18,7 @@ struct AdversaryRow: View {
         Text(adversary.name)
           .font(.body)
         if adversary.isHomebrew {
-          Text(adversary.source)
-            .font(.caption2)
-            .foregroundStyle(.white)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
-            .background(.blue)
-            .clipShape(.capsule)
+          SourceBadgeView(label: adversary.source)
         }
       }
       Text("\(adversary.role.rawValue) · Tier \(adversary.tier) · DC \(adversary.difficulty)")

--- a/Encounter/Views/AdversaryRunnerCard.swift
+++ b/Encounter/Views/AdversaryRunnerCard.swift
@@ -27,13 +27,9 @@ struct AdversaryRunnerCard: View {
   @State private var nameError: String?
   @FocusState private var isNameFieldFocused: Bool
 
-  private var displayName: String {
-    let adversary = compendium.adversary(id: slot.adversaryID)
-    return slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
-  }
-
   var body: some View {
     let adversary = compendium.adversary(id: slot.adversaryID)
+    let displayName = slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
     let major = adversary.map { "\($0.thresholdMajor)" } ?? "—"
     let severe = adversary.map { "\($0.thresholdSevere)" } ?? "—"
 
@@ -156,7 +152,8 @@ struct AdversaryRunnerCard: View {
   }
 
   private func beginRename() {
-    pendingName = displayName
+    let adversary = compendium.adversary(id: slot.adversaryID)
+    pendingName = slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
     nameError = nil
     isEditingName = true
     isNameFieldFocused = true

--- a/Encounter/Views/AdversaryRunnerRow.swift
+++ b/Encounter/Views/AdversaryRunnerRow.swift
@@ -16,10 +16,7 @@ struct AdversaryRunnerRow: View {
   let slot: AdversaryState
   let compendium: Compendium
 
-  private var displayName: String {
-    let adversary = compendium.adversary(id: slot.adversaryID)
-    return slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
-  }
+  @ScaledMetric(relativeTo: .caption2) private var conditionIconSize: CGFloat = 8
 
   private var sortedConditions: [Condition] {
     slot.conditions.sorted { $0.displayName < $1.displayName }
@@ -27,6 +24,7 @@ struct AdversaryRunnerRow: View {
 
   var body: some View {
     let adversary = compendium.adversary(id: slot.adversaryID)
+    let displayName = slot.customName ?? adversary?.name ?? "Unknown (\(slot.adversaryID))"
 
     VStack(alignment: .leading, spacing: 6) {
       HStack(spacing: 6) {
@@ -50,7 +48,7 @@ struct AdversaryRunnerRow: View {
           HStack(spacing: 3) {
             ForEach(sortedConditions, id: \.self) { condition in
               Image(systemName: condition.sfSymbol)
-                .font(.system(size: 8))
+                .font(.system(size: conditionIconSize))
                 .foregroundStyle(.orange)
             }
           }

--- a/Encounter/Views/AdversaryRunnerSection.swift
+++ b/Encounter/Views/AdversaryRunnerSection.swift
@@ -38,23 +38,22 @@ struct AdversaryRunnerSection: View {
         .buttonStyle(.plain)
         .disabled(slot.isDefeated)
         .accessibilityIdentifier("runner.adversary-row")
-        .accessibilityLabel(
-          {
-            let name = slot.customName ?? slot.adversaryID
-            var parts: [String] = [name]
-            if slot.isDefeated {
-              parts.append("defeated")
-            }
-            if !slot.conditions.isEmpty {
-              let conditionNames = slot.conditions.map(\.displayName).sorted().joined(
-                separator: ", ")
-              parts.append("Conditions: \(conditionNames)")
-            }
-            return parts.joined(separator: ", ")
-          }()
-        )
+        .accessibilityLabel(rowLabel(for: slot))
         .accessibilityHint(slot.isDefeated ? "" : "Tap to expand")
       }
     }
+  }
+
+  private func rowLabel(for slot: AdversaryState) -> String {
+    let name = slot.customName ?? slot.adversaryID
+    var parts: [String] = [name]
+    if slot.isDefeated {
+      parts.append("defeated")
+    }
+    if !slot.conditions.isEmpty {
+      let conditionNames = slot.conditions.map(\.displayName).sorted().joined(separator: ", ")
+      parts.append("Conditions: \(conditionNames)")
+    }
+    return parts.joined(separator: ", ")
   }
 }

--- a/Encounter/Views/DifficultyAssessorView.swift
+++ b/Encounter/Views/DifficultyAssessorView.swift
@@ -35,15 +35,6 @@ struct DifficultyAssessorView: View {
 
   private var isPulsing: Bool { rating?.category == .likelyTPK }
 
-  private func toggleBinding(for adj: DifficultyBudget.Adjustment) -> Binding<Bool> {
-    Binding(
-      get: { manualAdjustments.contains(adj) },
-      set: { on in
-        if on { manualAdjustments.insert(adj) } else { manualAdjustments.remove(adj) }
-      }
-    )
-  }
-
   @State private var animating = false
 
   var body: some View {

--- a/Encounter/Views/EnvironmentDetailView.swift
+++ b/Encounter/Views/EnvironmentDetailView.swift
@@ -27,13 +27,7 @@ struct EnvironmentDetailView: View {
       Section {
         VStack(alignment: .leading, spacing: 6) {
           if environment.source != "srd" {
-            Text(environment.source)
-              .font(.caption2)
-              .foregroundStyle(.white)
-              .padding(.horizontal, 5)
-              .padding(.vertical, 2)
-              .background(.blue)
-              .clipShape(.capsule)
+            SourceBadgeView(label: environment.source)
           }
           Text(environment.description)
             .font(.subheadline)

--- a/Encounter/Views/EnvironmentRow.swift
+++ b/Encounter/Views/EnvironmentRow.swift
@@ -18,13 +18,7 @@ struct EnvironmentRow: View {
         Text(environment.name)
           .font(.body)
         if environment.isHomebrew {
-          Text(environment.source)
-            .font(.caption2)
-            .foregroundStyle(.white)
-            .padding(.horizontal, 5)
-            .padding(.vertical, 2)
-            .background(.blue)
-            .clipShape(.capsule)
+          SourceBadgeView(label: environment.source)
         }
       }
       Text(environment.description)

--- a/Encounter/Views/LastFetchedLabel.swift
+++ b/Encounter/Views/LastFetchedLabel.swift
@@ -5,8 +5,6 @@
 //  Caption-sized label showing when a ContentSource was last fetched.
 //
 
-import DHKit
-import DHModels
 import SwiftUI
 
 struct LastFetchedLabel: View {

--- a/Encounter/Views/ResumePromptView.swift
+++ b/Encounter/Views/ResumePromptView.swift
@@ -64,14 +64,9 @@ struct ResumePromptView: View {
           .accessibilityHidden(true)
         Text(target.definition.name)
           .font(.title2.bold())
-        let activeCount = target.session.activeAdversaries.count
-        Text(
-          activeCount == 1
-            ? "1 adversary still active"
-            : "\(activeCount) adversaries still active"
-        )
-        .font(.subheadline)
-        .foregroundStyle(.secondary)
+        Text(activeAdversariesLabel(count: target.session.activeAdversaries.count, suffix: "still active"))
+          .font(.subheadline)
+          .foregroundStyle(.secondary)
       }
       Button("Resume Encounter") {
         onResume(target)
@@ -95,19 +90,18 @@ struct ResumePromptView: View {
           Text(target.definition.name)
             .font(.headline)
             .foregroundStyle(.primary)
-          let activeCount = target.session.activeAdversaries.count
-          Text(
-            activeCount == 1
-              ? "1 adversary active"
-              : "\(activeCount) adversaries active"
-          )
-          .font(.caption)
-          .foregroundStyle(.secondary)
+          Text(activeAdversariesLabel(count: target.session.activeAdversaries.count, suffix: "active"))
+            .font(.caption)
+            .foregroundStyle(.secondary)
         }
       }
       .buttonStyle(.plain)
       .accessibilityIdentifier("resume.session-\(target.id)")
     }
+  }
+
+  private func activeAdversariesLabel(count: Int, suffix: String) -> String {
+    count == 1 ? "1 adversary \(suffix)" : "\(count) adversaries \(suffix)"
   }
 }
 

--- a/Encounter/Views/SourceBadgeView.swift
+++ b/Encounter/Views/SourceBadgeView.swift
@@ -1,0 +1,32 @@
+//
+//  SourceBadgeView.swift
+//  Encounter
+//
+//  Small blue capsule badge showing a homebrew content source name.
+//  Used in adversary and environment rows and detail views.
+//
+
+import SwiftUI
+
+/// A small capsule badge displaying a homebrew content source label.
+struct SourceBadgeView: View {
+  let label: String
+
+  var body: some View {
+    Text(label)
+      .font(.caption2)
+      .foregroundStyle(.white)
+      .padding(.horizontal, 5)
+      .padding(.vertical, 2)
+      .background(.blue)
+      .clipShape(.capsule)
+  }
+}
+
+#Preview {
+  HStack {
+    SourceBadgeView(label: "my-homebrew")
+    SourceBadgeView(label: "Expanded Compendium")
+  }
+  .padding()
+}

--- a/Encounter/Views/TypeBadgeView.swift
+++ b/Encounter/Views/TypeBadgeView.swift
@@ -5,7 +5,6 @@
 //  Capsule badge showing an adversary's role type (e.g. "Minion", "Bruiser").
 //
 
-import DHKit
 import DHModels
 import SwiftUI
 

--- a/EncounterTests/EncounterTests.swift
+++ b/EncounterTests/EncounterTests.swift
@@ -225,36 +225,38 @@ struct ConditionTests {
   }
 }
 
+// MARK: - Shared helpers (EncounterSessionTests + PlayerStateSessionTests)
+
+@MainActor private func makeTestSession() -> EncounterSession {
+  EncounterSession(name: "Test Encounter")
+}
+
+private func makeIronguardSoldier() -> Adversary {
+  Adversary(
+    id: "ironguard-soldier",
+    name: "Ironguard Soldier",
+    tier: 1,
+    role: .bruiser,
+    flavorText: "A disciplined mercenary.",
+    difficulty: 11,
+    thresholdMajor: 5,
+    thresholdSevere: 10,
+    hp: 6,
+    stress: 3,
+    attackModifier: "+3",
+    attackName: "Longsword",
+    attackRange: .veryClose,
+    damage: "1d10+3 phy"
+  )
+}
+
 // MARK: - EncounterSession
 
 @MainActor struct EncounterSessionTests {
 
-  private func makeSession() -> EncounterSession {
-    EncounterSession(name: "Test Encounter")
-  }
-
-  private func makeSoldier() -> Adversary {
-    Adversary(
-      id: "ironguard-soldier",
-      name: "Ironguard Soldier",
-      tier: 1,
-      role: .bruiser,
-      flavorText: "A disciplined mercenary.",
-      difficulty: 11,
-      thresholdMajor: 5,
-      thresholdSevere: 10,
-      hp: 6,
-      stress: 3,
-      attackModifier: "+3",
-      attackName: "Longsword",
-      attackRange: .veryClose,
-      damage: "1d10+3 phy"
-    )
-  }
-
   @Test func addAdversaryPopulatesSlot() {
-    let session = makeSession()
-    let soldier = makeSoldier()
+    let session = makeTestSession()
+    let soldier = makeIronguardSoldier()
     session.add(adversary: soldier)
 
     #expect(session.adversarySlots.count == 1)
@@ -266,8 +268,8 @@ struct ConditionTests {
   // MARK: - Rename
 
   @Test func renameAdversary_success() {
-    let session = makeSession()
-    let soldier = makeSoldier()
+    let session = makeTestSession()
+    let soldier = makeIronguardSoldier()
     session.add(adversary: soldier, customName: "Alpha")
     session.add(adversary: soldier, customName: "Bravo")
     let id = session.adversarySlots[0].id
@@ -279,8 +281,8 @@ struct ConditionTests {
   }
 
   @Test func renameAdversary_duplicate() {
-    let session = makeSession()
-    let soldier = makeSoldier()
+    let session = makeTestSession()
+    let soldier = makeIronguardSoldier()
     session.add(adversary: soldier, customName: "Alpha")
     session.add(adversary: soldier, customName: "Bravo")
     let id = session.adversarySlots[0].id
@@ -292,8 +294,8 @@ struct ConditionTests {
   }
 
   @Test func renameAdversary_emptyName() {
-    let session = makeSession()
-    let soldier = makeSoldier()
+    let session = makeTestSession()
+    let soldier = makeIronguardSoldier()
     session.add(adversary: soldier, customName: "Alpha")
     let id = session.adversarySlots[0].id
 
@@ -303,8 +305,8 @@ struct ConditionTests {
   }
 
   @Test func renameAdversary_selfNameAllowed() {
-    let session = makeSession()
-    let soldier = makeSoldier()
+    let session = makeTestSession()
+    let soldier = makeIronguardSoldier()
     session.add(adversary: soldier, customName: "Alpha")
     let id = session.adversarySlots[0].id
 
@@ -315,8 +317,8 @@ struct ConditionTests {
   }
 
   @Test func applyDamageReducesHP() {
-    let session = makeSession()
-    let soldier = makeSoldier()
+    let session = makeTestSession()
+    let soldier = makeIronguardSoldier()
     session.add(adversary: soldier)
 
     session.applyDamage(4, to: session.adversarySlots[0].id)
@@ -324,8 +326,8 @@ struct ConditionTests {
   }
 
   @Test func applyDamageToZeroMarksDefeated() {
-    let session = makeSession()
-    let soldier = makeSoldier()
+    let session = makeTestSession()
+    let soldier = makeIronguardSoldier()
     session.add(adversary: soldier)
 
     session.applyDamage(100, to: session.adversarySlots[0].id)
@@ -335,7 +337,7 @@ struct ConditionTests {
   }
 
   @Test func fearAndHopeMutations() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.incrementFear(by: 3)
     #expect(session.fearPool == 3)
 
@@ -351,8 +353,8 @@ struct ConditionTests {
   }
 
   @Test func isOverWhenAllDefeated() {
-    let session = makeSession()
-    let soldier = makeSoldier()
+    let session = makeTestSession()
+    let soldier = makeIronguardSoldier()
     session.add(adversary: soldier)
     #expect(session.isOver == false)
 
@@ -363,22 +365,22 @@ struct ConditionTests {
   // MARK: Adversary Conditions
 
   @Test func adversarySlotStartsWithNoConditions() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
+    let session = makeTestSession()
+    session.add(adversary: makeIronguardSoldier())
     #expect(session.adversarySlots[0].conditions.isEmpty)
   }
 
   @Test func applyConditionToAdversarySlot() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
+    let session = makeTestSession()
+    session.add(adversary: makeIronguardSoldier())
 
     session.applyCondition(.restrained, to: session.adversarySlots[0].id)
     #expect(session.adversarySlots[0].conditions.contains(.restrained))
   }
 
   @Test func removeConditionFromAdversarySlot() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
+    let session = makeTestSession()
+    session.add(adversary: makeIronguardSoldier())
 
     session.applyCondition(.hidden, to: session.adversarySlots[0].id)
     session.removeCondition(.hidden, from: session.adversarySlots[0].id)
@@ -386,8 +388,8 @@ struct ConditionTests {
   }
 
   @Test func conditionsDoNotStack() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
+    let session = makeTestSession()
+    session.add(adversary: makeIronguardSoldier())
 
     session.applyCondition(.vulnerable, to: session.adversarySlots[0].id)
     session.applyCondition(.vulnerable, to: session.adversarySlots[0].id)
@@ -395,24 +397,24 @@ struct ConditionTests {
   }
 
   @Test func emptyCustomConditionOnAdversaryIsRejected() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
+    let session = makeTestSession()
+    session.add(adversary: makeIronguardSoldier())
 
     session.applyCondition(.custom(""), to: session.adversarySlots[0].id)
     #expect(session.adversarySlots[0].conditions.isEmpty)
   }
 
   @Test func whitespaceCustomConditionOnAdversaryIsRejected() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
+    let session = makeTestSession()
+    session.add(adversary: makeIronguardSoldier())
 
     session.applyCondition(.custom("   "), to: session.adversarySlots[0].id)
     #expect(session.adversarySlots[0].conditions.isEmpty)
   }
 
   @Test func customConditionOnAdversarySlot() {
-    let session = makeSession()
-    session.add(adversary: makeSoldier())
+    let session = makeTestSession()
+    session.add(adversary: makeIronguardSoldier())
 
     session.applyCondition(.custom("Enraged"), to: session.adversarySlots[0].id)
     #expect(session.adversarySlots[0].conditions.contains(.custom("Enraged")))
@@ -459,29 +461,6 @@ struct PlayerStateTests {
 
 @MainActor struct PlayerStateSessionTests {
 
-  private func makeSession() -> EncounterSession {
-    EncounterSession(name: "Test Encounter")
-  }
-
-  private func makeSoldier() -> Adversary {
-    Adversary(
-      id: "ironguard-soldier",
-      name: "Ironguard Soldier",
-      tier: 1,
-      role: .bruiser,
-      flavorText: "A disciplined mercenary.",
-      difficulty: 11,
-      thresholdMajor: 5,
-      thresholdSevere: 10,
-      hp: 6,
-      stress: 3,
-      attackModifier: "+3",
-      attackName: "Longsword",
-      attackRange: .veryClose,
-      damage: "1d10+3 phy"
-    )
-  }
-
   private func makePlayer() -> PlayerState {
     PlayerState(
       name: "Aldric",
@@ -495,14 +474,14 @@ struct PlayerStateTests {
   }
 
   @Test func addPlayerSlotToSession() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
     #expect(session.playerSlots.count == 1)
     #expect(session.playerSlots[0].name == "Aldric")
   }
 
   @Test func applyDamageToPlayerSlot() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyDamage(2, to: session.playerSlots[0].id)
@@ -510,7 +489,7 @@ struct PlayerStateTests {
   }
 
   @Test func playerDamageClampsToZero() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyDamage(100, to: session.playerSlots[0].id)
@@ -518,7 +497,7 @@ struct PlayerStateTests {
   }
 
   @Test func applyStressToPlayerSlot() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyStress(3, to: session.playerSlots[0].id)
@@ -526,7 +505,7 @@ struct PlayerStateTests {
   }
 
   @Test func playerStressClampsToMax() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyStress(100, to: session.playerSlots[0].id)
@@ -534,7 +513,7 @@ struct PlayerStateTests {
   }
 
   @Test func healPlayerSlot() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyDamage(4, to: session.playerSlots[0].id)
@@ -543,7 +522,7 @@ struct PlayerStateTests {
   }
 
   @Test func healPlayerClampsToMax() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyDamage(2, to: session.playerSlots[0].id)
@@ -552,7 +531,7 @@ struct PlayerStateTests {
   }
 
   @Test func clearPlayerStress() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyStress(4, to: session.playerSlots[0].id)
@@ -561,7 +540,7 @@ struct PlayerStateTests {
   }
 
   @Test func markArmorSlotOnPlayer() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
     let slotID = session.playerSlots[0].id
 
@@ -570,7 +549,7 @@ struct PlayerStateTests {
   }
 
   @Test func markArmorSlotClampsToZero() {
-    let session = makeSession()
+    let session = makeTestSession()
     var player = makePlayer()
     player = PlayerState(
       name: player.name, maxHP: player.maxHP, maxStress: player.maxStress,
@@ -586,7 +565,7 @@ struct PlayerStateTests {
   }
 
   @Test func emptyCustomConditionOnPlayerIsRejected() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyCondition(.custom(""), to: session.playerSlots[0].id)
@@ -594,7 +573,7 @@ struct PlayerStateTests {
   }
 
   @Test func applyConditionToPlayerSlot() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyCondition(.vulnerable, to: session.playerSlots[0].id)
@@ -602,7 +581,7 @@ struct PlayerStateTests {
   }
 
   @Test func removeConditionFromPlayerSlot() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
 
     session.applyCondition(.hidden, to: session.playerSlots[0].id)
@@ -611,7 +590,7 @@ struct PlayerStateTests {
   }
 
   @Test func removePlayerFromSession() {
-    let session = makeSession()
+    let session = makeTestSession()
     session.add(player: makePlayer())
     let slotID = session.playerSlots[0].id
 

--- a/EncounterTests/PlayerConditionsTests.swift
+++ b/EncounterTests/PlayerConditionsTests.swift
@@ -8,7 +8,6 @@
 
 import DHKit
 import DHModels
-import Foundation
 import Testing
 
 @testable import Encounter
@@ -74,31 +73,6 @@ import Testing
     let (session, player) = makeSession()
     session.removeCondition(.restrained, from: player.id)
     #expect(session.playerSlots[0].conditions.isEmpty)
-  }
-
-  // MARK: - Strip row accessibility label
-
-  @Test func conditionNamesIncludedInAccessibilityLabelWhenActive() {
-    let (session, player) = makeSession()
-    session.applyCondition(.restrained, to: player.id)
-    let updated = session.playerSlots[0]
-    let label =
-      updated.conditions.isEmpty
-      ? updated.name
-      : updated.name + ", "
-        + updated.conditions.map(\.displayName).sorted().joined(separator: ", ")
-    #expect(label.contains("Restrained"))
-    #expect(label.contains("Aric"))
-  }
-
-  @Test func accessibilityLabelIsNameOnlyWhenNoConditions() {
-    let (_, player) = makeSession()
-    let label =
-      player.conditions.isEmpty
-      ? player.name
-      : player.name + ", "
-        + player.conditions.map(\.displayName).sorted().joined(separator: ", ")
-    #expect(label == "Aric")
   }
 
   // MARK: - Condition+UI: SF Symbol mapping

--- a/EncounterUITests/EncounterUITests.swift
+++ b/EncounterUITests/EncounterUITests.swift
@@ -2,39 +2,3 @@
 //  EncounterUITests.swift
 //  EncounterUITests
 //
-//
-
-import XCTest
-
-final class EncounterUITests: XCTestCase {
-
-  override func setUpWithError() throws {
-    // Put setup code here. This method is called before the invocation of each test method in the class.
-
-    // In UI tests it is usually best to stop immediately when a failure occurs.
-    continueAfterFailure = false
-
-    // In UI tests it’s important to set the initial state - such as interface orientation - required for your tests before they run. The setUp method is a good place to do this.
-  }
-
-  override func tearDownWithError() throws {
-    // Put teardown code here. This method is called after the invocation of each test method in the class.
-  }
-
-  @MainActor
-  func testExample() throws {
-    // UI tests must launch the application that they test.
-    let app = XCUIApplication()
-    app.launch()
-
-    // Use XCTAssert and related functions to verify your tests produce the correct results.
-  }
-
-  @MainActor
-  func testLaunchPerformance() throws {
-    // This measures how long it takes to launch your application.
-    measure(metrics: [XCTApplicationLaunchMetric()]) {
-      XCUIApplication().launch()
-    }
-  }
-}

--- a/EncounterUITests/ExplorationScreenshotTests.swift
+++ b/EncounterUITests/ExplorationScreenshotTests.swift
@@ -24,9 +24,9 @@ class ExplorationScreenshotTests: ExplorationUITestCase {
     screenshotScene(named: "runner-row")
   }
 
-  func testPlayerStripScene() throws {
-    navigate(to: "exploration.player-strip")
-    screenshotScene(named: "player-strip")
+  func testPlayerRunnerScene() throws {
+    navigate(to: "exploration.player-runner")
+    screenshotScene(named: "player-runner")
   }
 
   func testPipTrackScene() throws {
@@ -45,8 +45,8 @@ class ExplorationScreenshotTests: ExplorationUITestCase {
       app.buttons["exploration.runner-row"].waitForExistence(timeout: 3),
       "Runner row scene should be listed")
     XCTAssertTrue(
-      app.buttons["exploration.player-strip"].waitForExistence(timeout: 3),
-      "Player strip scene should be listed")
+      app.buttons["exploration.player-runner"].waitForExistence(timeout: 3),
+      "Player runner scene should be listed")
     screenshotScene(named: "exploration-root")
   }
 }


### PR DESCRIPTION
## Summary

- **`SourceBadgeView`** (new) — extracts the 5-modifier blue capsule badge chain duplicated identically in `AdversaryRow`, `EnvironmentRow`, `AdversaryDetailView`, `EnvironmentDetailView`
- **`ContentWriter`** — generic `readSourcePackFile<T: Decodable>` helper replaces 12 duplicated lines between `readAdversaries` / `readEnvironments`
- **`ResumePromptView`** — adversary count pluralization ternary repeated in two functions extracted to a private helper
- **`EncounterTests`** — file-private `makeTestSession` / `makeIronguardSoldier` factories replace byte-for-byte duplicate helpers across two test structs (~24 lines removed)
- **`AdversaryRunnerSection`** — IIFE `.accessibilityLabel` closure → `private func rowLabel(for:)`, matching `PlayerRunnerSection`
- **`AdversaryConditionsSection`** — accessibility pattern aligned with `PlayerConditionsSection`: `.accessibilityAddTraits` → `.accessibilityValue` + `.accessibilityHint`; missing `.padding(.horizontal, 4)` added
- **`AdversaryRunnerRow`** — hardcoded `8` in `.font(.system(size: 8))` → `@ScaledMetric(relativeTo: .caption2)`, matching `PlayerRunnerRow`; redundant `displayName` computed property removed
- **`AdversaryRunnerCard`** — redundant `displayName` computed property removed
- **`DifficultyAssessorView`** — unused `toggleBinding(for:)` private function deleted
- **Unused imports** removed from `LastFetchedLabel` and `TypeBadgeView`
- **`EncounterUITests`** — boilerplate `testExample` / `testLaunchPerformance` stubs removed
- **`PlayerConditionsTests`** — two fragile string-concatenation tests removed; coverage exists at ViewInspector level in `PlayerRunnerRowTests`
- **`ExplorationScreenshotTests`** — three stale `"exploration.player-strip"` scene IDs corrected to `"exploration.player-runner"` (these tests were silently failing)

Net: 18 files, −96 lines.

## Test plan

- [x] `xcodebuild test -scheme Encounter -destination 'platform=macOS'` — **TEST SUCCEEDED**