### PR TITLE
docs: UX redesign planning — ADRs 0043-0047, ux-requirements, redesign-plan

### DIFF
--- a/docs/decisions/0019-macos-split-view-ios-stack.md
+++ b/docs/decisions/0019-macos-split-view-ios-stack.md
@@ -1,6 +1,6 @@
 # ADR-0019: macOS NavigationSplitView, iOS NavigationStack
 
-**Status:** Accepted
+**Status:** Superseded by [ADR-0043](0043-platform-navigation-architecture.md)
 **Date:** 2026-03-17
 
 ## Context

--- a/docs/decisions/0040-encounters-first-navigation.md
+++ b/docs/decisions/0040-encounters-first-navigation.md
@@ -1,6 +1,6 @@
 # ADR-0040: Encounters as the default landing screen
 
-**Status:** Accepted
+**Status:** Superseded by [ADR-0043](0043-platform-navigation-architecture.md)
 **Date:** 2026-04-25
 
 ## Context

--- a/docs/decisions/0043-platform-navigation-architecture.md
+++ b/docs/decisions/0043-platform-navigation-architecture.md
@@ -1,0 +1,82 @@
+# ADR-0043: Platform-Specific Navigation Architecture
+
+**Status:** Accepted
+**Date:** 2026-05-03
+
+## Context
+
+This supersedes [ADR-0019](0019-macos-split-view-ios-stack.md) and [ADR-0040](0040-encounters-first-navigation.md).
+
+ADR-0019 established a macOS `NavigationSplitView` / iOS `NavigationStack` split, with the macOS sidebar containing two independent items (Encounters, Party). ADR-0040 made Encounters the default landing destination. Hands-on use exposed three problems:
+
+1. **Mode conflation.** Encounters, party management, compendium browsing, and live running are distinct activities with different information densities. Serving them through a shared sidebar navigation forced constant context-switching rather than mode-switching.
+2. **iPad not considered.** ADR-0019 treated iPadOS as equivalent to iOS, placing it on the `NavigationStack` path. A split-view design is better suited to iPadOS's larger canvas and supports a more capable prep workflow.
+3. **No first-class run mode.** The encounter runner was a sheet on macOS and a `fullScreenCover` on iOS — both modal overlays. The transition did not communicate the weight of "switching from prep to running a live encounter."
+
+## Decision
+
+Three distinct navigation architectures, one per platform family:
+
+### iOS — `NavigationStack` with toolbar mode toggle
+
+The root screen is a single view containing an encounter list (top) and the party roster (below). A **segmented toolbar control** (Encounters | Compendium) switches the entire root content:
+
+- **Encounters mode:** encounter list + party roster; tapping an encounter pushes to `EncounterEditorView`; from the editor, tapping Run pushes to `EncounterRunnerView`. Both are standard push transitions on the same stack.
+- **Compendium mode:** full-screen adversary list with search/filter; create custom adversary, import DHPack, export local collection.
+
+```
+NavigationStack
+  ├── Root (toggle: Encounters | Compendium)
+  │     ├── Encounters: encounter list + party
+  │     └── Compendium: adversary list
+  └── navigationDestination:
+        EncounterDefinition → EncounterEditorView
+          └── EncounterSession → EncounterRunnerView
+```
+
+The launch-time `ResumePromptView` sheet is retired. Paused sessions are visible inline as "In Progress" badges on the encounter row — no separate modal needed.
+
+### iPadOS — `NavigationSplitView` with segmented toolbar mode switch
+
+A `NavigationSplitView` with `columnVisibility` driven by `AppWindowMode`. Three modes:
+
+| Mode | Left (sidebar) | Center | Right (detail) |
+|---|---|---|---|
+| Encounter Prep (default) | Encounter list + Party roster | Encounter editor | Compendium utility panel |
+| Compendium Management | Adversary list (grouped) | — hidden — | Adversary inspector/editor |
+| Running Encounter | Runner rows (adversaries + players) + Pause/End | — hidden — | Selected adversary detail |
+
+Column visibility: `encounterPrep` → `.all` (3 columns); other modes → `.doubleColumn` (sidebar + detail only).
+
+Mode switch: **segmented toolbar control** (`Picker` in toolbar, Encounters | Compendium). Run mode is entered by tapping the Run button in `EncounterEditorView`; it sets `AppWindowMode = .runningEncounter(session)` on `ContentView`.
+
+### macOS — `NavigationSplitView` with menu-driven mode switch
+
+Identical three-mode column structure as iPadOS. Mode switch: **menu command** (`View → Encounters`, `View → Compendium`). Run mode is entered and exited the same way as iPadOS (mode state on ContentView).
+
+## `AppWindowMode` (macOS + iPadOS)
+
+```swift
+enum AppWindowMode {
+    case encounterPrep
+    case compendiumManagement
+    case runningEncounter(EncounterSession)
+}
+```
+
+`ContentView` owns `@State var windowMode: AppWindowMode = .encounterPrep` on the macOS/iPadOS branch. The mode propagates to child views via explicit `init` parameters (ADR-0041).
+
+## Options Considered
+
+- **Three separate navigation roots (rejected):** Clean separation but duplicates structural logic and makes cross-mode state management (e.g. which encounter is selected) harder to coordinate.
+- **TabView for all platforms (rejected):** Works for iOS but tab bars on macOS are not idiomatic; tabs do not express the encounter → compendium → run hierarchy.
+- **Sheet/fullScreenCover for run mode (prior approach, rejected):** Modal presentations communicate "temporary overlay." Running a live encounter is a first-class mode, not a temporary digression. Mode-swap better communicates the transition.
+
+## Consequences
+
+- `ContentView` is nearly fully rewritten. The macOS/iPadOS branch uses `AppWindowMode`; the iOS branch uses `iOSRootMode` (`.encounters` / `.compendium`).
+- The `TabView` structure on iOS is eliminated. `PartyOverviewView` is no longer a tab root; party management moves into the combined root view.
+- `ResumePromptView` and `ResumeTarget` are retired.
+- The six-variable resume state machine in `ContentView` is replaced by reading `SessionRegistry` for paused sessions and displaying in-progress state inline.
+- Shared panel components (`EncounterAndPartyPanel`, `CompendiumUtilityPanel`, `CompendiumAdversaryListPanel`, `AdversaryInspectorView`, `RunnerListPanel`, `RunnerDetailPanel`) are new; they are reused across macOS and iPadOS.
+- iOS-specific root views (`EncounterAndPartyRootView`, `CompendiumRootView`) are separate files.

--- a/docs/decisions/0044-encounter-session-lifecycle.md
+++ b/docs/decisions/0044-encounter-session-lifecycle.md
@@ -1,0 +1,78 @@
+# ADR-0044: Encounter Session Lifecycle (Running / Paused)
+
+**Status:** Accepted
+**Date:** 2026-05-03
+
+## Context
+
+Prior to this decision, `EncounterSession` had no explicit lifecycle state. A session was implicitly "active" when present in `SessionRegistry` and not `.isOver`. Pausing did not exist as an operation — the GM could background the app and the session would persist on disk via `SessionStore`, but there was no explicit "pause" affordance in the UI.
+
+This created two problems:
+
+1. **No in-progress signal in the encounter list.** The encounter library row had no way to indicate a session was waiting to be resumed short of the launch-time `ResumePromptView` sheet, which only appeared at startup.
+2. **Resume flow was a modal launch-time interruption.** The six-variable state machine in `ContentView` drove a sheet that appeared once at launch and was gone. If the GM dismissed it accidentally, recovery required navigating manually.
+
+## Decision
+
+Add a `SessionPhase` enum and `phase` property to `EncounterSession` in DHKit:
+
+```swift
+public enum SessionPhase: String, Codable, Sendable {
+    case running
+    case paused
+}
+
+// On EncounterSession:
+public var phase: SessionPhase = .running
+```
+
+Add two methods:
+
+```swift
+public func pause() { phase = .paused }
+public func resume() { phase = .running }
+```
+
+`SessionStore` persists and restores `phase` as part of the session JSON. No migration needed for existing sessions on disk — they decode without a `phase` field and default to `.running` (which is the correct assumption: if a session was saved without a phase, it was interrupted while running).
+
+### Lifecycle transitions
+
+```
+(session created) → .running
+  ├── user taps Pause → .paused → saved to SessionStore → returns to encounter list
+  │     ├── user taps Resume → .running → re-enters run mode
+  │     └── user taps End (from paused) → session deleted from SessionStore + SessionRegistry
+  └── user taps End Encounter (while running) → session deleted
+```
+
+### In-progress badge
+
+`EncounterLibraryRow` receives `isPaused: Bool` from its parent. When `true`, the row shows an "In Progress" capsule badge and the run-affordance label changes to "Resume". This replaces the launch-time `ResumePromptView`.
+
+Derivation in the parent (list or panel):
+
+```swift
+let pausedDefinitionIDs: Set<EncounterDefinition.ID> = Set(
+    sessionRegistry.sessions.values
+        .filter { $0.phase == .paused }
+        .compactMap { $0.definitionID }
+)
+```
+
+### Retirement of `ResumePromptView`
+
+The launch-time sheet (`ResumePromptView`, `ResumeTarget`, `ResumeSheetPayload`) is retired. Paused sessions are always visible inline. The six-state-variable resume logic in `ContentView` is removed.
+
+## Options Considered
+
+- **Keep implicit state, improve launch-time sheet (rejected).** Would still require the complex modal coordination and fails to provide a persistent in-progress signal once the sheet is dismissed.
+- **Add `.ended` phase (considered, deferred).** An `.ended` phase could represent sessions that completed combat (all adversaries defeated) vs. sessions that were manually stopped. This is useful for future session history or analytics. Deferred — the current `isOver` computed property (`currentHP <= 0` for all adversaries) already captures the defeated state. A formal `.ended` case can be added without breaking the current decision.
+- **Phase on `SessionRegistry` only, not on the model (rejected).** Moving the phase into the app-layer `SessionRegistry` would lose the information on the next app launch when the registry is rebuilt from `SessionStore`. It must live on the persisted model.
+
+## Consequences
+
+- DHKit package (`gwillish/DHModels`) requires a PR adding `SessionPhase`, `phase`, `pause()`, and `resume()` to `EncounterSession`.
+- `SessionStore` in the app encodes/decodes `phase`; existing sessions on disk without a `phase` field default gracefully to `.running`.
+- `EncounterLibraryRow` gains an `isPaused: Bool` parameter.
+- `EncounterRunnerView` gains a Pause toolbar button that calls `session.pause()`, invokes `SessionStore.save(_:)`, and pops the navigation stack (iOS) or sets `windowMode = .encounterPrep` (macOS/iPadOS).
+- `ResumePromptView.swift` and `ResumeTarget.swift` are deleted once all reference sites are removed.

--- a/docs/decisions/0045-compendium-management-mode.md
+++ b/docs/decisions/0045-compendium-management-mode.md
@@ -1,0 +1,79 @@
+# ADR-0045: Compendium Management Mode
+
+**Status:** Accepted
+**Date:** 2026-05-03
+
+## Context
+
+This changes the status of [ADR-0025](0025-adversary-creator-difficulty-meter-deferred.md) from deferred to active: adversary creation and compendium management are now in scope.
+
+Previously the compendium was only accessible as a modal sheet (`CompendiumBrowserView`) opened from the encounter builder. This made it purely instrumental — a way to select adversaries for an encounter — with no path to browse, create, or manage content independently. Three capabilities had no home:
+
+1. Creating custom (local) adversaries
+2. Importing `.dhpack` files to expand the compendium
+3. Exporting a local adversary collection as a `.dhpack` for sharing
+
+## Decision
+
+The compendium is a first-class **mode**, not a sheet. Its implementation differs by platform:
+
+### macOS / iPadOS — 2-panel split
+
+When `AppWindowMode == .compendiumManagement`, `ContentView` collapses to 2 columns (`columnVisibility = .doubleColumn`):
+
+- **Left panel (`CompendiumAdversaryListPanel`):** grouped adversary list — SRD section (read-only), one section per loaded DHPack (read-only), Local section (editable). `AdversaryFilterBar` at top filters across all groups. Toolbar actions: Add Adversary, Import DHPack, Export Local.
+- **Right panel (`AdversaryInspectorView`):** for SRD and DHPack adversaries, shows the read-only stat card (same content as `AdversaryDetailView`). For local custom adversaries, adds an Edit button that opens `AdversaryCreatorForm` in edit mode. Empty state when nothing is selected.
+
+macOS mode switch: `View → Compendium` / `View → Encounters` menu commands.
+iPadOS mode switch: segmented toolbar control.
+
+### iOS — full-screen list
+
+The root toolbar toggle (Encounters | Compendium) switches the entire root content. In Compendium mode, `CompendiumRootView` fills the screen:
+
+- Adversary list with `AdversaryFilterBar` at top
+- Grouped sections: SRD | [DHPack name] per loaded pack | Local
+- Toolbar: Import DHPack, Export Local, Add Adversary
+- Tapping an adversary row pushes to `AdversaryDetailView`; local adversaries get an Edit button there
+
+### DHPack semantics
+
+**DHPacks are import/export bundles only — they are not editable in place.** A loaded DHPack contributes its adversaries to the compendium as a read-only group. The only operations on a loaded pack are remove (unload from compendium) and refresh (re-fetch if from a remote URL).
+
+The export flow (`DHPackExportSheet`) assembles a new `.dhpack` file from a multi-select of local adversaries and presents it via the system share sheet. The resulting file has no connection to previously loaded packs.
+
+### Custom adversary creation (`AdversaryCreatorForm`)
+
+Multi-step form per the ADR-0025 draft (now implemented):
+
+1. **Identity** — name, adversary type, tier; shows 2-3 SRD peers for reference
+2. **Stats** — HP, Stress, Difficulty, Thresholds, Evasion; inline soft range indicators (within range / above average / outlier) based on SRD peers; guidance only, never blocks save
+3. **Attack & Features** — attack name, modifier, range, damage string; feature list (add passive/action/reaction)
+4. **Review** — full stat card preview; soft out-of-range summary; Save
+
+Local adversaries are stored in the `homebrew/` subdirectory of the content directory (already provisioned by `ContentWriter`). `ContentStore` gains `saveLocalAdversary(_:)` and `deleteLocalAdversary(id:)` methods.
+
+### `AdversaryFilterBar` (shared component)
+
+Stateless view accepting bindings: `searchText: Binding<String>`, `selectedTier: Binding<Int?>`, `selectedType: Binding<AdversaryType?>`. Used by:
+- `CompendiumAdversaryListPanel` (macOS/iPadOS)
+- `CompendiumRootView` (iOS)
+- `CompendiumSelectorSheet` (encounter editor selection context)
+
+### `CompendiumSelectorSheet` (encounter editor context)
+
+The modal used when adding adversaries to an encounter. Distinct from the compendium management views — it is selection-only (no create, no export). An "Import DHPack" button is included so GMs can load new content mid-prep without leaving the context. Replaces `CompendiumBrowserView` as the encounter-editor selection entry point.
+
+## Options Considered
+
+- **Expand `CompendiumBrowserView` sheet to include management (rejected).** A sheet constrained by the builder context would be awkward for a management workflow and wouldn't work at all for the macOS/iPadOS always-visible utility panel.
+- **Separate app section / tab for compendium (rejected).** Adding a third tab or sidebar item for compendium management returns to the navigation-list model that ADR-0043 replaces. Mode switching is cleaner.
+- **Edit DHPacks in place (rejected).** A DHPack is a portable file format shared between tools. Editing it would create confusion about provenance and break the open/portable intent (Principle 7). Adversaries to be edited must be detached from their pack and saved locally.
+
+## Consequences
+
+- `CompendiumBrowserView` is retired as the selection entry point; `CompendiumSelectorSheet` replaces it. `CompendiumBrowserView` may be kept for the standalone browse-without-select path or merged into the management views.
+- Four new view files: `CompendiumAdversaryListPanel`, `AdversaryInspectorView`, `CompendiumRootView`, `AdversaryCreatorForm`, `DHPackExportSheet`.
+- `ContentStore` gains `saveLocalAdversary(_:)`, `deleteLocalAdversary(id:)`, and `exportPack(adversaryIDs:) async -> URL`.
+- `AdversaryCreatorForm` is opened as a `.sheet` on all platforms. On macOS/iPadOS it can also be opened inline in the detail column when editing an existing local adversary.
+- The soft power-validation range indicators (ADR-0025 open question) are derived from the same `DifficultyBudget` pure functions already in place; the stats step queries the compendium for SRD peers of the selected type/tier.

