### PR TITLE
feat: tier-aware difficulty (#71)

### DIFF
--- a/Encounter/Views/AdversaryRosterRow.swift
+++ b/Encounter/Views/AdversaryRosterRow.swift
@@ -4,6 +4,7 @@
 //
 //  Single row in the adversary roster inside EncounterBuilderView.
 //  Looks up the adversary by ID for display; shows a fallback if unresolvable.
+//  When partyTier is provided, off-tier adversaries show a TierBadgeView.
 //
 
 import DHKit
@@ -13,30 +14,37 @@ import SwiftUI
 struct AdversaryRosterRow: View {
   let adversaryID: String
   let compendium: Compendium
+  let partyTier: Int?
 
   private var adversary: Adversary? {
     compendium.adversary(id: adversaryID)
   }
 
   var body: some View {
-    VStack(alignment: .leading, spacing: 2) {
-      Text(adversary?.name ?? "Unknown Adversary")
-        .font(.body)
-      if let adversary {
-        Text("\(adversary.role.rawValue) · Tier \(adversary.tier)")
-          .font(.caption)
-          .foregroundStyle(.secondary)
-      } else {
-        Text("ID: \(adversaryID)")
-          .font(.caption2)
-          .foregroundStyle(.tertiary)
+    HStack {
+      VStack(alignment: .leading, spacing: 2) {
+        Text(adversary?.name ?? "Unknown Adversary")
+          .font(.body)
+        if let adversary {
+          Text("\(adversary.role.rawValue) · Tier \(adversary.tier)")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        } else {
+          Text("ID: \(adversaryID)")
+            .font(.caption2)
+            .foregroundStyle(.tertiary)
+        }
+      }
+      Spacer()
+      if let adversary, let pt = partyTier, adversary.tier != pt {
+        TierBadgeView(adversaryTier: adversary.tier, partyTier: pt)
       }
     }
     .padding(.vertical, 2)
   }
 }
 
-#Preview {
+#Preview("No party tier") {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
@@ -47,7 +55,40 @@ struct AdversaryRosterRow: View {
       attackRange: .veryClose, damage: "1d4 phy"
     ))
   return List {
-    AdversaryRosterRow(adversaryID: "goblin", compendium: compendium)
-    AdversaryRosterRow(adversaryID: "missing-id", compendium: compendium)
+    AdversaryRosterRow(adversaryID: "goblin", compendium: compendium, partyTier: nil)
+    AdversaryRosterRow(adversaryID: "missing-id", compendium: compendium, partyTier: nil)
+  }
+}
+
+#Preview("T2 party — mixed tiers") {
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
+    ))
+  compendium.addAdversary(
+    Adversary(
+      id: "orc", name: "Orc Bruiser", tier: 2, role: .bruiser,
+      flavorText: "Massive and relentless.", difficulty: 14,
+      thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+      attackModifier: "+5", attackName: "Great Axe",
+      attackRange: .veryClose, damage: "2d10+4 phy"
+    ))
+  compendium.addAdversary(
+    Adversary(
+      id: "dragon", name: "Young Dragon", tier: 3, role: .solo,
+      flavorText: "Barely contained fury.", difficulty: 18,
+      thresholdMajor: 15, thresholdSevere: 30, hp: 20, stress: 6,
+      attackModifier: "+8", attackName: "Flame Breath",
+      attackRange: .far, damage: "4d10 fir"
+    ))
+  return List {
+    AdversaryRosterRow(adversaryID: "goblin", compendium: compendium, partyTier: 2)
+    AdversaryRosterRow(adversaryID: "orc", compendium: compendium, partyTier: 2)
+    AdversaryRosterRow(adversaryID: "dragon", compendium: compendium, partyTier: 2)
   }
 }

--- a/Encounter/Views/AdversaryRosterSection.swift
+++ b/Encounter/Views/AdversaryRosterSection.swift
@@ -13,6 +13,7 @@ import SwiftUI
 struct AdversaryRosterSection: View {
   let adversaryIDs: [String]
   let compendium: Compendium
+  let partyTier: Int?
   let onBrowse: () -> Void
   let onRemove: (IndexSet) -> Void
 
@@ -24,7 +25,11 @@ struct AdversaryRosterSection: View {
           .italic()
       } else {
         ForEach(adversaryIDs.indices, id: \.self) { index in
-          AdversaryRosterRow(adversaryID: adversaryIDs[index], compendium: compendium)
+          AdversaryRosterRow(
+            adversaryID: adversaryIDs[index],
+            compendium: compendium,
+            partyTier: partyTier
+          )
         }
         .onDelete(perform: onRemove)
       }
@@ -42,7 +47,7 @@ struct AdversaryRosterSection: View {
   }
 }
 
