### PR TITLE
feat: PlayerStore hiddenPlayerIDs persistence + hide/reveal methods

### DIFF
--- a/Encounter/Services/PlayerStore.swift
+++ b/Encounter/Services/PlayerStore.swift
@@ -50,12 +50,17 @@ public final class PlayerStore {
   /// Non-nil if the last `load()` or a persist operation failed.
   public private(set) var loadError: (any Error)?
 
+  /// Player IDs that are hidden from the active encounter roster.
+  /// This is a roster-wide flag — independent of party membership.
+  public private(set) var hiddenPlayerIDs: Set<UUID> = []
+
   // MARK: - Storage
 
   private var directory: URL
 
   private var playersURL: URL { directory.appending(path: "players.json") }
   private var partyURL: URL { directory.appending(path: "party.json") }
+  private var hiddenURL: URL { directory.appending(path: "hidden-players.json") }
 
   // MARK: - Init
 
@@ -80,13 +85,16 @@ public final class PlayerStore {
     directory = newDirectory
     players = []
     party = Party(name: "Active Party")
+    hiddenPlayerIDs = []
   }
 
   // MARK: - Computed
 
-  /// Active party members resolved in party order.
+  /// Active party members resolved in party order, excluding hidden players.
   public var activePartyPlayers: [Player] {
-    party.playerIDs.compactMap { id in players.first { $0.id == id } }
+    party.playerIDs
+      .filter { !hiddenPlayerIDs.contains($0) }
+      .compactMap { id in players.first { $0.id == id } }
   }
 
   // MARK: - Player Operations
@@ -107,11 +115,26 @@ public final class PlayerStore {
     await persist()
   }
 
-  /// Removes the player from the roster and from the party, then persists.
+  /// Removes the player from the roster, the party, and hidden IDs, then persists.
   /// No-op if the ID is not found.
   public func deletePlayer(id: UUID) async {
     players.removeAll { $0.id == id }
     party.playerIDs.removeAll { $0 == id }
+    hiddenPlayerIDs.remove(id)
+    await persist()
+  }
+
+  // MARK: - Hide / Show
+
+  /// Hide a player from the active encounter roster. No-op if already hidden.
+  public func hidePlayer(id: UUID) async {
+    hiddenPlayerIDs.insert(id)
+    await persist()
+  }
+
+  /// Reveal a previously hidden player. No-op if not hidden.
+  public func showPlayer(id: UUID) async {
+    hiddenPlayerIDs.remove(id)
     await persist()
   }
 
@@ -130,10 +153,11 @@ public final class PlayerStore {
     await persist()
   }
 
-  /// Wipes all players and resets the party to empty. Requires confirmation in UI.
+  /// Wipes all players, resets the party to empty, and clears hidden IDs.
   public func resetAll() async {
     players = []
     party = Party(name: "Active Party")
+    hiddenPlayerIDs = []
     await persist()
   }
 
@@ -159,6 +183,11 @@ public final class PlayerStore {
       {
         party = decoded
       }
+      if let data = try? Data(contentsOf: hiddenURL),
+        let decoded = try? decoder.decode(Set<UUID>.self, from: data)
+      {
+        hiddenPlayerIDs = decoded
+      }
     } catch {
       loadError = error
     }
@@ -175,9 +204,11 @@ public final class PlayerStore {
   private func persist() async {
     let playersCopy = players
     let partyCopy = party
+    let hiddenCopy = hiddenPlayerIDs
     do {
       try await Self.writeJSON(playersCopy, to: playersURL)
       try await Self.writeJSON(partyCopy, to: partyURL)
+      try await Self.writeJSON(hiddenCopy, to: hiddenURL)
     } catch {
       loadError = error
     }

--- a/Encounter/Services/PlayerStore.swift
+++ b/Encounter/Services/PlayerStore.swift
@@ -126,7 +126,9 @@ public final class PlayerStore {
 
   // MARK: - Hide / Show
 
-  /// Hide a player from the active encounter roster. No-op if already hidden.
+  /// Hide a UUID from the active encounter roster. No-op if already hidden.
+  /// The UUID need not belong to a current player — phantom IDs are tracked and
+  /// will persist until explicitly revealed or `resetAll()` is called.
   public func hidePlayer(id: UUID) async {
     hiddenPlayerIDs.insert(id)
     await persist()

--- a/Encounter/Services/PlayerStore.swift
+++ b/Encounter/Services/PlayerStore.swift
@@ -133,7 +133,7 @@ public final class PlayerStore {
   }
 
   /// Reveal a previously hidden player. No-op if not hidden.
-  public func showPlayer(id: UUID) async {
+  public func revealPlayer(id: UUID) async {
     hiddenPlayerIDs.remove(id)
     await persist()
   }
@@ -163,7 +163,7 @@ public final class PlayerStore {
 
   // MARK: - Load
 
-  /// Reads `players.json` and `party.json` from `directory`.
+  /// Reads `players.json`, `party.json`, and `hidden-players.json` from `directory`.
   ///
   /// Missing files are treated as empty state (first launch). Corrupt files
   /// are skipped and `loadError` is set.

--- a/EncounterTests/PlayerStoreTests.swift
+++ b/EncounterTests/PlayerStoreTests.swift
@@ -321,11 +321,16 @@ import Testing
 
   @Test func hidePhantomIDIsTrackedButDoesNotAffectActivePartyPlayers() async {
     let store = makeStore()
+    let real = makePlayer(name: "Aric")
+    await store.addPlayer(real)
+    await store.addToParty(id: real.id)
     let phantom = UUID()
-    // ID not in players or party.
+    // Phantom ID — not in players or party.
     await store.hidePlayer(id: phantom)
     #expect(store.hiddenPlayerIDs.contains(phantom))
-    #expect(store.activePartyPlayers.isEmpty)
+    // Real party member is unaffected.
+    #expect(store.activePartyPlayers.count == 1)
+    #expect(store.activePartyPlayers[0].id == real.id)
   }
 
   @Test func deletePlayerAlsoRemovesFromHiddenIDs() async {
@@ -352,7 +357,7 @@ import Testing
     #expect(store2.hiddenPlayerIDs.contains(player.id))
   }
 
-  @Test func revealAfterReloadRoundTrips() async {
+  @Test func hideThenRevealPersistsEmptyHiddenState() async {
     let dir = FileManager.default.temporaryDirectory
       .appending(path: UUID().uuidString, directoryHint: .isDirectory)
     defer { try? FileManager.default.removeItem(at: dir) }
@@ -387,12 +392,22 @@ import Testing
     let dir = FileManager.default.temporaryDirectory
       .appending(path: UUID().uuidString, directoryHint: .isDirectory)
     defer { try? FileManager.default.removeItem(at: dir) }
-    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    // Seed a valid player so we can confirm other files still load.
+    let seed = PlayerStore(directory: dir)
+    let player = makePlayer()
+    await seed.addPlayer(player)
+    // Overwrite hidden-players.json with corrupt data.
     let corruptData = Data("not valid json".utf8)
     try? corruptData.write(to: dir.appending(path: "hidden-players.json"))
 
     let store = PlayerStore(directory: dir)
     await store.load()
+    // Corrupt hidden file silently degrades — no error surfaced.
+    #expect(store.loadError == nil)
+    // Other files (players.json) were still read correctly.
+    #expect(store.players.count == 1)
+    #expect(store.players[0].id == player.id)
+    // Hidden state falls back to empty.
     #expect(store.hiddenPlayerIDs.isEmpty)
   }
 
@@ -403,6 +418,36 @@ import Testing
     await store.hidePlayer(id: player.id)
     await store.resetAll()
     #expect(store.hiddenPlayerIDs.isEmpty)
+  }
+
+  @Test func resetAllPersistsEmptyHiddenIDs() async {
+    let dir = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store1 = PlayerStore(directory: dir)
+    let player = makePlayer()
+    await store1.addPlayer(player)
+    await store1.hidePlayer(id: player.id)
+    await store1.resetAll()
+
+    let store2 = PlayerStore(directory: dir)
+    await store2.load()
+    #expect(store2.hiddenPlayerIDs.isEmpty)
+  }
+
+  @Test func hidingMiddlePlayerPreservesPartyOrder() async {
+    let store = makeStore()
+    let p1 = makePlayer(name: "Zara")
+    let p2 = makePlayer(name: "Aric")
+    let p3 = makePlayer(name: "Mira")
+    await store.addPlayer(p1)
+    await store.addPlayer(p2)
+    await store.addPlayer(p3)
+    await store.addToParty(id: p1.id)
+    await store.addToParty(id: p2.id)
+    await store.addToParty(id: p3.id)
+    await store.hidePlayer(id: p2.id)
+    #expect(store.activePartyPlayers.map(\.name) == ["Zara", "Mira"])
   }
 
   // MARK: - relocate

--- a/EncounterTests/PlayerStoreTests.swift
+++ b/EncounterTests/PlayerStoreTests.swift
@@ -247,6 +247,112 @@ import Testing
     #expect(store.loadError == nil)
   }
 
+  // MARK: - hidePlayer / showPlayer
+
+  @Test func hidePlayerAddsToHiddenIDs() async {
+    let store = makeStore()
+    let player = makePlayer()
+    await store.addPlayer(player)
+    await store.hidePlayer(id: player.id)
+    #expect(store.hiddenPlayerIDs.contains(player.id))
+  }
+
+  @Test func showPlayerRemovesFromHiddenIDs() async {
+    let store = makeStore()
+    let player = makePlayer()
+    await store.addPlayer(player)
+    await store.hidePlayer(id: player.id)
+    await store.showPlayer(id: player.id)
+    #expect(!store.hiddenPlayerIDs.contains(player.id))
+  }
+
+  @Test func hideIsIdempotent() async {
+    let store = makeStore()
+    let player = makePlayer()
+    await store.addPlayer(player)
+    await store.hidePlayer(id: player.id)
+    await store.hidePlayer(id: player.id)
+    #expect(store.hiddenPlayerIDs.count == 1)
+  }
+
+  @Test func showVisiblePlayerIsNoOp() async {
+    let store = makeStore()
+    let player = makePlayer()
+    await store.addPlayer(player)
+    await store.showPlayer(id: player.id)
+    #expect(store.hiddenPlayerIDs.isEmpty)
+  }
+
+  @Test func hiddenPlayerExcludedFromActivePartyPlayers() async {
+    let store = makeStore()
+    let p1 = makePlayer(name: "Aric")
+    let p2 = makePlayer(name: "Lira")
+    await store.addPlayer(p1)
+    await store.addPlayer(p2)
+    await store.addToParty(id: p1.id)
+    await store.addToParty(id: p2.id)
+    await store.hidePlayer(id: p1.id)
+    #expect(store.activePartyPlayers.count == 1)
+    #expect(store.activePartyPlayers[0].id == p2.id)
+  }
+
+  @Test func hiddenPlayerNotInPartyIsTracked() async {
+    let store = makeStore()
+    let player = makePlayer()
+    await store.addPlayer(player)
+    // Not added to party — hidden is a roster-wide flag.
+    await store.hidePlayer(id: player.id)
+    #expect(store.hiddenPlayerIDs.contains(player.id))
+  }
+
+  @Test func deletePlayerAlsoRemovesFromHiddenIDs() async {
+    let store = makeStore()
+    let player = makePlayer()
+    await store.addPlayer(player)
+    await store.hidePlayer(id: player.id)
+    await store.deletePlayer(id: player.id)
+    #expect(!store.hiddenPlayerIDs.contains(player.id))
+    #expect(store.players.isEmpty)
+  }
+
+  @Test func hiddenIDsRoundTripsThroughPersistence() async throws {
+    let dir = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(atPath: dir.path) }
+    let store1 = PlayerStore(directory: dir)
+    let player = makePlayer()
+    await store1.addPlayer(player)
+    await store1.hidePlayer(id: player.id)
+
+    let store2 = PlayerStore(directory: dir)
+    await store2.load()
+    #expect(store2.hiddenPlayerIDs.contains(player.id))
+  }
+
+  @Test func showAfterReloadRoundTrips() async throws {
+    let dir = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(atPath: dir.path) }
+    let store1 = PlayerStore(directory: dir)
+    let player = makePlayer()
+    await store1.addPlayer(player)
+    await store1.hidePlayer(id: player.id)
+    await store1.showPlayer(id: player.id)
+
+    let store2 = PlayerStore(directory: dir)
+    await store2.load()
+    #expect(!store2.hiddenPlayerIDs.contains(player.id))
+  }
+
+  @Test func resetAllClearsHiddenIDs() async {
+    let store = makeStore()
+    let player = makePlayer()
+    await store.addPlayer(player)
+    await store.hidePlayer(id: player.id)
+    await store.resetAll()
+    #expect(store.hiddenPlayerIDs.isEmpty)
+  }
+
   // MARK: - relocate
 
   @Test func relocateClearsInMemoryState() async {

--- a/EncounterTests/PlayerStoreTests.swift
+++ b/EncounterTests/PlayerStoreTests.swift
@@ -244,10 +244,11 @@ import Testing
     await store.load()
     #expect(store.players.isEmpty)
     #expect(store.party.playerIDs.isEmpty)
+    #expect(store.hiddenPlayerIDs.isEmpty)
     #expect(store.loadError == nil)
   }
 
-  // MARK: - hidePlayer / showPlayer
+  // MARK: - hidePlayer / revealPlayer
 
   @Test func hidePlayerAddsToHiddenIDs() async {
     let store = makeStore()
@@ -257,12 +258,12 @@ import Testing
     #expect(store.hiddenPlayerIDs.contains(player.id))
   }
 
-  @Test func showPlayerRemovesFromHiddenIDs() async {
+  @Test func revealPlayerRemovesFromHiddenIDs() async {
     let store = makeStore()
     let player = makePlayer()
     await store.addPlayer(player)
     await store.hidePlayer(id: player.id)
-    await store.showPlayer(id: player.id)
+    await store.revealPlayer(id: player.id)
     #expect(!store.hiddenPlayerIDs.contains(player.id))
   }
 
@@ -275,11 +276,11 @@ import Testing
     #expect(store.hiddenPlayerIDs.count == 1)
   }
 
-  @Test func showVisiblePlayerIsNoOp() async {
+  @Test func revealVisiblePlayerIsNoOp() async {
     let store = makeStore()
     let player = makePlayer()
     await store.addPlayer(player)
-    await store.showPlayer(id: player.id)
+    await store.revealPlayer(id: player.id)
     #expect(store.hiddenPlayerIDs.isEmpty)
   }
 
@@ -296,6 +297,19 @@ import Testing
     #expect(store.activePartyPlayers[0].id == p2.id)
   }
 
+  @Test func allPartyPlayersHiddenEmptiesActivePartyPlayers() async {
+    let store = makeStore()
+    let p1 = makePlayer(name: "Aric")
+    let p2 = makePlayer(name: "Lira")
+    await store.addPlayer(p1)
+    await store.addPlayer(p2)
+    await store.addToParty(id: p1.id)
+    await store.addToParty(id: p2.id)
+    await store.hidePlayer(id: p1.id)
+    await store.hidePlayer(id: p2.id)
+    #expect(store.activePartyPlayers.isEmpty)
+  }
+
   @Test func hiddenPlayerNotInPartyIsTracked() async {
     let store = makeStore()
     let player = makePlayer()
@@ -303,6 +317,15 @@ import Testing
     // Not added to party — hidden is a roster-wide flag.
     await store.hidePlayer(id: player.id)
     #expect(store.hiddenPlayerIDs.contains(player.id))
+  }
+
+  @Test func hidePhantomIDIsTrackedButDoesNotAffectActivePartyPlayers() async {
+    let store = makeStore()
+    let phantom = UUID()
+    // ID not in players or party.
+    await store.hidePlayer(id: phantom)
+    #expect(store.hiddenPlayerIDs.contains(phantom))
+    #expect(store.activePartyPlayers.isEmpty)
   }
 
   @Test func deletePlayerAlsoRemovesFromHiddenIDs() async {
@@ -315,10 +338,10 @@ import Testing
     #expect(store.players.isEmpty)
   }
 
-  @Test func hiddenIDsRoundTripsThroughPersistence() async throws {
+  @Test func hiddenIDsRoundTripsThroughPersistence() async {
     let dir = FileManager.default.temporaryDirectory
       .appending(path: UUID().uuidString, directoryHint: .isDirectory)
-    defer { try? FileManager.default.removeItem(atPath: dir.path) }
+    defer { try? FileManager.default.removeItem(at: dir) }
     let store1 = PlayerStore(directory: dir)
     let player = makePlayer()
     await store1.addPlayer(player)
@@ -329,19 +352,48 @@ import Testing
     #expect(store2.hiddenPlayerIDs.contains(player.id))
   }
 
-  @Test func showAfterReloadRoundTrips() async throws {
+  @Test func revealAfterReloadRoundTrips() async {
     let dir = FileManager.default.temporaryDirectory
       .appending(path: UUID().uuidString, directoryHint: .isDirectory)
-    defer { try? FileManager.default.removeItem(atPath: dir.path) }
+    defer { try? FileManager.default.removeItem(at: dir) }
     let store1 = PlayerStore(directory: dir)
     let player = makePlayer()
     await store1.addPlayer(player)
     await store1.hidePlayer(id: player.id)
-    await store1.showPlayer(id: player.id)
+    await store1.revealPlayer(id: player.id)
 
     let store2 = PlayerStore(directory: dir)
     await store2.load()
     #expect(!store2.hiddenPlayerIDs.contains(player.id))
+  }
+
+  @Test func hideRevealHideToggleRoundTripsPersistence() async {
+    let dir = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    let store1 = PlayerStore(directory: dir)
+    let player = makePlayer()
+    await store1.addPlayer(player)
+    await store1.hidePlayer(id: player.id)
+    await store1.revealPlayer(id: player.id)
+    await store1.hidePlayer(id: player.id)
+
+    let store2 = PlayerStore(directory: dir)
+    await store2.load()
+    #expect(store2.hiddenPlayerIDs.contains(player.id))
+  }
+
+  @Test func corruptHiddenPlayersFileDegradesGracefully() async {
+    let dir = FileManager.default.temporaryDirectory
+      .appending(path: UUID().uuidString, directoryHint: .isDirectory)
+    defer { try? FileManager.default.removeItem(at: dir) }
+    try? FileManager.default.createDirectory(at: dir, withIntermediateDirectories: true)
+    let corruptData = Data("not valid json".utf8)
+    try? corruptData.write(to: dir.appending(path: "hidden-players.json"))
+
+    let store = PlayerStore(directory: dir)
+    await store.load()
+    #expect(store.hiddenPlayerIDs.isEmpty)
   }
 
   @Test func resetAllClearsHiddenIDs() async {
@@ -357,11 +409,14 @@ import Testing
 
   @Test func relocateClearsInMemoryState() async {
     let store = makeStore()
-    await store.addPlayer(makePlayer())
+    let player = makePlayer()
+    await store.addPlayer(player)
+    await store.hidePlayer(id: player.id)
     let newDir = FileManager.default.temporaryDirectory
       .appending(path: UUID().uuidString, directoryHint: .isDirectory)
     store.relocate(to: newDir)
     #expect(store.players.isEmpty)
     #expect(store.party.playerIDs.isEmpty)
+    #expect(store.hiddenPlayerIDs.isEmpty)
   }
 }


### PR DESCRIPTION
## Summary

- Adds `public private(set) var hiddenPlayerIDs: Set<UUID>` — a roster-wide visibility flag independent of party membership
- `hidePlayer(id:)` and `revealPlayer(id:)` are the sole mutation path (both idempotent); phantom UUIDs are accepted by design
- `activePartyPlayers` now filters out hidden IDs before resolving players, preserving party order
- `deletePlayer` and `resetAll` clean up `hiddenPlayerIDs`
- Persisted to `hidden-players.json` alongside `players.json` and `party.json`

## Test plan

- [x] `hidePlayerAddsToHiddenIDs`
- [x] `revealPlayerRemovesFromHiddenIDs`
- [x] `hideIsIdempotent`
- [x] `revealVisiblePlayerIsNoOp`
- [x] `hiddenPlayerExcludedFromActivePartyPlayers`
- [x] `allPartyPlayersHiddenEmptiesActivePartyPlayers`
- [x] `hiddenPlayerNotInPartyIsTracked`
- [x] `hidePhantomIDIsTrackedButDoesNotAffectActivePartyPlayers`
- [x] `deletePlayerAlsoRemovesFromHiddenIDs`
- [x] `hiddenIDsRoundTripsThroughPersistence`
- [x] `hideThenRevealPersistsEmptyHiddenState`
- [x] `hideRevealHideToggleRoundTripsPersistence`
- [x] `corruptHiddenPlayersFileDegradesGracefully`
- [x] `resetAllClearsHiddenIDs`
- [x] `resetAllPersistsEmptyHiddenIDs`
- [x] `hidingMiddlePlayerPreservesPartyOrder`
- [x] `loadFromEmptyDirectoryStartsBlank` (extended with `hiddenPlayerIDs.isEmpty`)
- [x] `relocateClearsInMemoryState` (extended with `hiddenPlayerIDs.isEmpty`)

Closes #104