--- a/docs/decisions/0046-single-party-hidden-members.md
+++ b/docs/decisions/0046-single-party-hidden-members.md
@@ -1,0 +1,63 @@
+# ADR-0046: Single Party with Hidden Member Flag
+
+**Status:** Accepted
+**Date:** 2026-05-03
+
+## Context
+
+The app has always maintained a single active party (a `Party` value with a `playerIDs: [UUID]` array in `PlayerStore`). There was no documented decision explicitly adopting single-party and rejecting multi-party. Additionally, the only way to exclude a player from active encounters was to remove them from the party entirely — which meant re-entering all their stats when they returned.
+
+Common table situations that needed a solution:
+- A player misses a session; their character should not appear in the encounter runner but must remain in the roster for next session.
+- A player temporarily leaves the table mid-campaign; their character is not deleted, just absent.
+
+## Decision
+
+**The app supports exactly one party roster. No multi-party switching.**
+
+A player can be **hidden** — excluded from active encounter sessions — without being deleted from the roster. Hidden state is a global roster flag: once hidden, the player is excluded from all encounters until explicitly un-hidden.
+
+### Implementation
+
+`PlayerStore` gains `hiddenPlayerIDs: Set<UUID>` as a persisted property (stored in `<directory>/hidden-players.json`). The computed property `activePartyPlayers` filters hidden IDs:
+
+```swift
+public var activePartyPlayers: [Player] {
+    party.playerIDs
+        .filter { !hiddenPlayerIDs.contains($0) }
+        .compactMap { id in players.first { $0.id == id } }
+}
+```
+
+New methods:
+```swift
+public func hidePlayer(id: UUID) async
+public func showPlayer(id: UUID) async
+```
+
+`hidePlayer` adds to `hiddenPlayerIDs` and saves. `showPlayer` removes from `hiddenPlayerIDs` and saves. Deleting a player also removes them from `hiddenPlayerIDs`.
+
+This avoids modifying the DHKit `Player` type while keeping the feature fully at the app layer.
+
+### UI affordances
+
+Hidden players are shown in the party list with a distinct visual style (grayed, `eye.slash` icon) and an Un-hide button. They are always visible in the roster so their existence is not surprising when they reappear. The count of active (non-hidden) party members is what flows into encounter difficulty calculations.
+
+### Why not per-encounter exclusion
+
+Per-encounter exclusion would require each `EncounterDefinition` to store a set of excluded player IDs. This complicates the builder, the difficulty assessor (which player count applies?), and the session factory. The primary use case is a player being absent from a campaign arc — a roster-level signal, not an encounter-level one.
+
+## Options Considered
+
+- **Multi-party support (rejected).** Multiple named parties adds selection UI to every encounter workflow. The party is not a variable in a single-campaign GM tool — it is a stable configuration. If a GM runs multiple campaigns, they use separate app instances or separate encounter stores.
+- **Delete and re-add player (prior approach, replaced).** Deleting a player loses all their stat data and history. Re-entry is friction that discourages accuracy.
+- **Per-encounter excluded players (rejected).** See above. Roster-level flag matches the real-world signal (player is absent this session / this arc) better than an encounter-level flag.
+- **`isHidden` on `Player` in DHKit (considered, rejected).** Adding UI/roster state to the DHKit `Player` type mixes UI concern into the catalog model. The DHKit `Player` should remain a pure data type. `hiddenPlayerIDs` as an app-layer set is the correct separation.
+
+## Consequences
+
+- `PlayerStore` gains `hiddenPlayerIDs`, `hidePlayer(id:)`, `showPlayer(id:)`.
+- `PlayerStore.activePartyPlayers` excludes hidden players.
+- `EncounterAndPartyRootView` (iOS) and `EncounterAndPartyPanel` (macOS/iPadOS) both display hidden players with a distinct style and unhide affordance.
+- `DifficultyAssessorView` already consumes `activePartyPlayers` for party-tier calculations — no change needed there.
+- The concept of "Active Party" vs "Roster" in the existing party management UI simplifies: all players in `party.playerIDs` are the party; hidden/shown is the only sub-state. The `removeFromParty` / `addToParty` distinction used in `PartyOverviewView` is retired in favour of the single-party model.

--- a/docs/decisions/0047-macos-ipados-toolbar-menu-keyboard.md
+++ b/docs/decisions/0047-macos-ipados-toolbar-menu-keyboard.md
@@ -1,0 +1,208 @@
+# ADR-0047: macOS/iPadOS Toolbar, Menu Structure, Inspector, and Keyboard Model
+
+**Status:** Accepted
+**Date:** 2026-05-03
+
+## Context
+
+ADR-0043 established the three-mode `NavigationSplitView` architecture for macOS and iPadOS but did not specify:
+
+- What items appear in the window toolbar and in which order
+- The full macOS menu structure
+- Whether the right panel is a toggleable inspector or always-visible
+- Keyboard shortcuts for the primary workflows
+- Drag and drop between the compendium utility panel and the encounter editor
+- Sidebar bottom bar placement for management actions
+
+A review against Mario Guzmán's Mac Platform Design Guidelines (marioaguzman.github.io/design/) identified these as critical gaps for a native-feeling macOS app.
+
+## Decisions
+
+### 1. Right panel as a toggleable inspector
+
+The right panel (`CompendiumUtilityPanel`, `AdversaryInspectorView`, `RunnerDetailPanel`) is implemented as an AppKit/SwiftUI inspector using `.inspectorTrackingSeparator` and `.toggleInspector`. It is hideable/showable by the user.
+
+**Default visibility per mode:**
+- `.encounterPrep` — **open** (the compendium utility panel is the point of the right column in prep mode)
+- `.compendiumManagement` — **open** (adversary inspector is central to that mode)
+- `.runningEncounter` — **hidden** (runner list gets full width by default; GM can reveal the adversary reference panel when needed)
+
+The inspector toggle (`⌃⌘I`) is anchored as the trailing-most toolbar item in all modes.
+
+### 2. Toolbar design per mode
+
+Toolbar items follow the mental-model ordering rule (most-used → left) and use AppKit built-in identifiers where available.
+
+**All modes — fixed items:**
+- Leading anchor: `.toggleSidebar` + `.sidebarTrackingSeparator`
+- Trailing anchor: `.inspectorTrackingSeparator` + `.toggleInspector`
+
+**Encounter Prep — content zone items (contributed by `EncounterEditorView` when active):**
+- Run / Resume button (enabled only when an encounter is open in the center column)
+
+**iPadOS only — centered item (contributed by `ContentView`):**
+- `NSToolbarItemGroup` segmented picker: Encounters | Compendium (mode switch)
+
+**Compendium Management — content zone items:**
+- No additional toolbar items; all management actions (Add, Import, Export) live in the sidebar bottom bar.
+- `NSSearchToolbarItem` for search (expands in place) may be added here.
+
+**Running Encounter — content zone items:**
+- Pause button (⌘.)
+- End Encounter button (no keyboard shortcut — destructive)
+- Fear Tracker button (existing `FearTrackerButton`)
+
+In run mode, the sidebar toggle remains present but the left runner panel is not typically hidden; the inspector toggle controls the right adversary reference panel.
+
+### 3. Sidebar bottom bars for management actions
+
+Per the sidebar guidelines, actions that create, delete, or modify sidebar content belong in the **sidebar's bottom bar** (`safeAreaBar(edge:alignment:spacing:content:)`), not in the toolbar zone.
+
+Encounter list bottom bar (in `EncounterAndPartyPanel`):
+- [+] New Encounter
+- [−] Delete selected encounter (enabled when an encounter is selected; confirmation required)
+
+Party list bottom bar (in `EncounterAndPartyPanel`):
+- [+] Add Player → `PlayerForm` sheet
+- [−] Remove selected player (confirmation required)
+
+Compendium adversary list bottom bar (in `CompendiumAdversaryListPanel`):
+- [+] Add Adversary → `AdversaryCreatorForm`
+- [↓] Import DHPack → file importer
+- [↑] Export Local → `DHPackExportSheet`
+
+The sidebar toolbar zone contains only `.toggleSidebar` and `.sidebarTrackingSeparator`.
+
+### 4. Menu structure
+
+```
+Encounter (app menu)
+  About Encounter
+  ─────
+  Settings…                     ⌘,
+  ─────
+  Hide Encounter                 ⌘H
+  Hide Others                    ⌥⌘H
+  Quit Encounter                 ⌘Q
+
+File
+  New Encounter                  ⌘N         (context: encounter mode)
+  New Adversary                  ⌘N         (context: compendium mode)
+  ─────
+  Rename…                                   (enabled: item selected)
+  Delete…                        ⌫          (enabled: item selected; confirmation required)
+  ─────
+  Import DHPack…                 ⇧⌘I
+  Export Local Adversaries…                 (enabled: local adversaries exist)
+
+Edit
+  Undo                           ⌘Z
+  Redo                           ⇧⌘Z
+  ─────
+  Cut                            ⌘X
+  Copy                           ⌘C
+  Paste                          ⌘V
+  Select All                     ⌘A
+
+Encounter                                   (top-level; actions are contextual)
+  Run Encounter                  ⌘R         (enabled: encounter selected, no active session)
+  Resume Encounter               ⌘R         (enabled: paused session for selection)
+  ─────
+  Pause Encounter                ⌘.         (enabled: session running)
+  End Encounter                             (enabled: session running or paused; confirmation)
+  ─────
+  Reset Encounter                           (enabled: session exists; confirmation)
+
+View
+  Show/Hide Sidebar              ⌃⌘S
+  Show/Hide Inspector            ⌃⌘I
+  ─────
+  Encounters                     ⌘1         (mode switch)
+  Compendium                     ⌘2         (mode switch)
+
+Window
+  (standard AppKit items)
+
+Help
+  Encounter Help
+  (search bar)
+```
+
+**Implementation notes:**
+- `⌘N` is context-sensitive: `CommandMenu("File")` checks the current `AppWindowMode` — creates an encounter in `.encounterPrep`, creates an adversary in `.compendiumManagement`.
+- `⌘R` is also context-sensitive: enabled and labeled "Run" or "Resume" based on whether a paused session exists.
+- The "Encounter" top-level menu uses `CommandMenu("Encounter")`. Its items enable/disable based on `encounterSelection` and `AppWindowMode` in `ContentView`.
+- `Run Encounter` / `Resume Encounter` share the `⌘R` key; only one is enabled at a time.
+
+### 5. Keyboard shortcuts
+
+Full shortcut table:
+
+| Action | macOS | iPadOS | Notes |
+|---|---|---|---|
+| New Encounter (in encounter mode) | ⌘N | ⌘N | |
+| New Adversary (in compendium mode) | ⌘N | ⌘N | Same key, different context |
+| Delete selected item | ⌫ | ⌫ | Confirmation required |
+| Rename selected item | ↩ | ↩ | Opens inline rename or alert |
+| Open / edit selected encounter | ⌘↩ | ⌘↩ | Focus center column |
+| Run Encounter | ⌘R | ⌘R | Disabled when running; shows Resume label when paused |
+| Resume Encounter | ⌘R | ⌘R | Shares key with Run; only one enabled at a time |
+| Pause Encounter | ⌘. | ⌘. | Standard Mac "stop" chord |
+| End Encounter | — | — | No shortcut; deliberate — destructive |
+| Reset Encounter | — | — | No shortcut; deliberate — destructive |
+| Mode: Encounters | ⌘1 | ⌘1 | |
+| Mode: Compendium | ⌘2 | ⌘2 | |
+| Toggle Sidebar | ⌃⌘S | ⌃⌘S | AppKit `.toggleSidebar` built-in |
+| Toggle Inspector | ⌃⌘I | ⌃⌘I | AppKit `.toggleInspector` built-in |
+| Focus search / filter bar | ⌘F | ⌘F | |
+| Add Adversary to Encounter | ⌘⇧A | ⌘⇧A | From compendium row or utility panel |
+| Import DHPack | ⌘⇧I | — | |
+| Settings | ⌘, | — | |
+
+**No keyboard shortcut for Fear Tracker** — the GM is typically using pointing device to manage the runner list; the Fear popover button is the right affordance.
+
+**No keyboard shortcuts for End or Reset** — both are destructive. Deliberate menu navigation or button click is the intended path.
+
+**iPadOS hardware keyboard:** All of the above apply when a hardware keyboard is connected. SwiftUI `Commands` work on iPadOS. Additionally:
+- Arrow keys navigate selected list item
+- Return opens/renames the selected item (consistent with macOS)
+- Escape dismisses sheets and deselects
+
+### 6. Drag and drop
+
+In scope for the macOS/iPadOS redesign (Milestone 4):
+
+- **Source:** Adversary rows in `CompendiumUtilityPanel` (prep mode, right panel)
+- **Target:** Adversary list in `EncounterEditorView` (center column)
+- **Behavior:** Dropping an adversary row onto the list adds it to the encounter (same as tapping the row). Duplicate detection: if the adversary is already in the encounter, ask to add a second slot or do nothing.
+- **Implementation:** `draggable(adversary)` on the row, `.dropDestination(for: Adversary.self)` on the list or an explicit drop zone within the section.
+- **iPadOS:** Touch drag works with the same API.
+
+Drag is not implemented between other panels (e.g., no drag from the encounter editor to the runner, no drag to reorder adversary slots — those are separate features).
+
+### 7. Mac polish requirements
+
+The following are required for a native-feeling app but are not tracked as separate ADRs:
+
+- **Tooltips** on all interactive controls (toolbar buttons, sidebar bottom bar buttons, condition toggles). Add `.help("description")` modifier.
+- **Minimum window size:** 900 pt wide × 560 pt tall. Enforced with `.frame(minWidth: 900, minHeight: 560)` on the `WindowGroup`'s content. Sidebar min width 240 pt, max 360 pt; inspector min width 280 pt, max 400 pt.
+- **State restoration:** `AppWindowMode` and `selectedEncounterID` should restore on relaunch. Use `@SceneStorage` for the mode and selection.
+- **Dock menu:** Override `applicationDockMenu` to offer "New Encounter" and, when a paused session exists, "Resume [encounter name]".
+- **Spotlight keywords** in `Info.plist` (`MDItemKeywords`): "daggerheart, encounter, gm, gamemaster, ttrpg, rpg, adversary, combat".
+- **Credits.rtf** in bundle resources for the standard About window.
+
+## Options Considered
+
+- **Pause/End in the left runner panel vs. toolbar (decided: toolbar).** Window-mode commands (pause, end) should not scroll with content. The toolbar is the stable, always-visible location for them.
+- **Fear shortcut (decided: no shortcut).** The GM is already using the trackpad/mouse during a run. A keyboard shortcut for Fear adds memorization burden for an action that has a one-tap affordance.
+- **Drag from compendium utility panel (decided: in scope).** The tap-to-add callback is simpler to build but click-drag is the idiomatic Mac interaction for "move this thing into that list." Both coexist — tapping still calls `onSelect` directly.
+
+## Consequences
+
+- `EncounterApp.swift` gains a full `Commands` block with `CommandMenu("File")`, `CommandMenu("Encounter")`, `CommandMenu("View")`, and several `CommandGroup(replacing:)` entries.
+- `ContentView` (macOS/iPadOS branch) adds `@SceneStorage` for `AppWindowMode` and selection.
+- `WindowGroup` in `EncounterApp.swift` gets `.frame(minWidth: 900, minHeight: 560)` and sidebar/inspector width constraints.
+- `EncounterAndPartyPanel` and `CompendiumAdversaryListPanel` gain sidebar bottom bars instead of inline toolbar buttons.
+- `RunnerListPanel` loses its Pause/End header buttons; these move to the toolbar (contributed when `AppWindowMode == .runningEncounter`).
+- Drag source added to adversary rows in `CompendiumUtilityPanel`; drop target added to `EncounterEditorView` adversary list section.
+- All interactive controls gain `.help("…")` tooltips.