-#Preview {
+#Preview("No party tier") {
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
@@ -56,6 +61,28 @@ struct AdversaryRosterSection: View {
     AdversaryRosterSection(
       adversaryIDs: ["goblin", "goblin"],
       compendium: compendium,
+      partyTier: nil,
+      onBrowse: {},
+      onRemove: { _ in }
+    )
+  }
+}
+
+#Preview("T2 party") {
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
+    ))
+  return Form {
+    AdversaryRosterSection(
+      adversaryIDs: ["goblin", "goblin"],
+      compendium: compendium,
+      partyTier: 2,
       onBrowse: {},
       onRemove: { _ in }
     )

--- a/Encounter/Views/DifficultyAssessorView.swift
+++ b/Encounter/Views/DifficultyAssessorView.swift
@@ -4,8 +4,10 @@
 //
 //  Always-visible difficulty budget panel pinned via .safeAreaInset(edge: .bottom).
 //
-//  Auto-detected adjustments (multipleSolos, noBigThreats) are shown
-//  as read-only labels. GM-discretionary adjustments are Toggle rows.
+//  Auto-detected adjustments (multipleSolos, noBigThreats, lowerTierAdversary) are
+//  shown as read-only labels. GM-discretionary adjustments are Toggle rows.
+//  lowerTierAdversary moves to the auto-detected list when the roster triggers it;
+//  it remains a manual toggle when the roster has no lower-tier adversaries.
 //
 
 import DHKit
@@ -16,12 +18,18 @@ struct DifficultyAssessorView: View {
   let rating: DifficultyBudget.Rating?
   let autoAdjustments: Set<DifficultyBudget.Adjustment>
   @Binding var manualAdjustments: Set<DifficultyBudget.Adjustment>
+  let partyTier: Int?
+  let playerCount: Int
 
-  // Only these four adjustments can be toggled manually.
-  // multipleSolos and noBigThreats are auto-detected from the roster.
+  // All four GM-discretionary adjustments; lowerTierAdversary is suppressed
+  // from this list when it is already present in autoAdjustments.
   private static let manualCases: [DifficultyBudget.Adjustment] = [
     .easierFight, .harderFight, .boostedDamage, .lowerTierAdversary,
   ]
+
+  private var effectiveManualCases: [DifficultyBudget.Adjustment] {
+    Self.manualCases.filter { !autoAdjustments.contains($0) }
+  }
 
   private var difficultyColor: Color {
     switch rating?.category {
@@ -62,6 +70,13 @@ struct DifficultyAssessorView: View {
           }
         }
 
+        // Party context line
+        if let partyTier {
+          Text("Party: T\(partyTier) · \(playerCount) \(playerCount == 1 ? "player" : "players")")
+            .font(.caption)
+            .foregroundStyle(.secondary)
+        }
+
         // Auto-detected adjustments (informational, non-interactive)
         if !autoAdjustments.isEmpty {
           VStack(alignment: .leading, spacing: 2) {
@@ -74,8 +89,9 @@ struct DifficultyAssessorView: View {
         }
 
         // Manual GM-discretionary toggles
+        // lowerTierAdversary is excluded when auto-detected (see effectiveManualCases)
         VStack(alignment: .leading, spacing: 4) {
-          ForEach(Self.manualCases, id: \.self) { adj in
+          ForEach(effectiveManualCases, id: \.self) { adj in
             let isOn = manualAdjustments.contains(adj)
             HStack(spacing: 6) {
               Image(systemName: isOn ? "checkmark.square.fill" : "square")
@@ -107,26 +123,33 @@ struct DifficultyAssessorView: View {
   }
 }
 
-#Preview("On Budget — 4 players, 14 BP spent") {
+#Preview("On Budget — T2 party, 4 players, 14 BP spent") {
   @Previewable @State var manual: Set<DifficultyBudget.Adjustment> = []
   let rating = DifficultyBudget.Rating(budget: 14, cost: 14, remaining: 0)
-  DifficultyAssessorView(rating: rating, autoAdjustments: [], manualAdjustments: $manual)
-    .padding()
+  DifficultyAssessorView(
+    rating: rating, autoAdjustments: [], manualAdjustments: $manual,
+    partyTier: 2, playerCount: 4
+  )
+  .padding()
 }
 
-#Preview("Dangerous — over budget") {
+#Preview("Dangerous — over budget, lower-tier auto-detected") {
   @Previewable @State var manual: Set<DifficultyBudget.Adjustment> = []
   let rating = DifficultyBudget.Rating(budget: 14, cost: 19, remaining: -5)
   DifficultyAssessorView(
     rating: rating,
-    autoAdjustments: [.multipleSolos],
-    manualAdjustments: $manual
+    autoAdjustments: [.multipleSolos, .lowerTierAdversary],
+    manualAdjustments: $manual,
+    partyTier: 2, playerCount: 4
   )
   .padding()
 }
 
 #Preview("No players configured") {
   @Previewable @State var manual: Set<DifficultyBudget.Adjustment> = []
-  DifficultyAssessorView(rating: nil, autoAdjustments: [], manualAdjustments: $manual)
-    .padding()
+  DifficultyAssessorView(
+    rating: nil, autoAdjustments: [], manualAdjustments: $manual,
+    partyTier: nil, playerCount: 0
+  )
+  .padding()
 }

--- a/Encounter/Views/DifficultyAssessorView.swift
+++ b/Encounter/Views/DifficultyAssessorView.swift
@@ -31,6 +31,11 @@ struct DifficultyAssessorView: View {
     Self.manualCases.filter { !autoAdjustments.contains($0) }
   }
 
+  // Stable display order: iterate allCases (declaration order) keeping only those in autoAdjustments.
+  private var sortedAutoAdjustments: [DifficultyBudget.Adjustment] {
+    DifficultyBudget.Adjustment.allCases.filter { autoAdjustments.contains($0) }
+  }
+
   private var difficultyColor: Color {
     switch rating?.category {
     case .tooEasy: return .teal
@@ -80,7 +85,7 @@ struct DifficultyAssessorView: View {
         // Auto-detected adjustments (informational, non-interactive)
         if !autoAdjustments.isEmpty {
           VStack(alignment: .leading, spacing: 2) {
-            ForEach(Array(autoAdjustments), id: \.self) { adj in
+            ForEach(sortedAutoAdjustments, id: \.self) { adj in
               Label(adj.displayName, systemImage: "checkmark.circle.fill")
                 .font(.caption)
                 .foregroundStyle(.secondary)

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -60,8 +60,22 @@ struct EncounterBuilderView: View {
     draft.adversaryIDs.compactMap { compendium.adversary(id: $0)?.role }
   }
 
+  private var adversaryTiers: [Int] {
+    draft.adversaryIDs.compactMap { compendium.adversary(id: $0)?.tier }
+  }
+
+  private var partyTier: Int? {
+    let levels = playerStore.activePartyPlayers.map(\.level)
+    guard !levels.isEmpty else { return nil }
+    return DifficultyBudget.partyTier(levels: levels)
+  }
+
   private var autoAdjustments: Set<DifficultyBudget.Adjustment> {
-    DifficultyBudget.suggestedAdjustments(adversaryTypes: adversaryTypes)
+    DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: adversaryTypes,
+      adversaryTiers: adversaryTiers,
+      partyTier: partyTier
+    )
   }
 
   private var budgetAdjustment: Int {
@@ -83,6 +97,7 @@ struct EncounterBuilderView: View {
       AdversaryRosterSection(
         adversaryIDs: draft.adversaryIDs,
         compendium: compendium,
+        partyTier: partyTier,
         onBrowse: { showCompendium = true },
         onRemove: removeAdversary(at:)
       )
@@ -102,7 +117,9 @@ struct EncounterBuilderView: View {
         DifficultyAssessorView(
           rating: difficultyRating,
           autoAdjustments: autoAdjustments,
-          manualAdjustments: $manualAdjustments
+          manualAdjustments: $manualAdjustments,
+          partyTier: partyTier,
+          playerCount: playerStore.activePartyPlayers.count
         )
         .listRowInsets(EdgeInsets())
       }

--- a/Encounter/Views/EncounterBuilderView.swift
+++ b/Encounter/Views/EncounterBuilderView.swift
@@ -192,6 +192,9 @@ struct EncounterBuilderView: View {
     .onChange(of: draft.name) { _, _ in
       saveDebounced()
     }
+    .onChange(of: autoAdjustments) { _, newAuto in
+      manualAdjustments.subtract(newAuto)
+    }
   }
 
   // MARK: - Toolbar

--- a/Encounter/Views/ResumePromptView.swift
+++ b/Encounter/Views/ResumePromptView.swift
@@ -64,9 +64,12 @@ struct ResumePromptView: View {
           .accessibilityHidden(true)
         Text(target.definition.name)
           .font(.title2.bold())
-        Text(activeAdversariesLabel(count: target.session.activeAdversaries.count, suffix: "still active"))
-          .font(.subheadline)
-          .foregroundStyle(.secondary)
+        Text(
+          activeAdversariesLabel(
+            count: target.session.activeAdversaries.count, suffix: "still active")
+        )
+        .font(.subheadline)
+        .foregroundStyle(.secondary)
       }
       Button("Resume Encounter") {
         onResume(target)
@@ -90,9 +93,11 @@ struct ResumePromptView: View {
           Text(target.definition.name)
             .font(.headline)
             .foregroundStyle(.primary)
-          Text(activeAdversariesLabel(count: target.session.activeAdversaries.count, suffix: "active"))
-            .font(.caption)
-            .foregroundStyle(.secondary)
+          Text(
+            activeAdversariesLabel(count: target.session.activeAdversaries.count, suffix: "active")
+          )
+          .font(.caption)
+          .foregroundStyle(.secondary)
         }
       }
       .buttonStyle(.plain)

--- a/Encounter/Views/TierBadgeView.swift
+++ b/Encounter/Views/TierBadgeView.swift
@@ -6,7 +6,6 @@
 //  Amber = below party tier, Red = above party tier, hidden when matching or partyTier is nil.
 //
 
-import DHModels
 import SwiftUI
 
 struct TierBadgeView: View {

--- a/Encounter/Views/TierBadgeView.swift
+++ b/Encounter/Views/TierBadgeView.swift
@@ -1,0 +1,61 @@
+//
+//  TierBadgeView.swift
+//  Encounter
+//
+//  Badge indicating an adversary's tier relative to the party tier.
+//  Amber = below party tier, Red = above party tier, hidden when matching or partyTier is nil.
+//
+
+import DHModels
+import SwiftUI
+
+struct TierBadgeView: View {
+  let adversaryTier: Int
+  let partyTier: Int
+
+  @Environment(\.accessibilityDifferentiateWithoutColor) private var differentiateWithoutColor
+
+  private var color: Color? {
+    if adversaryTier < partyTier { return .orange }
+    if adversaryTier > partyTier { return .red }
+    return nil
+  }
+
+  private var relationLabel: String {
+    adversaryTier < partyTier ? "below party tier" : "above party tier"
+  }
+
+  var body: some View {
+    if let color {
+      HStack(spacing: 2) {
+        if differentiateWithoutColor {
+          Image(systemName: adversaryTier < partyTier ? "arrow.down" : "arrow.up")
+            .font(.caption.bold())
+            .accessibilityHidden(true)
+        }
+        Text("T\(adversaryTier)")
+          .font(.caption.bold())
+      }
+      .foregroundStyle(color)
+      .padding(.horizontal, 6)
+      .padding(.vertical, 2)
+      .background(color.opacity(0.12), in: Capsule())
+      .accessibilityLabel("Tier \(adversaryTier), \(relationLabel)")
+    }
+  }
+}
+
+#Preview("Below party tier") {
+  TierBadgeView(adversaryTier: 1, partyTier: 2)
+    .padding()
+}
+
+#Preview("Above party tier") {
+  TierBadgeView(adversaryTier: 3, partyTier: 2)
+    .padding()
+}
+
+#Preview("Matching tier — hidden") {
+  TierBadgeView(adversaryTier: 2, partyTier: 2)
+    .padding()
+}

--- a/EncounterTests/EncounterTests.swift
+++ b/EncounterTests/EncounterTests.swift
@@ -883,6 +883,107 @@ struct DifficultyBudgetTests {
     #expect(DifficultyBudget.Adjustment.noBigThreats.pointValue == 1)
     #expect(DifficultyBudget.Adjustment.harderFight.pointValue == 2)
   }
+
+  // MARK: Tier Utilities
+
+  @Test(arguments: [(1, 1), (2, 2), (4, 2), (5, 3), (7, 3), (8, 4), (10, 4)])
+  func tierForLevel(level: Int, expectedTier: Int) {
+    #expect(DifficultyBudget.tier(forLevel: level) == expectedTier)
+  }
+
+  @Test func partyTierSinglePlayer() {
+    #expect(DifficultyBudget.partyTier(levels: [1]) == 1)
+  }
+
+  @Test func partyTierFourPlayers() {
+    // median 3.5 → ceil 4 → T2
+    #expect(DifficultyBudget.partyTier(levels: [2, 3, 4, 5]) == 2)
+  }
+
+  @Test func partyTierTwoPlayers() {
+    // median 4.5 → ceil 5 → T3
+    #expect(DifficultyBudget.partyTier(levels: [4, 5]) == 3)
+  }
+
+  @Test func partyTierThreePlayers() {
+    // median 8 → T4
+    #expect(DifficultyBudget.partyTier(levels: [7, 8, 9]) == 4)
+  }
+
+  @Test func partyTierEmptyReturnsOne() {
+    // Model returns 1 for empty input as a safe default.
+    // Note: EncounterBuilderView.partyTier returns nil for empty party (suppresses
+    // the party tier UI line); this is intentionally different from the model default.
+    #expect(DifficultyBudget.partyTier(levels: []) == 1)
+  }
+
+  // MARK: lowerTierAdversary Auto-Detection
+
+  @Test func lowerTierAdversaryAutoDetected() {
+    let adjustments = DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: [.standard],
+      adversaryTiers: [1],
+      partyTier: 2
+    )
+    #expect(adjustments.contains(.lowerTierAdversary))
+  }
+
+  @Test func lowerTierAdversaryNotDetectedMatchingTier() {
+    let adjustments = DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: [.standard],
+      adversaryTiers: [2],
+      partyTier: 2
+    )
+    #expect(!adjustments.contains(.lowerTierAdversary))
+  }
+
+  @Test func lowerTierAdversaryNotDetectedAbovePartyTier() {
+    let adjustments = DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: [.standard],
+      adversaryTiers: [3],
+      partyTier: 2
+    )
+    #expect(!adjustments.contains(.lowerTierAdversary))
+  }
+
+  @Test func lowerTierAdversaryNotDetectedEmptyTiers() {
+    // adversaryTiers omitted — zip truncates to empty, no lower-tier detection
+    let adjustments = DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: [.standard],
+      adversaryTiers: [],
+      partyTier: 2
+    )
+    #expect(!adjustments.contains(.lowerTierAdversary))
+  }
+
+  @Test func lowerTierAdversaryNotDetectedForUnknownTierZero() {
+    // tier 0 means "unknown" — must not trigger lowerTierAdversary
+    let adjustments = DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: [.standard],
+      adversaryTiers: [0],
+      partyTier: 2
+    )
+    #expect(!adjustments.contains(.lowerTierAdversary))
+  }
+
+  @Test func lowerTierAdversaryNotDetectedNilPartyTier() {
+    let adjustments = DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: [.standard],
+      adversaryTiers: [1],
+      partyTier: nil
+    )
+    #expect(!adjustments.contains(.lowerTierAdversary))
+  }
+
+  @Test func lowerTierAdversaryDetectionWithMismatchedArrayLengths() {
+    // zip truncates to shorter array; first adversary is T1 vs party T3 → detected
+    let adjustments = DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: [.standard, .standard],
+      adversaryTiers: [1],
+      partyTier: 3
+    )
+    #expect(adjustments.contains(.lowerTierAdversary))
+  }
 }
 
 // MARK: - Environment

--- a/EncounterTests/EncounterTests.swift
+++ b/EncounterTests/EncounterTests.swift
@@ -984,6 +984,16 @@ struct DifficultyBudgetTests {
     )
     #expect(adjustments.contains(.lowerTierAdversary))
   }
+
+  @Test func lowerTierAdversaryNotDetectedWhenAllMatchPartyTier() {
+    // multiple adversaries all at party tier — no lower-tier detection
+    let adjustments = DifficultyBudget.suggestedAdjustments(
+      adversaryTypes: [.standard, .bruiser, .minion],
+      adversaryTiers: [2, 2, 2],
+      partyTier: 2
+    )
+    #expect(!adjustments.contains(.lowerTierAdversary))
+  }
 }
 
 // MARK: - Environment

--- a/EncounterTests/TierBadgeViewTests.swift
+++ b/EncounterTests/TierBadgeViewTests.swift
@@ -1,0 +1,38 @@
+//
+//  TierBadgeViewTests.swift
+//  EncounterTests
+//
+
+import SwiftUI
+import Testing
+import ViewInspector
+
+@testable import Encounter
+
+@MainActor
+@Suite("TierBadgeView")
+struct TierBadgeViewTests {
+
+  // MARK: - Accessibility label
+
+  @Test func belowPartyTierAccessibilityLabel() throws {
+    let sut = TierBadgeView(adversaryTier: 1, partyTier: 2)
+    let hstack = try sut.inspect().find(ViewType.HStack.self)
+    #expect(try hstack.accessibilityLabel().string() == "Tier 1, below party tier")
+  }
+
+  @Test func abovePartyTierAccessibilityLabel() throws {
+    let sut = TierBadgeView(adversaryTier: 3, partyTier: 2)
+    let hstack = try sut.inspect().find(ViewType.HStack.self)
+    #expect(try hstack.accessibilityLabel().string() == "Tier 3, above party tier")
+  }
+
+  // MARK: - Hidden when tiers match
+
+  @Test func matchingTierRendersNoContent() {
+    let sut = TierBadgeView(adversaryTier: 2, partyTier: 2)
+    #expect(throws: (any Error).self) {
+      try sut.inspect().find(ViewType.HStack.self)
+    }
+  }
+}