--- a/docs/first-principles.md
+++ b/docs/first-principles.md
@@ -108,6 +108,24 @@ Future local-network sharing (GM and player apps on the same table network) and
 eventual remote support for distributed play are valid extensions of this
 foundation — not requirements that change the core.
 
+## 12. iOS, iPadOS, and macOS are all first-class platform targets
+
+*This supersedes Principle 9.*
+
+iOS, iPadOS, and macOS each receive a navigation model and interaction idiom
+appropriate to their input model and screen size:
+
+- **iOS** — push navigation; single-column screens; at-the-table primary device
+- **iPadOS** — split-view with toolbar mode switching; covers both prep and run at the table
+- **macOS** — split-view with menu-driven mode switching; primary prep device
+
+Each platform gets a distinct root layout. There is no shared-layout compromise.
+`#if os(iOS)` / `#if os(macOS)` conditional compilation is used where platforms
+diverge; shared components are platform-agnostic and used by all three.
+
+visionOS is a supported build target but receives no platform-specific design
+work at this stage — it inherits the iOS layout.
+
 ---
 
 *These principles are intended to be stable. If a principle needs to change,

--- a/docs/redesign-plan.md
+++ b/docs/redesign-plan.md
@@ -1,0 +1,580 @@
+# Encounter UX Redesign — Implementation Plans
+
+## Context
+
+The prototype has exposed fundamental navigation and mode-mixing problems. The app conflates creator and executor workflows, uses a generic cross-platform layout rather than platform-native patterns, and lacks a first-class encounter lifecycle (pause/resume/end). This plan rebuilds the UX layer from documented decisions while preserving the working model and services layer.
+
+Design decisions recorded during planning session (2026-05-03):
+- macOS/iPadOS compendium mode: 2-panel collapse (adversary list | detail/inspector)
+- macOS run mode: same-window mode swap (no new window)
+- Player hide: global party flag (roster-wide, not per-encounter)
+- Custom adversary creation: full multi-step form (ADR-0025 draft)
+- DHPacks are import/export bundles only — not editable in place
+
+---
+
+## Platform Architecture
+
+### Shared concept: `AppWindowMode` (macOS + iPadOS)
+
+```swift
+enum AppWindowMode {
+    case encounterPrep                         // 3-panel
+    case compendiumManagement                  // 2-panel
+    case runningEncounter(EncounterSession)    // 2-panel
+}
+```
+
+`NavigationSplitView` column visibility changes with mode:
+- `.encounterPrep` → `columnVisibility = .all` (3 columns)
+- `.compendiumManagement` / `.runningEncounter` → `columnVisibility = .doubleColumn` (sidebar + detail only)
+
+### macOS layout per mode
+
+| Mode | Left (sidebar) | Center | Right (detail) |
+|---|---|---|---|
+| Encounter Prep | Encounter list + Party list | Encounter editor | Compendium utility panel |
+| Compendium Management | Adversary list (grouped) | — hidden — | Adversary inspector/editor |
+| Running Encounter | Adversary runner rows + Player section + Pause/End | — hidden — | Selected adversary detail |
+
+Mode switch: **menu command** (`View → Compendium` / `View → Encounters`)
+
+### iPadOS layout per mode
+
+Same 3-panel structure as macOS. Mode switch: **segmented toolbar control** (Encounters | Compendium).
+
+Run mode is triggered by a "Run" button in the encounter editor toolbar; the window transitions in place (same as macOS).
+
+### iOS layout
+
+Root view is a single `NavigationStack`. The root screen has a **segmented toolbar toggle** (Encounters | Compendium):
+
+- **Encounters mode** — encounter list (top) + party list (below); tapping a row pushes to the encounter editor; run affordance pushes to run mode
+- **Compendium mode** — adversary list (full screen); searchable/filterable; create custom adversary, import DHPack, export local collection
+
+Push hierarchy:
+```
+NavigationStack
+  Root (Encounters|Compendium toggle)
+    └── EncounterEditorView        ← push from encounter row
+          └── EncounterRunnerView  ← push from Run button
+```
+
+---
+
+## Model Changes Required
+
+These must land before any platform work begins.
+
+### 1. `SessionPhase` — DHKit package update (gwillish/DHModels)
+
+Add to `EncounterSession`:
+```swift
+public enum SessionPhase: String, Codable { case running, paused }
+public var phase: SessionPhase = .running
+```
+
+`SessionStore` must persist and restore `phase`. The resume prompt and in-progress indicators read `phase == .paused`.
+
+### 2. Player `isHidden` — app-level, `PlayerStore`
+
+Add `hiddenPlayerIDs: Set<UUID>` as a persisted property on `PlayerStore` (JSON file alongside `party.json`). Update `activePartyPlayers` to filter out hidden IDs. Add `hidePlayer(id:)` / `showPlayer(id:)` methods.
+
+This avoids modifying the DHKit `Player` type while cleanly modelling the roster-level flag.
+
+### 3. Encounter in-progress state — `EncounterLibraryRow`
+
+`SessionRegistry` already keys sessions by `EncounterDefinition.ID`. Pass `isPaused: Bool` to `EncounterLibraryRow` (derived from `SessionRegistry` in the parent). Show a visual indicator when a paused session exists for the row's definition. Change the run affordance label: "Run" → "Resume".
+
+---
+
+## New Shared Components
+
+These components are platform-agnostic and consumed on all three platforms.
+
+| Component | Purpose |
+|---|---|
+| `AdversaryFilterBar` | Text search + tier picker + type filter menu; accepts bindings, emits filter state |
+| `CompendiumSelectorSheet` | Modal adversary selector: parameterized search, add-to-encounter callback, import DHPack button |
+| `AdversaryCreatorForm` | Multi-step form: Identity → Stats → Attack & Features → Review (ADR-0025 draft) |
+| `DHPackExportSheet` | Multi-select list of local adversaries → export as `.dhpack` via system share sheet |
+| `SessionLifecycleButton` | Reusable Pause / End button component used in runner panels on all platforms |
+
+---
+
+## Milestone 0: Documentation and ADRs
+
+Write before implementation begins. These record decisions made in this planning session and guide all downstream work.
+
+**ADRs to write:**
+
+| ADR | Title | Supersedes |
+|---|---|---|
+| 0043 | Platform-specific navigation architecture | ADR-0019, ADR-0040 |
+| 0044 | Encounter session lifecycle (running / paused / ended) | — |
+| 0045 | Compendium management mode | ADR-0025 (changes deferred status) |
+| 0046 | Single party with hidden member flag | — |
+| 0047 | macOS/iPadOS toolbar, menu structure, inspector, and keyboard model | — |
+
+**Update status lines (one-line edit only):**
+- `docs/decisions/0019-macos-split-view-ios-stack.md` → `Superseded by [ADR-0043](0043-platform-navigation-architecture.md)`
+- `docs/decisions/0040-encounters-first-navigation.md` → `Superseded by [ADR-0043](0043-platform-navigation-architecture.md)`
+
+**New docs to write:**
+- `docs/ux-requirements.md` — per-platform requirements derived from this plan; canonical reference for screen structure and interaction patterns
+- Update `docs/ui-vocabulary.md` — replace navigation map, update screen reference table, add new component glossary entries
+- `docs/first-principles.md` — add Principle 12 superseding Principle 9: iOS, iPadOS, and macOS are all first-class platform targets with distinct navigation idioms; visionOS is a supported build target but receives no platform-specific design work
+
+**Issues for this milestone:**
+- [x] Write ADR-0043 (navigation architecture)
+- [x] Write ADR-0044 (session lifecycle)
+- [x] Write ADR-0045 (compendium management mode)
+- [x] Write ADR-0046 (party hidden member flag)
+- [x] Write ADR-0047 (macOS/iPadOS toolbar, menu, inspector, keyboard)
+- [x] Update superseded status on ADR-0019 and ADR-0040
+- [x] Write `docs/ux-requirements.md`
+- [x] Update `docs/ui-vocabulary.md`
+- [x] Add Principle 12 to `docs/first-principles.md`
+
+---
+
+## Milestone 1: Foundation — Model and Shared Infrastructure
+
+All platform work depends on this milestone.
+
+### 1a. DHKit: `SessionPhase`
+
+- **Test first:** `SessionStoreTests` — verify `phase` round-trips through save/load; verify `paused` sessions are not presented to the runner without explicit resume action
+- Add `SessionPhase` enum and `phase` property to `EncounterSession` in DHKit (package PR)
+- Update `SessionStore.save(_:)` and `SessionStore.load(into:)` to persist `phase`
+- Add `pause()` and `resume()` methods on `EncounterSession` that set `phase`
+
+### 1b. App: `PlayerStore` hidden player support
+
+Critical files: `Encounter/Services/PlayerStore.swift`
+
+- **Test first:** `PlayerStoreTests` — hidden player excluded from `activePartyPlayers`; hide/show round-trips through persistence; deleting a player also removes from `hiddenPlayerIDs`
+- Add `private(set) var hiddenPlayerIDs: Set<UUID>` to `PlayerStore`
+- Add `hidePlayer(id:) async` and `showPlayer(id:) async`
+- Update `activePartyPlayers` to filter hidden IDs
+- Persist `hiddenPlayerIDs` to `<directory>/hidden-players.json`
+
+### 1c. `EncounterLibraryRow` in-progress indicator
+
+Critical files: `Encounter/Views/EncounterLibraryRow.swift`
+
+- **Test first:** `EncounterLibraryRowTests` — row with a paused session shows indicator; row without session does not
+- Pass `isPaused: Bool` into `EncounterLibraryRow` (derived from `SessionRegistry` in the parent)
+- Show a capsule badge ("In Progress") and change run button label to "Resume"
+
+### 1d. Shared `AdversaryFilterBar`
+
+New file: `Encounter/Views/AdversaryFilterBar.swift`
+
+- **Test first:** `AdversaryFilterBarTests` — text search filters by name; tier picker filters by tier; type menu filters by type; combined filters compose with AND
+- Stateless: accepts bindings `searchText`, `selectedTier`, `selectedType`; renders search field + filter controls
+- Used by `CompendiumSelectorSheet`, `CompendiumAdversaryListPanel`, and `CompendiumRootView`
+
+### 1e. `CompendiumSelectorSheet`
+
+New file: `Encounter/Views/CompendiumSelectorSheet.swift`
+
+- **Test first:** `CompendiumSelectorSheetTests` — shows `AdversaryFilterBar`; adversary row tap calls `onSelect`; import DHPack button present
+- Props: `compendium: Compendium`, `contentStore: ContentStore`, `onSelect: (Adversary) -> Void`
+- Contains `AdversaryFilterBar` + filtered adversary list
+- "Import DHPack" toolbar button calls `contentStore.importPack(from:)` via file importer
+- Replaces `CompendiumBrowserView` as the selection-mode entry point from the encounter editor
+
+**Issues for this milestone:**
+- [ ] DHKit PR: add `SessionPhase`, `pause()`, `resume()` to `EncounterSession`
+- [ ] App: update `SessionStore` to persist `SessionPhase` (save/load round-trip)
+- [ ] `PlayerStore`: `hiddenPlayerIDs` persistence + hide/show methods
+- [ ] `EncounterLibraryRow`: in-progress indicator + resume label
+- [ ] `AdversaryFilterBar` shared component
+- [ ] `CompendiumSelectorSheet` shared component
+
+---
+
+## Holistic Plan: iOS Redesign
+
+**Goal:** Single `NavigationStack` root with toolbar mode toggle. Encounters + party co-located on root screen. Push navigation through edit → run. Full pause/resume/end lifecycle. No tabs.
+
+**Replaces:** `ContentView` iOS branch, `TabView`, `EncounterLibraryView` as root, `PartyOverviewView` as a tab
+
+### Milestone 2: iOS Root View Redesign
+
+#### 2a. `EncounterAndPartyRootView` (new)
+
+New file: `Encounter/Views/EncounterAndPartyRootView.swift`
+
+- **Test first:** `EncounterAndPartyRootViewTests` — encounter list visible; party list visible below; segmented toolbar toggle present; switching to compendium replaces list content
+- Top section: scrollable encounter list (reuses `EncounterLibraryList`); each row has name, in-progress badge, run/resume affordance button
+- Bottom section: party member list (add/delete/hide controls); hidden members shown with a distinct style (grayed, `eye.slash` icon) with unhide affordance
+- Toolbar: centered `Picker` segmented control (Encounters | Compendium)
+- State: `@State var rootMode: iOSRootMode` where `iOSRootMode` is `.encounters` or `.compendium`
+
+#### 2b. `CompendiumRootView` (new, iOS)
+
+New file: `Encounter/Views/CompendiumRootView.swift`
+
+- **Test first:** `CompendiumRootViewTests` — adversary list visible; `AdversaryFilterBar` present; DHPack import button present; export button present
+- Full-screen adversary list; `AdversaryFilterBar` at top
+- Grouped sections: SRD | [DHPack name] | Local
+- Toolbar: "Import DHPack" (file importer), "Export Local" (→ `DHPackExportSheet`), "Add Adversary" (→ `AdversaryCreatorForm`)
+- Tapping adversary row pushes to `AdversaryDetailView`
+
+#### 2c. Update `ContentView` iOS branch
+
+Critical file: `Encounter/ContentView.swift`
+
+Replace the `TabView` iOS branch with a `NavigationStack` wrapping `EncounterAndPartyRootView`. The stack's `navigationDestination` bindings cover:
+- `EncounterDefinition` → `EncounterEditorView`
+- `EncounterSession` → `EncounterRunnerView`
+- `Adversary` → `AdversaryDetailView`
+
+Simplify resume state: replace the 6-variable resume state machine with paused sessions visible inline in the encounter list. `ResumePromptView` is retired.
+
+**Issues for this milestone:**
+- [ ] `EncounterAndPartyRootView`: encounter list + party section + toolbar toggle
+- [ ] `CompendiumRootView`: adversary list with filter, grouped sections, import/export
+- [ ] `ContentView` iOS branch: replace TabView with NavigationStack, simplify resume state
+- [ ] Retire `ResumePromptView`, `PartyOverviewView` (iOS tab usage)
+
+### Milestone 3: iOS Encounter Editor and Run Mode
+
+#### 3a. `EncounterEditorView` (rename/update from `EncounterBuilderView`)
+
+Critical file: `Encounter/Views/EncounterBuilderView.swift`
+
+- **Test first:** `EncounterEditorViewTests` — Run button shown when no session; Resume button shown when paused session exists; "Browse Compendium" opens `CompendiumSelectorSheet` (not `CompendiumBrowserView`)
+- Replace `.fullScreenCover` runner presentation with `NavigationLink` push
+- Replace `CompendiumBrowserView` sheet with `CompendiumSelectorSheet` sheet
+- `DifficultyAssessorView` remains fixed to bottom
+
+#### 3b. `EncounterRunnerView` pause/resume/end lifecycle
+
+Critical file: `Encounter/Views/EncounterRunnerView.swift`
+
+- **Test first:** `EncounterRunnerViewTests` — Pause button calls `session.pause()`; End button calls `store.clearSession(for:)`; paused session persists in `SessionStore`
+- Add "Pause" toolbar/nav button that calls `session.pause()`, saves via `SessionStore`, then pops navigation
+- "End Encounter" existing button clears session entirely
+- No change to the accordion runner list or player section
+
+**Issues for this milestone:**
+- [ ] `EncounterEditorView`: replace `.fullScreenCover` runner presentation with `NavigationLink` push
+- [ ] `EncounterEditorView`: replace `CompendiumBrowserView` sheet with `CompendiumSelectorSheet` (depends on M1e)
+- [ ] `EncounterEditorView`: show Resume label and behavior when a paused session exists (depends on M1a + M1c)
+- [ ] `EncounterRunnerView`: Pause action + session lifecycle wiring
+
+---
+
+## Holistic Plan: iPadOS and macOS Redesign
+
+iPadOS and macOS share the `AppWindowMode` state machine and the same three-panel/two-panel `NavigationSplitView` structure. They share all panel components. iPadOS gets the segmented toolbar control; macOS gets menu commands.
+
+### Milestone 4: macOS/iPadOS — Encounter Prep (3-panel)
+
+#### 4a. `AppWindowMode` and updated `ContentView` macOS/iPadOS branch
+
+Critical file: `Encounter/ContentView.swift`
+
+- **Test first:** `AppWindowMode` transitions; `columnVisibility = .all` in prep mode; `columnVisibility = .doubleColumn` in compendium/run mode
+- Replace the current `NavigationSplitView` sidebar (2-item list) with the new 3-panel structure keyed on `AppWindowMode`
+- Mode switch for iPadOS: `Picker` segmented in toolbar
+- Mode switch for macOS: `Commands` menu (`View → Encounters`, `View → Compendium`)
+
+#### 4b. `EncounterAndPartyPanel` (new, sidebar — encounter prep mode)
+
+New file: `Encounter/Views/EncounterAndPartyPanel.swift`
+
+- **Test first:** encounter list shows in-progress badges; party section below with hide/unhide
+- Encounter list (top): rows with name, in-progress badge, "Run"/"Resume" button per row
+- Party section (bottom): player list, add/delete, hide/unhide affordances
+- Selection drives the center column (`EncounterEditorView`)
+
+#### 4c. `CompendiumUtilityPanel` (new, detail column — encounter prep mode)
+
+New file: `Encounter/Views/CompendiumUtilityPanel.swift`
+
+- **Test first:** `AdversaryFilterBar` visible; filtered list shows; tapping adversary adds to encounter via callback
+- Right utility panel — always visible in encounter prep mode; replaces the Browse Compendium sheet button
+- Accepts `onSelect: (Adversary) -> Void` callback
+- Contains `AdversaryFilterBar` + filtered adversary list; tapping a row calls `onSelect` immediately
+- "Import DHPack" button at bottom
+
+#### 4d. Update `EncounterEditorView` for macOS/iPadOS
+
+- Hide the "Browse Compendium" sheet button when on macOS/iPadOS (right panel replaces it)
+- `DifficultyAssessorView` stays
+
+#### 4e. Toolbar, Commands, and Keyboard (macOS/iPadOS)
+
+Per ADR-0047.
+
+- **Test first:** `CommandsTests` — `⌘N` creates encounter in prep mode; `⌘1`/`⌘2` switch modes; `⌘R` enables when encounter selected and no running session; `⌘.` only enabled when session running
+- Add full `Commands` block in `EncounterApp.swift`: `CommandMenu("File")`, `CommandMenu("Encounter")`, `CommandMenu("View")`, `CommandGroup(replacing: .newItem)`, `CommandGroup(replacing: .appInfo)`
+- `⌘N` context-sensitive: checks `AppWindowMode`
+- `⌘R` Run/Resume context-sensitive: enabled and labeled based on session state
+- `⌘.` Pause: enabled only while `.runningEncounter`
+- `⌘1`/`⌘2` mode switch
+- `⌃⌘S` / `⌃⌘I` sidebar/inspector toggles (AppKit built-ins; also hooked in `View` menu)
+- iPadOS: `NSToolbarItemGroup` segmented mode picker centered in toolbar
+
+#### 4f. Inspector toggle defaults and sidebar bottom bars
+
+Per ADR-0047.
+
+- **Test first:** inspector open by default in prep mode; sidebar bottom bars render correct action buttons per section
+- Right panel implemented as inspector: `.inspectorTrackingSeparator` + `.toggleInspector`; default open in `.encounterPrep`
+- `EncounterAndPartyPanel`: encounter list bottom bar ([+] New, [−] Delete); party list bottom bar ([+] Add Player, [−] Remove)
+- All bottom bars use `safeAreaBar(edge:alignment:spacing:content:)`
+- Toolbar zone: only `.toggleSidebar` + `.sidebarTrackingSeparator` (no action buttons in toolbar zone)
+
+#### 4g. Run button in encounter prep toolbar
+
+- Toolbar content zone (contributed by `EncounterEditorView`): Run / Resume button enabled only when an encounter is selected in the center column
+- Wired to the same `windowMode = .runningEncounter(session)` transition as the in-row button
+
+#### 4h. Drag and drop: CompendiumUtilityPanel → EncounterEditorView
+
+Per ADR-0047.
+
+- **Test first:** `DragDropTests` — dragging an adversary row from the utility panel and dropping on the encounter adversary list calls `onSelect`; duplicate adversary triggers confirmation
+- `draggable(adversary)` on adversary rows in `CompendiumUtilityPanel`
+- `.dropDestination(for: Adversary.self)` on the adversary list section in `EncounterEditorView`
+- Duplicate detection: ask to add second slot or do nothing
+
+#### 4i. Window constraints and state restoration
+
+Per ADR-0047.
+
+- `WindowGroup` content: `.frame(minWidth: 900, minHeight: 560)`
+- Sidebar min 240 pt, max 360 pt; inspector min 280 pt, max 400 pt
+- `@SceneStorage` for `AppWindowMode` and `selectedEncounterID` in `ContentView` (macOS/iPadOS branch)
+
+#### 4j. Tooltips on all interactive controls (prep mode)
+
+- Add `.help("…")` to every toolbar button, sidebar bottom bar button, and condition toggle in prep-mode views
+- Tooltip text follows: verb + noun pattern (e.g. "Add a new encounter", "Delete selected encounter")
+
+#### 4k. Mac polish: Dock menu, Spotlight keywords, Credits.rtf
+
+- `EncounterApp.swift` / `AppDelegate`: override `applicationDockMenu` — offer "New Encounter" always; "Resume [name]" when a paused session exists in `SessionRegistry`
+- `Info.plist`: add `MDItemKeywords` = `daggerheart, encounter, gm, gamemaster, ttrpg, rpg, adversary, combat`
+- Add `Credits.rtf` to bundle resources (Copy Bundle Resources build phase)
+
+**Issues for this milestone:**
+- [ ] `AppWindowMode` enum + `NavigationSplitView` 3-panel structure + column visibility transitions in `ContentView`
+- [ ] iPadOS segmented toolbar mode picker (`NSToolbarItemGroup` centered in toolbar, `ContentView`)
+- [ ] `EncounterAndPartyPanel` sidebar (prep mode)
+- [ ] `CompendiumUtilityPanel` right panel (prep mode)
+- [ ] `EncounterEditorView` conditional Browse button suppression on macOS/iPadOS
+- [ ] `Commands` block in `EncounterApp.swift`: File menu, Encounter menu, View menu + all keyboard shortcuts (ADR-0047)
+- [ ] Inspector toggle wiring: `.inspectorTrackingSeparator` + `.toggleInspector`; open by default in prep mode
+- [ ] Sidebar bottom bars: `EncounterAndPartyPanel` (encounter list section + party section)
+- [ ] Run button in encounter prep toolbar (contributed by `EncounterEditorView`)
+- [ ] Drag and drop: `CompendiumUtilityPanel` rows → `EncounterEditorView` adversary list
+- [ ] Window and panel size constraints: min window 900×560pt, sidebar 240–360pt, inspector 280–400pt
+- [ ] `@SceneStorage` state restoration for `AppWindowMode` and `selectedEncounterID`
+- [ ] Tooltips (`.help()`) on all prep-mode interactive controls
+- [ ] Mac polish: Dock menu override, Spotlight keywords (`Info.plist`), `Credits.rtf` in bundle
+
+### Milestone 5: macOS/iPadOS — Compendium Management Mode (2-panel)
+
+#### 5a. `CompendiumAdversaryListPanel` (new, sidebar — compendium mode)
+
+New file: `Encounter/Views/CompendiumAdversaryListPanel.swift`
+
+- **Test first:** SRD group visible; DHPack groups visible; Local group visible; `AdversaryFilterBar` filters all groups
+- Grouped `List`: SRD | [DHPack name] per loaded pack | Local
+- `AdversaryFilterBar` at top (filters across all groups)
+- Selection drives `AdversaryInspectorView`
+- "Add Adversary" (+) button → `AdversaryCreatorForm`; "Import DHPack" → file importer; "Export Local" → `DHPackExportSheet`
+
+#### 5b. `AdversaryInspectorView` (new, detail — compendium mode)
+
+New file: `Encounter/Views/AdversaryInspectorView.swift`
+
+- **Test first:** SRD adversary shows read-only detail; local adversary shows edit controls; no selection shows empty state
+- SRD/DHPack adversaries: read-only stat card
+- Local adversaries: adds Edit button → `AdversaryCreatorForm` in edit mode
+- No "Add to Encounter" button (this is management mode, not selection mode)
+
+#### 5c. Sidebar bottom bar and inspector toggle for compendium mode
+
+Per ADR-0047.
+
+- `CompendiumAdversaryListPanel` bottom bar: [+] Add Adversary, [↓] Import DHPack, [↑] Export Local (enabled when local adversaries exist)
+- Inspector default: **open** in `.compendiumManagement`
+- All bottom bar buttons have `.help("…")` tooltips
+
+**Issues for this milestone:**
+- [ ] `CompendiumAdversaryListPanel` with grouped sections + filter + bottom bar actions (Add, Import, Export)
+- [ ] `AdversaryInspectorView` with read-only and edit paths
+- [ ] Inspector open by default in compendium mode
+- [ ] Tooltips on all compendium-mode interactive controls
+
+### Milestone 6: macOS/iPadOS — Run Mode (2-panel)
+
+#### 6a. `RunnerListPanel` (new, sidebar — run mode)
+
+New file: `Encounter/Views/RunnerListPanel.swift`
+
+- **Test first:** adversary rows sorted (defeated at bottom); player section below; accordion selection drives the right panel
+- Adversary section: `AdversaryRunnerSection` (reused)
+- Player section: `PlayerRunnerSection` (reused)
+- Expanded accordion selection drives the right panel
+- Pause and End controls live in the window toolbar (see 6d), not in this panel
+
+#### 6b. `RunnerDetailPanel` (new, detail — run mode)
+
+New file: `Encounter/Views/RunnerDetailPanel.swift`
+
+- **Test first:** selected adversary stats visible; no adversary selected shows placeholder
+- Shows `AdversaryStatReference` and `FeatureSectionsView` for expanded adversary
+- Read-only reference — damage/stress controls remain in the left accordion card
+- Players show `PlayerRunnerCard` content when a player row is expanded
+
+#### 6c. Run mode activation and deactivation
+
+Critical file: `Encounter/ContentView.swift` (macOS/iPadOS branch)
+
+- **Test first:** Run button sets `windowMode = .runningEncounter(session)`; Pause resets to `.encounterPrep`; End clears session and resets to `.encounterPrep`
+- Run button in `EncounterEditorView` calls `windowMode = .runningEncounter(session)` via callback/binding (ADR-0041)
+
+#### 6d. Toolbar in run mode and inspector toggle
+
+Per ADR-0047.
+
+- Toolbar content zone (contributed when `windowMode == .runningEncounter`): Pause (`⌘.`), End Encounter (no shortcut), Fear Tracker button
+- Inspector default: **hidden** in `.runningEncounter`; user can reveal adversary reference panel via `⌃⌘I`
+- Pause and End toolbar buttons are the authoritative controls; remove any Pause/End from the `RunnerListPanel` header (they move to the toolbar)
+- All run-mode toolbar and panel controls have `.help("…")` tooltips
+
+**Issues for this milestone:**
+- [ ] `RunnerListPanel` with adversary + player sections (Pause/End controls removed — they are in the toolbar)
+- [ ] `RunnerDetailPanel` for adversary/player detail in split
+- [ ] Run mode activation/deactivation wired through `AppWindowMode`
+- [ ] Run mode toolbar items: Pause, End, Fear Tracker (contributed by mode switch)
+- [ ] Inspector hidden by default in run mode
+- [ ] Tooltips on all run-mode interactive controls
+
+---
+
+## Holistic Plan: Compendium Management Features
+
+Shared across all platforms. Builds on compendium mode views from Milestones 2 and 5.
+
+### Milestone 7: Custom Adversary Creation (`AdversaryCreatorForm`)
+
+Multi-step form per ADR-0025 draft. Local adversaries saved in `homebrew/` directory (already provisioned by `ContentWriter`).
+
+#### Step structure
+1. **Identity** — name, type (AdversaryType picker), tier (1–5); surfaces 2-3 SRD peers for stat reference
+2. **Stats** — HP, Stress, Difficulty, Thresholds (Major/Severe), Evasion; inline soft-range indicators per field (within range / above average / outlier) based on SRD peers; guidance only, never blocks save
+3. **Attack & Features** — attack name, modifier, range, damage string; feature list (add passive/action/reaction)
+4. **Review** — full stat card preview; soft out-of-range summary; Save
+
+New file: `Encounter/Views/AdversaryCreatorForm.swift`
+
+- **Test first:** each step renders; Next/Back navigation; Save on review persists to `ContentStore`; out-of-range field shows warning label; duplicate name validation
+- Opened as `.sheet` on all platforms; on macOS/iPadOS also used inline in detail column for existing local adversaries
+- Edit mode: pre-fills all steps with existing local adversary data
+
+**Issues for this milestone:**
+- [ ] `ContentStore`: `saveLocalAdversary(_:)` and `deleteLocalAdversary(id:)` methods (unblocks all form steps)
+- [ ] `AdversaryCreatorForm` step 1: Identity + reference panel
+- [ ] `AdversaryCreatorForm` step 2: Stats + soft range indicators
+- [ ] `AdversaryCreatorForm` step 3: Attack & features list
+- [ ] `AdversaryCreatorForm` step 4: Review + save to local source
+- [ ] Edit mode: pre-fill from existing local adversary
+
+### Milestone 8: DHPack Export
+
+New file: `Encounter/Views/DHPackExportSheet.swift`
+
+- **Test first:** local adversaries listed; multi-select toggles; Export button disabled when nothing selected; tapping Export invokes system share sheet
+- Lists all local custom adversaries with checkboxes
+- "Export Selected" → assembles `DHPackContent` → writes temporary `.dhpack` → presents `ShareLink`
+
+**Issues for this milestone:**
+- [ ] `DHPackExportSheet` with multi-select and share sheet integration
+- [ ] `ContentStore`: `exportPack(adversaryIDs:) async -> URL` helper method
+
+---
+
+## Critical Files
+
+| File | Change |
+|---|---|
+| `Encounter/ContentView.swift` | Near-complete rewrite of both platform branches |
+| `Encounter/Views/EncounterBuilderView.swift` | Push nav, CompendiumSelectorSheet, Resume mode |
+| `Encounter/Views/EncounterRunnerView.swift` | Add Pause action, lifecycle wiring |
+| `Encounter/Views/EncounterLibraryRow.swift` | In-progress badge, Resume label |
+| `Encounter/Services/PlayerStore.swift` | `hiddenPlayerIDs`, hide/show methods |
+| `Encounter/Services/SessionStore.swift` | Persist `SessionPhase` |
+| DHKit `EncounterSession` | Add `SessionPhase`, `pause()`, `resume()` |
+
+**New files:**
+```
+Encounter/Views/EncounterAndPartyRootView.swift    (iOS)
+Encounter/Views/CompendiumRootView.swift           (iOS)
+Encounter/Views/EncounterAndPartyPanel.swift       (macOS/iPadOS sidebar)
+Encounter/Views/CompendiumUtilityPanel.swift       (macOS/iPadOS right — prep mode)
+Encounter/Views/CompendiumAdversaryListPanel.swift (macOS/iPadOS sidebar — compendium mode)
+Encounter/Views/AdversaryInspectorView.swift       (macOS/iPadOS right — compendium mode)
+Encounter/Views/RunnerListPanel.swift              (macOS/iPadOS sidebar — run mode)
+Encounter/Views/RunnerDetailPanel.swift            (macOS/iPadOS right — run mode)
+Encounter/Views/AdversaryFilterBar.swift           (shared)
+Encounter/Views/CompendiumSelectorSheet.swift      (shared)
+Encounter/Views/AdversaryCreatorForm.swift         (shared)
+Encounter/Views/DHPackExportSheet.swift            (shared)
+```
+
+**Files retired (delete after replacement is in place):**
+```
+Encounter/Views/ResumePromptView.swift
+Encounter/Views/ResumeTarget.swift
+```
+
+---
+
+## GitHub Milestones
+
+```
+Milestone 0: Documentation & ADRs
+Milestone 1: Foundation — Model and Shared Infrastructure
+Milestone 2: iOS Root View Redesign
+Milestone 3: iOS Encounter Editor and Run Mode
+Milestone 4: macOS/iPadOS — Encounter Prep (3-panel)
+Milestone 5: macOS/iPadOS — Compendium Management Mode
+Milestone 6: macOS/iPadOS — Run Mode
+Milestone 7: Custom Adversary Creation
+Milestone 8: DHPack Export
+```
+
+Dependency order: Milestone 1 → all others. Milestones 2–3 (iOS) and 4–6 (macOS/iPadOS) can proceed in parallel after Milestone 1. Milestones 7–8 follow all platform milestones.
+
+---
+
+## TDD Approach
+
+Each view and service follows the **red → green** cycle:
+
+1. Write the Swift Testing `@Test` that exercises the new behaviour
+2. Run `xcodebuild test -scheme Encounter -destination 'platform=macOS'` → confirm red
+3. Implement the minimum code to pass
+4. Run tests again → green
+5. `swift-format format --recursive --in-place Encounter/`
+6. Commit
+
+View tests use ViewInspector for structure/binding assertions. Model tests use Swift Testing directly. UIKit-requiring flows use XCUITest (`-testPlan AllTests`).
+
+---
+
+## Verification per Milestone
+
+- **After Milestone 1:** `SessionStoreTests` phase round-trip; `PlayerStoreTests` hide/show; `EncounterLibraryRowTests` badge
+- **After Milestones 2–3 (iOS):** XCUITest — launch → encounter list → push editor → run → pause → in-progress badge → resume → end
+- **After Milestones 4–6 (macOS/iPadOS):** macOS XCUITest — launch → 3-panel → select encounter → add adversary from right panel → run → pause → compendium mode → browse
+- **After Milestones 7–8:** XCUITest — create local adversary → add to encounter → export as DHPack → import DHPack

--- a/docs/ui-vocabulary.md
+++ b/docs/ui-vocabulary.md
@@ -63,42 +63,70 @@ Screenshots of all four proposals rendered in the app (iOS + macOS) are in `docs
 
 ## Navigation Map
 
+### iOS / visionOS
+
 ```mermaid
 flowchart TD
-    APP([App Launch]) --> CV[ContentView]
+    APP([App Launch]) --> CV[ContentView\nNavigationStack]
+    CV --> ROOT[EncounterAndPartyRootView\ntoolbar toggle: Encounters|Compendium]
 
-    CV -->|in-flight sessions| RP[ResumePromptView\nsheet]
-    RP -->|resume| ER
-    RP -->|resume| ER2
+    ROOT -->|Encounters mode| ENC_LIST[Encounter list + Party roster]
+    ROOT -->|Compendium mode| COMP_ROOT[CompendiumRootView]
 
-    subgraph iOS/visionOS
-        CV --> TAB_PARTY[Party tab]
-        CV --> TAB_ENC[Encounters tab]
-        TAB_PARTY --> PO[PartyOverviewView]
-        TAB_ENC --> EL[EncounterLibraryView]
-        EL -->|NavigationLink| EB[EncounterBuilderView]
-        EB -->|Run Encounter| ER[EncounterRunnerView\nfullScreenCover]
+    ENC_LIST -->|tap encounter row| EE[EncounterEditorView]
+    EE -->|Run / Resume| ER[EncounterRunnerView\npush]
+    ER -->|Pause| EE
+    ER -->|End| ENC_LIST
+
+    EE -->|sheet| CSS[CompendiumSelectorSheet]
+    CSS -->|onSelect| EE
+
+    COMP_ROOT -->|push| AD[AdversaryDetailView]
+    COMP_ROOT -->|sheet| ACF[AdversaryCreatorForm]
+    COMP_ROOT -->|sheet| DHPE[DHPackExportSheet]
+
+    ENC_LIST -->|sheet| PF[PlayerForm]
+```
+
+### macOS / iPadOS
+
+```mermaid
+flowchart TD
+    APP([App Launch]) --> CV[ContentView\nNavigationSplitView]
+    CV -->|AppWindowMode| MODE{Window Mode}
+
+    MODE -->|encounterPrep| PREP[3-panel layout]
+    MODE -->|compendiumManagement| COMP[2-panel layout]
+    MODE -->|runningEncounter| RUN[2-panel layout]
+
+    subgraph Encounter Prep
+        PREP --> LEFT_P[EncounterAndPartyPanel\nleft sidebar]
+        PREP --> CENTER_P[EncounterEditorView\ncenter column]
+        PREP --> RIGHT_P[CompendiumUtilityPanel\nright panel]
+        LEFT_P -->|selection| CENTER_P
+        RIGHT_P -->|onSelect| CENTER_P
+        CENTER_P -->|Run button| MODE
+        LEFT_P -->|sheet| PF2[PlayerForm]
     end
 