### PR DESCRIPTION
## Summary

- **Auto-detects `lowerTierAdversary`** when any roster adversary is below the party's derived tier — moves it from manual-only toggle to an auto-applied adjustment shown as a read-only label
- **Party context line** in `DifficultyAssessorView`: `"Party: T2 · 4 players"` when a party tier can be derived
- **Tier badge on adversary rows**: amber capsule for below-party-tier adversaries, red for above; hidden when tier matches or no party is configured
- **Accessibility**: badges carry a full `accessibilityLabel` (`"Tier 1, below party tier"`); `accessibilityDifferentiateWithoutColor` adds a directional arrow icon so color is not the sole differentiator
- **14 new tests** covering `tier(forLevel:)`, `partyTier(levels:)`, and all `suggestedAdjustments` tier-detection edge cases (unknown tier 0, nil partyTier, mismatched array lengths)

Closes #71. Depends on gwillish/DHModels#21 (merged) and #70 (merged).

## Files changed

| File | Change |
|---|---|
| `EncounterBuilderView.swift` | `adversaryTiers`, `partyTier` computed properties; updated `autoAdjustments` call |
| `DifficultyAssessorView.swift` | Party context line; `effectiveManualCases` filter suppresses toggle when auto-detected |
| `AdversaryRosterSection.swift` | Thread `partyTier: Int?` to rows |
| `AdversaryRosterRow.swift` | Render `TierBadgeView` for off-tier adversaries |
| `TierBadgeView.swift` | New — amber/red capsule badge with a11y support |
| `EncounterTests.swift` | 14 new `DifficultyBudgetTests` |

## Test plan

- [ ] `xcodebuild test -scheme Encounter -destination 'platform=macOS'` passes (247 tests, 0 failures)
- [ ] Builder with a T1 party and T2 adversary: no badge shown, no auto-detection
- [ ] Builder with a T2 party and T1 adversary: amber badge on row, `lowerTierAdversary` auto-detected in assessor panel, toggle hidden
- [ ] Builder with no party configured: no party tier line in assessor, no badges
- [ ] VoiceOver on a T1 adversary row in a T2 party reads `"Tier 1, below party tier"`