-    subgraph macOS
-        CV --> SIDEBAR[Sidebar]
-        SIDEBAR -->|Party item| PO2[PartyOverviewView]
-        SIDEBAR -->|Encounters item| EL2[EncounterLibraryView]
-        EL2 -->|selection| EB2[EncounterBuilderView\ndetail column]
-        EB2 -->|Run Encounter| ER2[EncounterRunnerView\nsheet]
+    subgraph Compendium Management
+        COMP --> LEFT_C[CompendiumAdversaryListPanel\nleft sidebar]
+        COMP --> RIGHT_C[AdversaryInspectorView\nright panel]
+        LEFT_C -->|selection| RIGHT_C
+        LEFT_C -->|sheet| ACF2[AdversaryCreatorForm]
+        LEFT_C -->|sheet| DHPE2[DHPackExportSheet]
+        RIGHT_C -->|Edit button| ACF2
     end
 
-    PO -->|sheet| PF[PlayerForm\nadd / edit]
-    EB -->|sheet| CB[CompendiumBrowserView]
-    CB -->|push| AD[AdversaryDetailView]
-    CB -->|push| ED[EnvironmentDetailView]
+    subgraph Run Mode
+        RUN --> LEFT_R[RunnerListPanel\nleft sidebar]
+        RUN --> RIGHT_R[RunnerDetailPanel\nright panel]
+        LEFT_R -->|expand row| RIGHT_R
+        LEFT_R -->|Pause| MODE
+        LEFT_R -->|End| MODE
+    end
 
-    EL -->|sheet| CS[ContentSourcesView]
-    EL -->|sheet| AB[AboutView]
-
-    ER --> PS[PlayerStrip\npinned bottom]
-    PS -->|popover| PE[PlayerEditPopover]
-    ER -->|toolbar popover| FT[FearTrackerButton popover]
+    CENTER_P -->|sheet| CSS2[CompendiumSelectorSheet]
 ```
 
 ---
@@ -107,22 +135,262 @@ flowchart TD
 
 ### ContentView
 
-Root container. On **iOS/visionOS** it is a `TabView` with two tabs. On **macOS** it is
-a three-column `NavigationSplitView` (sidebar → content → detail).
+Root container. Platform-specific navigation structure driven by `AppWindowMode` (macOS/iPadOS) or `iOSRootMode` (iOS/visionOS). See [ADR-0043](decisions/0043-platform-navigation-architecture.md).
 
 | Platform | Navigation model |
 |---|---|
-| iOS / visionOS | TabView — Party tab, Encounters tab |
-| macOS | NavigationSplitView — sidebar, content pane, detail pane |
+| iOS / visionOS | `NavigationStack` wrapping `EncounterAndPartyRootView` |
+| iPadOS | `NavigationSplitView` (3-panel in prep mode, 2-panel in compendium/run mode) |
+| macOS | `NavigationSplitView` (3-panel in prep mode, 2-panel in compendium/run mode) |
+
+---
+
+### `EncounterAndPartyRootView` — iOS root
+
+Single root screen for the iOS encounters workflow.
+
+**Layout**
+
+```
+┌─────────────────────────────────┐
+│  [Toolbar: ← Encounters | Compendium →]  │
+├─────────────────────────────────┤
+│  Encounter list (scrollable)    │
+│  ┌───────────────────────────┐  │
+│  │ EncounterLibraryRow       │  │  ← includes in-progress badge
+│  │ EncounterLibraryRow       │  │
+│  └───────────────────────────┘  │
+│  Divider                        │
+│  Party roster                   │
+│  ┌───────────────────────────┐  │
+│  │ PartyRosterRow            │  │  ← includes hide/unhide
+│  └───────────────────────────┘  │
+└─────────────────────────────────┘
+```
 
 **Accessibility identifiers**
 
 | Element | Identifier |
 |---|---|
-| Party tab (iOS) | `tab.party` |
-| Encounters tab (iOS) | `tab.encounters` |
-| Sidebar "Party" item (macOS) | `sidebar.party` |
-| Sidebar "Encounters" item (macOS) | `sidebar.encounters` |
+| Root mode toggle | `root.mode-toggle` |
+| Encounter row | `root.encounter-row` |
+| Party row | `root.party-row` |
+| In-progress badge | `library.row.in-progress-badge` |
+| Resume button (row) | `library.row.resume-button` |
+| Hide player button | `party.hide-button` |
+| Unhide player button | `party.unhide-button` |
+
+---
+
+### `CompendiumRootView` — iOS compendium
+
+Full-screen adversary list shown when the toolbar toggle is set to Compendium.
+
+**Layout**
+
+```
+┌─────────────────────────────────┐
+│  [Toolbar: ← Encounters | Compendium →]  │
+│  [Import DHPack] [Export] [+]   │
+├─────────────────────────────────┤
+│  AdversaryFilterBar             │
+├─────────────────────────────────┤
+│  Section: SRD (129 adversaries) │
+│  Section: [DHPack name]         │
+│  Section: Local                 │
+└─────────────────────────────────┘
+```
+
+---
+
+### `EncounterAndPartyPanel` — macOS/iPadOS sidebar (prep mode)
+
+Left panel of the 3-panel layout in encounter prep mode.
+
+**Layout**
+
+```
+┌─────────────────────────────────┐
+│  [+ New Encounter]              │
+│  Encounter list                 │
+│  ┌───────────────────────────┐  │
+│  │ EncounterLibraryRow       │  │
+│  └───────────────────────────┘  │
+│  ─────────────────────────────  │
+│  Party                  [+]     │
+│  ┌───────────────────────────┐  │
+│  │ PartyRosterRow            │  │
+│  └───────────────────────────┘  │
+└─────────────────────────────────┘
+```
+
+---
+
+### `CompendiumUtilityPanel` — macOS/iPadOS right panel (prep mode)
+
+Always-visible compendium panel in encounter prep mode. Replaces the Browse Compendium sheet.
+
+**Layout**
+
+```
+┌─────────────────────────────────┐
+│  AdversaryFilterBar             │
+├─────────────────────────────────┤
+│  Filtered adversary list        │
+│  ┌───────────────────────────┐  │
+│  │ AdversaryRow              │  │  ← tap to add to selected encounter
+│  └───────────────────────────┘  │
+├─────────────────────────────────┤
+│  [Import DHPack]                │
+└─────────────────────────────────┘
+```
+
+**Accessibility identifiers**
+
+| Element | Identifier |
+|---|---|
+| Utility panel root | `compendium.utility-panel` |
+| Filter bar | `compendium.filter-bar` |
+
+---
+
+### `CompendiumAdversaryListPanel` — macOS/iPadOS sidebar (compendium mode)
+
+Left panel when `AppWindowMode == .compendiumManagement`.
+
+**Layout**
+
+```
+┌─────────────────────────────────┐
+│  AdversaryFilterBar             │
+│  [+] [Import] [Export]          │
+├─────────────────────────────────┤
+│  Section: SRD                   │
+│  Section: [DHPack name]         │
+│  Section: Local                 │
+└─────────────────────────────────┘
+```
+
+---
+
+### `AdversaryInspectorView` — macOS/iPadOS right panel (compendium mode)
+
+Detail/editor panel for a selected adversary in compendium management mode.
+
+**States**
+
+| State | Display |
+|---|---|
+| No selection | Empty state placeholder |
+| SRD / DHPack adversary | Read-only stat card |
+| Local adversary | Stat card + Edit button → `AdversaryCreatorForm` |
+
+**Accessibility identifiers**
+
+| Element | Identifier |
+|---|---|
+| Inspector root | `compendium.inspector` |
+
+---
+
+### `RunnerListPanel` — macOS/iPadOS sidebar (run mode)
+
+Left panel when `AppWindowMode == .runningEncounter(_)`.
+
+**Layout**
+
+```
+┌─────────────────────────────────┐
+│  [Pause]            [End]       │
+│  🔥 Fear: 3         [+] [-]     │
+├─────────────────────────────────┤
+│  AdversaryRunnerSection         │
+│  ┌───────────────────────────┐  │
+│  │ AdversaryRunnerRow        │  │
+│  │ AdversaryRunnerCard (exp.)│  │
+│  └───────────────────────────┘  │
+│  PlayerRunnerSection            │
+│  ┌───────────────────────────┐  │
+│  │ PlayerRunnerRow           │  │
+│  └───────────────────────────┘  │
+└─────────────────────────────────┘
+```
+
+**Accessibility identifiers**
+
+| Element | Identifier |
+|---|---|
+| List panel root | `runner.list-panel` |
+| Pause button | `runner.pause-button` |
+
+---
+
+### `RunnerDetailPanel` — macOS/iPadOS right panel (run mode)
+
+Reference view showing stats for the currently expanded adversary or player.
+
+**States**
+
+| State | Display |
+|---|---|
+| Nothing expanded | Placeholder |
+| Adversary expanded | `AdversaryStatReference` + `FeatureSectionsView` |
+| Player expanded | `PlayerRunnerCard` content |
+
+**Accessibility identifiers**
+
+| Element | Identifier |
+|---|---|
+| Detail panel root | `runner.detail-panel` |
+
+---
+
+### `AdversaryCreatorForm` — all platforms
+
+Multi-step form for creating or editing a local adversary. Presented as `.sheet` on all platforms.
+
+**Steps**
+
+1. Identity — name, type, tier; SRD peer reference panel
+2. Stats — HP, stress, difficulty, thresholds, evasion; soft range indicators
+3. Attack & Features — attack stats; feature list (add passive/action/reaction)
+4. Review — stat card preview; out-of-range summary; Save
+
+**Accessibility identifiers**
+
+| Element | Identifier |
+|---|---|
+| Form root | `adversary-creator.form` |
+| Step indicator | `adversary-creator.step` |
+| Next button | `adversary-creator.next-button` |
+| Back button | `adversary-creator.back-button` |
+| Save button | `adversary-creator.save-button` |
+
+---
+
+### `CompendiumSelectorSheet` — all platforms
+
+Modal adversary selector opened from the encounter editor. Selection-only — no create or export.
+
+**Accessibility identifiers**
+
+| Element | Identifier |
+|---|---|
+| Sheet root | `compendium.selector-sheet` |
+| Filter bar | `compendium.filter-bar` |
+
+---
+
+### `DHPackExportSheet` — all platforms
+
+Multi-select sheet for exporting local adversaries as a `.dhpack` file.
+
+**Accessibility identifiers**
+
+| Element | Identifier |
+|---|---|
+| Sheet root | `dhpack-export.sheet` |
+| Export button | `dhpack-export.export-button` |
 
 ---
 
@@ -717,16 +985,19 @@ Reusable components that appear across multiple screens.
 
 ## Platform Layout Differences
 
-| Feature | iOS / visionOS | macOS |
-|---|---|---|
-| Root navigation | TabView (Party, Encounters) | NavigationSplitView (sidebar + content + detail) |
-| Encounter runner presentation | `fullScreenCover` | Sheet |
-| List actions | Swipe actions (trailing) | Context menus |
-| Navigation bar style | `.large` on main screens, `.inline` on modals | Standard |
-| Numeric input keyboard | `.numberPad` on relevant fields | Standard text input |
-| About screen access | Toolbar button in Encounters tab | Menu bar command |
-| New encounter dialog | `.alert` with text field | `.alert` with text field |
-| Compendium sheet sizing | Adaptive | `minWidth: 540, minHeight: 480` |
+| Feature | iOS / visionOS | iPadOS | macOS |
+|---|---|---|---|
+| Root navigation | `NavigationStack` | `NavigationSplitView` (3-panel) | `NavigationSplitView` (3-panel) |
+| Mode switch control | Segmented toolbar toggle | Segmented toolbar toggle | Menu command (`View →`) |
+| Encounter runner presentation | Push on `NavigationStack` | Same-window mode swap | Same-window mode swap |
+| Party location | Bottom of root screen | Bottom of left sidebar | Bottom of left sidebar |
+| Compendium in prep mode | Sheet (`CompendiumSelectorSheet`) | Right utility panel (always visible) | Right utility panel (always visible) |
+| Compendium management mode | Full-screen `CompendiumRootView` (toolbar toggle) | 2-panel split (sidebar + inspector) | 2-panel split (sidebar + inspector) |
+| List actions | Swipe actions (trailing) | Context menus + swipe | Context menus |
+| Navigation bar style | `.large` on main screens, `.inline` on pushed screens | Standard | Standard |
+| Numeric input keyboard | `.numberPad` on relevant fields | Adapts to keyboard/touch | Standard text input |
+| About screen access | Toolbar button | Toolbar button | Menu bar command |
+| New encounter dialog | `.alert` with text field | `.alert` with text field | `.alert` with text field |
 
 ---
 
@@ -736,16 +1007,21 @@ Reusable components that appear across multiple screens.
 |---|---|
 | **Encounter** | A saved encounter definition (name, adversaries, environment, notes) |
 | **Session** | A live, in-progress run of an encounter (mutable state) |
+| **SessionPhase** | Lifecycle state of a session: `.running` (active) or `.paused` (saved, resumable) |
 | **Adversary slot** | One instance of an adversary in a live session (has its own HP, stress, name, conditions) |
 | **Player slot** | One player character's runtime state (current HP, stress, armor, conditions) |
-| **Active Party** | Players currently assigned to participate in encounters |
-| **Roster** | All saved players, including those not in the active party |
+| **Party** | The single active party roster; one party per app instance |
+| **Hidden player** | A party member temporarily excluded from active sessions (global flag, not deleted) |
 | **Compendium** | The full catalog of available adversaries and environments |
-| **Content pack** (.dhpack) | A bundle of homebrew adversaries/environments importable into the Compendium |
+| **Content pack** (.dhpack) | A bundle of adversaries/environments; importable (read-only) or exportable from local adversaries |
+| **SRD adversaries** | Bundled, read-only adversaries from the Daggerheart SRD |
+| **Local adversaries** | Custom adversaries created in the app and stored in the `homebrew/` directory |
+| **AppWindowMode** | macOS/iPadOS window state enum: `.encounterPrep`, `.compendiumManagement`, `.runningEncounter` |
+| **iOSRootMode** | iOS root screen state: `.encounters` or `.compendium` |
 | **Budget Points (BP)** | Difficulty currency; each adversary costs BP; GM adjustments shift the total |
 | **Fear pool** | Shared GM resource tracked live in the runner; spent for monster actions |
 | **Condition** | A named status (e.g., Restrained, Vulnerable) toggled on a slot during a session |
 | **Threshold** | HP damage bracket (Minor / Major / Severe) at which special effects trigger |
 | **PipTrack** | The visual HP/Stress indicator — circles for small values, "X/Y" text for large ones |
-| **PlayerStrip** | The always-visible player panel pinned to the bottom of the runner screen |
 | **Accordion** | The runner's single-expand pattern: tapping a slot expands it and collapses the previous one |
+| **In-progress badge** | Visual indicator on an encounter row when a paused session exists for that encounter |

--- a/docs/ux-requirements.md
+++ b/docs/ux-requirements.md
@@ -1,0 +1,572 @@
+# Encounter — UX Requirements
+
+Per-platform screen structure, interaction patterns, and component responsibilities.
+Authoritative reference for all implementation work. Derived from the planning session of 2026-05-03.
+
+For architectural decisions see [ADR-0043](decisions/0043-platform-navigation-architecture.md),
+[ADR-0044](decisions/0044-encounter-session-lifecycle.md),
+[ADR-0045](decisions/0045-compendium-management-mode.md),
+[ADR-0046](decisions/0046-single-party-hidden-members.md).
+
+For the full implementation milestone breakdown see [docs/redesign-plan.md](redesign-plan.md).
+
+---
+
+## Design Principles for This Redesign
+
+1. **Platform-native, not least-common-denominator.** iOS uses push navigation; macOS and iPadOS use split views with mode switching. No shared structural compromise.
+2. **Modes, not destinations.** Encounter prep, compendium management, and live running are window/screen *modes* — not screens you navigate to and back from. Transitions communicate the change in context.
+3. **Creator and executor are separate.** Prep work (building encounters, managing the compendium) is visually and navigationally distinct from running work (live combat tracking). You cannot accidentally enter prep UI during a live encounter.
+4. **The encounter is always the unit of work.** The party, the compendium, and the runner all serve the encounter. Navigation always returns to the encounter list as the root.
+
+---
+
+## Platform Summary
+
+| Platform | Root navigation | Mode switch | Runner transition |
+|---|---|---|---|
+| iOS | `NavigationStack` | Toolbar segmented toggle | Push on stack |
+| iPadOS | `NavigationSplitView` (3-panel) | Toolbar segmented toggle | Same-window mode swap |
+| macOS | `NavigationSplitView` (3-panel) | Menu command | Same-window mode swap |
+| visionOS | Follows iOS layout | — | — |
+
+---
+
+## iOS Requirements
+
+### Root Screen (`EncounterAndPartyRootView`)
+
+**Navigation:** Root of a `NavigationStack`. No tabs.
+
+**Toolbar:** Centered segmented control — **Encounters** | **Compendium**. Controls `iOSRootMode` state.
+
+**Encounters mode content (default):**
+
+Top half — Encounter list:
+- Scrollable list of `EncounterDefinition` rows
+- Each row: encounter name + relative modified date
+- In-progress badge ("In Progress") shown when a paused session exists for that encounter
+- Run affordance: tapping the row body pushes to `EncounterEditorView`; a "Run" / "Resume" button in the row runs or resumes directly
+- Swipe actions: rename, delete (with confirmation)
+- Empty state: `ContentUnavailableView` with a "New Encounter" button
+- New encounter: toolbar (+) button, alert for name
+
+Bottom half — Party list:
+- Single party roster; no party switching
+- Each player row: name, level/tier badge, hide/unhide toggle
+- Hidden players: grayed text, `eye.slash` icon, "Unhide" swipe action
+- Active players: normal style, "Hide" swipe action, "Edit" swipe action
+- Add player: toolbar (+) button → `PlayerForm` sheet
+- Delete player: swipe trailing delete (confirmation required)
+
+**Compendium mode content:**
+Entire screen replaced by `CompendiumRootView` — see below.
+
+---
+
+### Compendium Root (`CompendiumRootView`) — iOS only
+
+**Navigation:** Nested within the root `NavigationStack`.
+
+**Content:**
+- `AdversaryFilterBar` pinned at top (search + tier + type filters)
+- Grouped adversary list: **SRD** section (read-only) | one section per loaded DHPack (read-only) | **Local** section (editable, may be empty)
+- Tapping an adversary row pushes to `AdversaryDetailView`
+- Local adversary `AdversaryDetailView` includes an "Edit" button → `AdversaryCreatorForm` sheet
+
+**Toolbar actions:**
+- "Add Adversary" (+) → `AdversaryCreatorForm` sheet (creates in Local section)
+- "Import DHPack" (archive icon) → file importer → `contentStore.importPack(from:)`
+- "Export Local" (share icon) → `DHPackExportSheet` sheet (only enabled when Local section is non-empty)
+
+---
+
+### Encounter Editor (`EncounterEditorView`) — iOS
+
+**Navigation:** Pushed from encounter row in `EncounterAndPartyRootView`.
+
+**Header:** Encounter name (editable inline or via rename action), back button.
+
+**Toolbar:**
+- **Run** button (or **Resume** when a paused session exists) — pushes to `EncounterRunnerView`
+- **Browse Compendium** (books icon) → `CompendiumSelectorSheet` sheet
+
+**Form sections:**
+1. Adversaries — editable list; "+" opens `CompendiumSelectorSheet`; swipe-to-delete
+2. Environment — 0 or 1; "Add" / "Replace" button
+3. Notes — collapsible `DisclosureGroup` with `TextEditor`
+
+**Footer (fixed, non-scrolling):**
+- `DifficultyAssessorView` — budget summary + color indicator + GM toggles
+
+---
+
+### Compendium Selector Sheet (`CompendiumSelectorSheet`) — iOS (and all platforms)
+
+**Presentation:** `.sheet` from encounter editor.
+
+**Purpose:** Selection only — not management. Adds adversaries to the current encounter.
+
+**Content:**
+- `AdversaryFilterBar` at top
+- Filtered adversary list (all sources: SRD + DHPacks + Local)
+- Tapping a row calls `onSelect(adversary)` and dismisses the sheet
+- "Import DHPack" toolbar button — adds a pack to the compendium without dismissing
+
+---
+
+### Encounter Runner (`EncounterRunnerView`) — iOS
+
+**Navigation:** Pushed from `EncounterEditorView`. Standard push transition.
+
+**Layout:** Single `List` with accordion sections:
+1. Adversary runner section (collapsed/expanded rows per ADR-0042 + ADR-0022)
+2. Player runner section (same accordion pattern)
+
+**Toolbar:**
+- Fear tracker button (🔥 N) — popover
+- **Pause** button — calls `session.pause()`, saves session, pops navigation back to editor
+- **End Encounter** button — destructive confirm → clears session, pops navigation
+
+**On pop (Pause):** encounter row in the root list now shows "In Progress" badge. "Resume" re-enters the runner with the saved session.
+
+---
+
+## iPadOS and macOS Requirements
+
+iPadOS and macOS share the same `AppWindowMode`-driven layout. They differ only in the mode switch control and minor idiom adjustments.
+
+---
+
+### `AppWindowMode` states
+
+| Mode | Columns visible | Left panel | Right panel |
+|---|---|---|---|
+| `.encounterPrep` | 3 | `EncounterAndPartyPanel` | `CompendiumUtilityPanel` |
+| `.compendiumManagement` | 2 (sidebar + detail) | `CompendiumAdversaryListPanel` | `AdversaryInspectorView` |
+| `.runningEncounter(session)` | 2 (sidebar + detail) | `RunnerListPanel` | `RunnerDetailPanel` |
+
+Center column: `EncounterEditorView` (only visible in `.encounterPrep`).
+
+---
+
+### Encounter Prep Mode — 3-panel
+
+**Left panel (`EncounterAndPartyPanel`):**
+
+Top section — Encounter list:
+- Rows: name, in-progress badge, "Run" / "Resume" button per row
+- Tapping row body selects the encounter (drives center column)
+- Context menu: rename, delete
+- Toolbar: "+" to create new encounter
+
+Bottom section — Party roster:
+- Single party; no party switching
+- Each player: name, level/tier badge
+- Hidden players: grayed, `eye.slash` icon, "Unhide" contextual action
+- Add player: "+" button → `PlayerForm` sheet
+- Edit player: contextual action → `PlayerForm` sheet
+- Delete player: contextual action (confirmation)
+- Hide/unhide player: contextual action
+
+**Center column (`EncounterEditorView`):**
+- Same sections as iOS editor (Adversaries, Environment, Notes, `DifficultyAssessorView`)
+- No "Browse Compendium" sheet button — the right panel replaces it
+- "Run" / "Resume" toolbar button → sets `windowMode = .runningEncounter(session)`
+
+**Right panel (`CompendiumUtilityPanel`):**
+- `AdversaryFilterBar` at top
+- Filtered adversary list (all sources); tapping a row calls `onSelect` to add to the currently selected encounter
+- "Import DHPack" button at bottom
+- Empty state when no encounter is selected in the center column
+
+---
+
+### Compendium Management Mode — 2-panel
+
+**Mode entry:**
+- macOS: `View → Compendium` menu command
+- iPadOS: segmented toolbar toggle (Encounters | Compendium)
+
+**Left panel (`CompendiumAdversaryListPanel`):**
+- `AdversaryFilterBar` at top (filters all groups)
+- Grouped list: **SRD** | [DHPack name] per loaded pack | **Local**
+- Selection drives right panel
+- Toolbar: "+" → `AdversaryCreatorForm`; "Import DHPack" icon; "Export Local" icon
+
+**Right panel (`AdversaryInspectorView`):**
+- No adversary selected: empty state / placeholder
+- SRD or DHPack adversary selected: read-only stat card (full `AdversaryDetailView` content)
+- Local adversary selected: same stat card + "Edit" button → `AdversaryCreatorForm` in edit mode (presented as sheet or inline)
+- No "Add to Encounter" action (this mode is for management, not selection)
+
+**Mode exit:**
+- macOS: `View → Encounters` menu command
+- iPadOS: segmented toolbar toggle back to Encounters
+- `windowMode` returns to `.encounterPrep`
+
+---
+
+### Run Mode — 2-panel
+
+**Mode entry:** "Run" / "Resume" button in `EncounterEditorView` toolbar. Sets `windowMode = .runningEncounter(session)`.
+
+**Left panel (`RunnerListPanel`):**
+- Adversary section: `AdversaryRunnerSection` (reused — accordion rows)
+- Player section: `PlayerRunnerSection` (reused — accordion rows)
+- Expanding a row drives the right panel
+- Defeated adversaries: dimmed, sorted to bottom
+- **Pause** button: calls `session.pause()`, saves, resets `windowMode = .encounterPrep`
+- **End Encounter** button: destructive confirm, clears session, resets `windowMode = .encounterPrep`
+- Fear tracker: accessible from this panel (popover button or inline display)
+
+**Right panel (`RunnerDetailPanel`):**
+- Nothing expanded: empty state / placeholder
+- Adversary expanded: read-only `AdversaryStatReference` + `FeatureSectionsView` for the selected slot's adversary
+- Player expanded: `PlayerRunnerCard` content (HP/Stress/Armor steppers + conditions) — note: editing player state from the right panel is acceptable since the accordion card in the left panel and the right panel can show complementary information
+- Right panel is reference/context; damage/stress actions stay in the left accordion card
+
+---
+
+## Shared Component Requirements
+
+### `AdversaryFilterBar`
+
+**Inputs (bindings):** `searchText: String`, `selectedTier: Int?`, `selectedType: AdversaryType?`
+
+**Controls:**
+- Text search field — filters by adversary name (case-insensitive, partial match)
+- Tier picker — nil = all tiers; 1–5 for specific tier
+- Type filter menu — nil = all types; one of `AdversaryType` cases
+
+**Filtering logic:** All active filters compose with AND. Empty search text + nil tier + nil type = no filter (show all).
+
+**Used by:** `CompendiumSelectorSheet`, `CompendiumAdversaryListPanel`, `CompendiumRootView`, `CompendiumUtilityPanel`
+
+---
+
+### `CompendiumSelectorSheet`
+
+**Init parameters:** `compendium: Compendium`, `contentStore: ContentStore`, `onSelect: (Adversary) -> Void`
+
+**Content:** `AdversaryFilterBar` + filtered adversary list (all sources)
+
+**Behaviors:**
+- Tapping an adversary row immediately calls `onSelect(_:)` and dismisses
+- "Import DHPack" toolbar button presents file importer; successful import adds pack to compendium without dismissing the sheet
+- "Done" button always visible to dismiss without selection
+
+---
+
+### `AdversaryCreatorForm`
+
+**Modes:** create (new local adversary) or edit (existing local adversary)
+
+**Steps:**
+1. Identity — name, `AdversaryType` picker, tier (1–5 stepper); reference panel shows 2–3 SRD peers
+2. Stats — HP, stress, difficulty, major threshold, severe threshold, evasion; each numeric field shows a soft range indicator (teal = within range, amber = above average, red = outlier) derived from SRD peer stats
+3. Attack & Features — attack name, modifier (Int), range (text), damage string; feature list with add/remove (each feature has name, kind: passive/action/reaction, description)
+4. Review — full stat card preview matching how the adversary will appear in `AdversaryDetailView`; list of any out-of-range stats (advisory only); Save button
+
+**Validation:**
+- Name must be non-empty and unique within local collection (soft error on Save, not on typing)
+- Out-of-range stats are surfaced as soft warnings, never as hard blocks
+- All fields have defaults based on tier and type
+
+**Save behavior:** calls `contentStore.saveLocalAdversary(_:)` → adversary appears in Local section of compendium views
+
+---
+
+### `DHPackExportSheet`
+
+**Init parameter:** `contentStore: ContentStore` (provides local adversary list)
+
+**Content:** Multi-select list of local adversaries (name + tier + type); "Export Selected" button (disabled when nothing selected)
+
+**Export flow:** assembles `DHPackContent` from selected adversaries → writes to `FileManager.default.temporaryDirectory/<name>.dhpack` → presents `ShareLink` (or `UIActivityViewController` on iOS < 16)
+
+---
+
+## Encounter Session Lifecycle
+
+```
+(session created from encounter definition) → phase = .running → EncounterRunnerView / RunnerListPanel
+  │
+  ├── GM taps Pause
+  │     └── session.pause() → SessionStore.save() → return to encounter list/editor
+  │           └── encounter row shows "In Progress" badge
+  │                 ├── GM taps Resume → session.resume() → re-enter runner
+  │                 └── GM taps End (from paused) → SessionStore.delete() + SessionRegistry.clear() → badge gone
+  │
+  └── GM taps End Encounter (while running)
+        └── SessionStore.delete() + SessionRegistry.clear() → return to encounter list/editor
+```
+
+Sessions with `phase == .paused` are displayed inline; no launch-time modal needed.
+
+---
+
+## Party Requirements
+
+- **Single party:** one party roster, no switching
+- **Hidden members:** `PlayerStore.hiddenPlayerIDs: Set<UUID>` — players in this set are excluded from `activePartyPlayers` and from session snapshots
+- **Display:** hidden players shown in party list with distinct style (`eye.slash` icon, grayed); always visible so they can be un-hidden
+- **Party management location:** bottom section of the left panel on macOS/iPadOS; bottom section of the encounters mode root view on iOS
+
+---
+
+## Difficulty Indicator
+
+`DifficultyAssessorView` remains in the encounter editor (iOS: fixed to bottom; macOS/iPadOS: fixed to bottom of center column). It consumes `activePartyPlayers` (which excludes hidden members) for party-tier calculations. No change to the underlying `DifficultyBudget` logic.
+
+---
+
+## Content Sources (DHPack)
+
+DHPacks are import/export bundles. They are not editable in place.
+
+| Operation | Where |
+|---|---|
+| Import DHPack | Compendium selector sheet (all platforms), Compendium root view (iOS), Compendium list panel (macOS/iPadOS) |
+| Export local collection | Compendium root view toolbar (iOS), Compendium list panel toolbar (macOS/iPadOS) |
+| Remove loaded DHPack | Content Sources management (existing `ContentSourcesView`) |
+| View loaded DHPacks | Grouped sections in compendium list views |
+
+---
+
+## Accessibility Identifiers (New and Changed)
+
+| Element | Identifier |
+|---|---|
+| Root mode toggle | `root.mode-toggle` |
+| Encounter row (iOS root) | `root.encounter-row` |
+| Party row (iOS root) | `root.party-row` |
+| Hide player button | `party.hide-button` |
+| Unhide player button | `party.unhide-button` |
+| In-progress badge | `library.row.in-progress-badge` |
+| Resume button (row) | `library.row.resume-button` |
+| Compendium utility panel | `compendium.utility-panel` |
+| Adversary filter bar | `compendium.filter-bar` |
+| Filter bar search field | `compendium.filter-bar.search` |
+| Filter bar tier picker | `compendium.filter-bar.tier` |
+| Filter bar type menu | `compendium.filter-bar.type` |
+| Compendium selector sheet | `compendium.selector-sheet` |
+| Adversary inspector | `compendium.inspector` |
+| Adversary creator form | `adversary-creator.form` |
+| Creator step indicator | `adversary-creator.step` |
+| Creator next button | `adversary-creator.next-button` |
+| Creator back button | `adversary-creator.back-button` |
+| Creator save button | `adversary-creator.save-button` |
+| DHPack export sheet | `dhpack-export.sheet` |
+| DHPack export button | `dhpack-export.export-button` |
+| Runner list panel | `runner.list-panel` |
+| Runner detail panel | `runner.detail-panel` |
+| Pause button | `runner.pause-button` |
+| Window mode toggle (iPadOS) | `window.mode-toggle` |
+
+---
+
+## macOS and iPadOS Native Design
+
+Full specification in [ADR-0047](decisions/0047-macos-ipados-toolbar-menu-keyboard.md).
+This section is the authoritative implementation reference extracted from that ADR.
+
+---
+
+### Inspector (Right Panel)
+
+The right panel is implemented as an AppKit/SwiftUI inspector using `.inspectorTrackingSeparator` and `.toggleInspector`. It is user-hideable.
+
+**Default visibility per mode:**
+
+| Mode | Default | Rationale |
+|---|---|---|
+| `.encounterPrep` | **Open** | The compendium utility panel is the primary workflow affordance in prep |
+| `.compendiumManagement` | **Open** | The adversary inspector is the central detail view in management mode |
+| `.runningEncounter` | **Hidden** | Runner list gets full width by default; GM reveals reference panel when needed |
+
+Toggle shortcut: `⌃⌘I` (AppKit `.toggleInspector` built-in). Anchored as trailing-most toolbar item in all modes.
+
+---
+
+### Toolbar Design per Mode
+
+Toolbar items follow mental-model ordering (most-used → left). Use AppKit built-in identifiers where available.
+
+**Fixed items present in all modes:**
+
+- Leading anchor: `.toggleSidebar` + `.sidebarTrackingSeparator`
+- Trailing anchor: `.inspectorTrackingSeparator` + `.toggleInspector`
+
+**Encounter Prep — content zone items (contributed by `EncounterEditorView`):**
+- Run / Resume button (enabled only when an encounter is open in the center column)
+
+**Compendium Management — content zone items:**
+- No additional toolbar items; all management actions (Add, Import, Export) live in the sidebar bottom bar
+- `NSSearchToolbarItem` may be added here if global search is desired
+
+**Running Encounter — content zone items:**
+- Pause button (`⌘.`)
+- End Encounter button (no keyboard shortcut — destructive)
+- Fear Tracker button (`FearTrackerButton`)
+
+**iPadOS only — centered item (contributed by `ContentView`):**
+- `NSToolbarItemGroup` segmented picker: Encounters | Compendium (mode switch)
+
+---
+
+### Sidebar Bottom Bars
+
+Per Mario Guzmán's sidebar guidelines, actions that create, delete, or modify sidebar content belong in the **sidebar's bottom bar** (`safeAreaBar(edge:alignment:spacing:content:)`), not the toolbar zone.
+
+**`EncounterAndPartyPanel` — Encounter list bottom bar:**
+- [+] New Encounter
+- [−] Delete selected encounter (enabled when an encounter is selected; confirmation required)
+
+**`EncounterAndPartyPanel` — Party list bottom bar:**
+- [+] Add Player → `PlayerForm` sheet
+- [−] Remove selected player (confirmation required)
+
+**`CompendiumAdversaryListPanel` — Adversary list bottom bar:**
+- [+] Add Adversary → `AdversaryCreatorForm`
+- [↓] Import DHPack → file importer
+- [↑] Export Local → `DHPackExportSheet`
+
+The sidebar toolbar zone contains only `.toggleSidebar` and `.sidebarTrackingSeparator` — no additional items.
+
+---
+
+### Menu Structure
+
+```
+Encounter (app menu)
+  About Encounter
+  ─────
+  Settings…                     ⌘,
+  ─────
+  Hide Encounter                 ⌘H
+  Hide Others                    ⌥⌘H
+  Quit Encounter                 ⌘Q
+
+File
+  New Encounter                  ⌘N         (context: encounter mode)
+  New Adversary                  ⌘N         (context: compendium mode)
+  ─────
+  Rename…                                   (enabled: item selected)
+  Delete…                        ⌫          (enabled: item selected; confirmation required)
+  ─────
+  Import DHPack…                 ⇧⌘I
+  Export Local Adversaries…                 (enabled: local adversaries exist)
+
+Edit
+  Undo                           ⌘Z
+  Redo                           ⇧⌘Z
+  ─────
+  Cut                            ⌘X
+  Copy                           ⌘C
+  Paste                          ⌘V
+  Select All                     ⌘A
+
+Encounter                                   (top-level menu; actions are contextual)
+  Run Encounter                  ⌘R         (enabled: encounter selected, no active session)
+  Resume Encounter               ⌘R         (enabled: paused session for selection)
+  ─────
+  Pause Encounter                ⌘.         (enabled: session running)
+  End Encounter                             (enabled: session running or paused; confirmation)
+  ─────
+  Reset Encounter                           (enabled: session exists; confirmation)
+
+View
+  Show/Hide Sidebar              ⌃⌘S
+  Show/Hide Inspector            ⌃⌘I
+  ─────
+  Encounters                     ⌘1         (mode switch)
+  Compendium                     ⌘2         (mode switch)
+
+Window
+  (standard AppKit items)
+
+Help
+  Encounter Help
+  (search bar)
+```
+
+**Implementation notes:**
+- `CommandMenu("File")` is context-sensitive: checks `AppWindowMode` — creates encounter in `.encounterPrep`, creates adversary in `.compendiumManagement`
+- `CommandMenu("Encounter")` uses `CommandMenu("Encounter")`. Items enable/disable based on `encounterSelection` and `AppWindowMode`
+- `Run Encounter` / `Resume Encounter` share `⌘R`; only one is enabled at a time
+- `EncounterApp.swift` gains a full `Commands` block with `CommandMenu("File")`, `CommandMenu("Encounter")`, `CommandMenu("View")`, and `CommandGroup(replacing:)` entries
+
+---
+
+### Keyboard Shortcuts
+
+| Action | macOS | iPadOS | Notes |
+|---|---|---|---|
+| New Encounter (encounter mode) | ⌘N | ⌘N | |
+| New Adversary (compendium mode) | ⌘N | ⌘N | Same key, different context |
+| Delete selected item | ⌫ | ⌫ | Confirmation required |
+| Rename selected item | ↩ | ↩ | Opens inline rename or alert |
+| Open / edit selected encounter | ⌘↩ | ⌘↩ | Focus center column |
+| Run Encounter | ⌘R | ⌘R | Disabled when running; shows Resume label when paused |
+| Resume Encounter | ⌘R | ⌘R | Shares key with Run; only one enabled at a time |
+| Pause Encounter | ⌘. | ⌘. | Standard Mac "stop" chord |
+| End Encounter | — | — | No shortcut — destructive |
+| Reset Encounter | — | — | No shortcut — destructive |
+| Mode: Encounters | ⌘1 | ⌘1 | |
+| Mode: Compendium | ⌘2 | ⌘2 | |
+| Toggle Sidebar | ⌃⌘S | ⌃⌘S | AppKit `.toggleSidebar` built-in |
+| Toggle Inspector | ⌃⌘I | ⌃⌘I | AppKit `.toggleInspector` built-in |
+| Focus search / filter bar | ⌘F | ⌘F | |
+| Add Adversary to Encounter | ⌘⇧A | ⌘⇧A | From compendium row or utility panel |
+| Import DHPack | ⌘⇧I | — | |
+| Settings | ⌘, | — | |
+
+**No shortcut for Fear Tracker** — GM uses pointing device during a run; the Fear popover is the right affordance.
+**No shortcuts for End or Reset** — both are destructive; deliberate menu navigation or button tap is the intended path.
+
+**iPadOS hardware keyboard:** All shortcuts above apply. Additionally: arrow keys navigate selected list item; Return opens/renames; Escape dismisses sheets and deselects.
+
+---
+
+### Drag and Drop
+
+- **Source:** Adversary rows in `CompendiumUtilityPanel` (prep mode, right panel)
+- **Target:** Adversary list in `EncounterEditorView` (center column)
+- **Behavior:** Drop adds the adversary to the encounter (same as tapping the row). Duplicate detection: if already in encounter, ask to add a second slot or do nothing.
+- **API:** `draggable(adversary)` on the row; `.dropDestination(for: Adversary.self)` on the list or an explicit drop zone within the adversaries section
+- **iPadOS:** Touch drag works with the same SwiftUI API
+
+Drag is not in scope between other panels (no reorder, no drag from runner, etc.).
+
+---
+
+### Window and Panel Constraints
+
+```swift
+// WindowGroup content (EncounterApp.swift)
+.frame(minWidth: 900, minHeight: 560)
+
+// Sidebar (EncounterAndPartyPanel, CompendiumAdversaryListPanel, RunnerListPanel)
+// min 240 pt, max 360 pt
+
+// Inspector (CompendiumUtilityPanel, AdversaryInspectorView, RunnerDetailPanel)
+// min 280 pt, max 400 pt
+```
+
+---
+
+### Mac Polish Requirements
+
+All interactive controls **must** have a `.help("description")` tooltip modifier.
+
+**State restoration:** Use `@SceneStorage` for `AppWindowMode` and `selectedEncounterID` so the window state persists across launches.
+
+**Dock menu:** Override `applicationDockMenu` to offer:
+- "New Encounter" (always)
+- "Resume [encounter name]" (only when a paused session exists)
+
+**Spotlight keywords** in `Info.plist` (`MDItemKeywords`):
+`daggerheart, encounter, gm, gamemaster, ttrpg, rpg, adversary, combat`
+
+**Credits.rtf** in bundle resources for the standard About window.


### PR DESCRIPTION
## Summary

Records the complete platform redesign direction from the 2026-05-03 planning session. All docs — no production code changes. Establishes the ADR and requirements foundation that every implementation milestone will reference.

- **5 new ADRs** covering navigation architecture, session lifecycle, compendium mode, party model, and macOS/iPadOS native design (toolbar, menus, inspector, keyboard shortcuts)
- **`docs/ux-requirements.md`** — authoritative per-platform screen structure, interaction patterns, and component responsibilities; includes a full macOS native design section (inspector defaults, toolbar per mode, menu structure, keyboard shortcut table, drag-and-drop, window constraints, Mac polish)
- **`docs/redesign-plan.md`** — milestone breakdown (M0–M8) with discrete GitHub issues, TDD approach, and verification criteria per milestone
- **`docs/first-principles.md`** — Principle 12 added: iOS, iPadOS, and macOS are all first-class targets with distinct navigation idioms
- **`docs/ui-vocabulary.md`** — navigation maps replaced, new screen entries, updated terminology
- **ADR-0019, ADR-0040** — status lines updated to superseded

## Milestones defined

| # | Title | Key deliverable |
|---|---|---|
| 0 | Documentation & ADRs | This PR |
| 1 | Foundation — Model & Shared Infrastructure | `SessionPhase`, `PlayerStore` hide/show, `AdversaryFilterBar`, `CompendiumSelectorSheet` |
| 2 | iOS Root View Redesign | `NavigationStack` root, `EncounterAndPartyRootView`, `CompendiumRootView` |
| 3 | iOS Encounter Editor & Run Mode | Push nav, pause/resume lifecycle |
| 4 | macOS/iPadOS — Encounter Prep (3-panel) | `AppWindowMode`, all prep panels, Commands block, inspector, drag-drop, Mac polish |
| 5 | macOS/iPadOS — Compendium Mode | `CompendiumAdversaryListPanel`, `AdversaryInspectorView` |
| 6 | macOS/iPadOS — Run Mode | `RunnerListPanel`, `RunnerDetailPanel`, run mode toolbar |
| 7 | Custom Adversary Creation | `AdversaryCreatorForm` (4 steps) |
| 8 | DHPack Export | `DHPackExportSheet` |

## Test plan

- [ ] Confirm all linked ADR files render correctly in GitHub markdown
- [ ] Verify `docs/redesign-plan.md` issue lists match the sub-section details (no orphaned items)
- [ ] Confirm ADR-0019 and ADR-0040 status lines read "Superseded by ADR-0043"
- [ ] Confirm `docs/first-principles.md` Principle 12 is present and references Principle 9