### PR TITLE
feat: AdversaryFilterBar shared component

### DIFF
--- a/Encounter/Views/Adversary+Filtering.swift
+++ b/Encounter/Views/Adversary+Filtering.swift
@@ -1,0 +1,16 @@
+import DHModels
+import Foundation
+
+extension [Adversary] {
+  // Stateless AND-predicate: each non-nil/non-empty argument narrows the result.
+  // Parent views own the filter state and call this to derive the displayed list.
+  nonisolated func filtered(searchText: String, tier: Int?, type: AdversaryType?) -> [Adversary] {
+    filter { adversary in
+      let matchesSearch = searchText.isEmpty
+        || adversary.name.localizedStandardContains(searchText)
+      let matchesTier = tier == nil || adversary.tier == tier
+      let matchesType = type == nil || adversary.role == type
+      return matchesSearch && matchesTier && matchesType
+    }
+  }
+}

--- a/Encounter/Views/AdversaryFilterBar.swift
+++ b/Encounter/Views/AdversaryFilterBar.swift
@@ -2,9 +2,9 @@
 //  AdversaryFilterBar.swift
 //  Encounter
 //
-//  Stateless filter bar for adversary lists. Binds search text, tier, and type;
-//  all active filters compose with AND. The static filter(_:searchText:tier:type:)
-//  method applies the same logic for use in parent views.
+//  Stateless filter bar for adversary lists: search text, tier, and type compose
+//  with AND. All filter state is owned by the parent so the bar can be mounted
+//  in multiple contexts without duplicating the predicate. See Adversary+Filtering.swift.
 //
 
 import DHModels
@@ -16,65 +16,69 @@ struct AdversaryFilterBar: View {
   @Binding var selectedType: AdversaryType?
 
   var body: some View {
-    HStack(spacing: 8) {
-      HStack(spacing: 4) {
-        Image(systemName: "magnifyingglass")
-          .foregroundStyle(.secondary)
-        TextField("Search", text: $searchText)
-          .textFieldStyle(.plain)
-          .accessibilityIdentifier("compendium.filter-bar.search")
-        if !searchText.isEmpty {
-          Button("Clear search", systemImage: "xmark.circle.fill") {
-            searchText = ""
-          }
-          .labelStyle(.iconOnly)
-          .foregroundStyle(.secondary)
-          .buttonStyle(.plain)
+    ViewThatFits(in: .horizontal) {
+      HStack(spacing: 8) {
+        searchField.layoutPriority(1)
+        tierPicker
+        typePicker
+      }
+      VStack(spacing: 6) {
+        searchField
+        HStack(spacing: 8) {
+          tierPicker
+          typePicker
+          Spacer()
         }
       }
-      .padding(.horizontal, 8)
-      .padding(.vertical, 6)
-      .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 8))
-
-      Picker("Tier", selection: $selectedTier) {
-        Text("All").tag(Int?.none)
-        ForEach(1...5, id: \.self) { tier in
-          Text("Tier \(tier)").tag(Int?.some(tier))
-        }
-      }
-      .pickerStyle(.menu)
-      .accessibilityIdentifier("compendium.filter-bar.tier")
-
-      Picker("Type", selection: $selectedType) {
-        Text("All").tag(AdversaryType?.none)
-        ForEach(AdversaryType.allCases, id: \.self) { type in
-          Text(type.rawValue).tag(AdversaryType?.some(type))
-        }
-      }
-      .pickerStyle(.menu)
-      .accessibilityIdentifier("compendium.filter-bar.type")
     }
     .padding(.horizontal)
     .padding(.vertical, 6)
-    .accessibilityElement(children: .contain)
     .accessibilityIdentifier("compendium.filter-bar")
   }
 
-  // MARK: - Filter logic
-
-  static func filter(
-    _ adversaries: [Adversary],
-    searchText: String,
-    tier: Int?,
-    type: AdversaryType?
-  ) -> [Adversary] {
-    adversaries.filter { adversary in
-      let matchesSearch = searchText.isEmpty
-        || adversary.name.localizedCaseInsensitiveContains(searchText)
-      let matchesTier = tier == nil || adversary.tier == tier
-      let matchesType = type == nil || adversary.role == type
-      return matchesSearch && matchesTier && matchesType
+  @ViewBuilder private var searchField: some View {
+    HStack(spacing: 4) {
+      Image(systemName: "magnifyingglass")
+        .foregroundStyle(.secondary)
+        .accessibilityHidden(true)
+      TextField("Search", text: $searchText)
+        .textFieldStyle(.plain)
+        .accessibilityLabel("Search adversaries")
+        .accessibilityIdentifier("compendium.filter-bar.search")
+      if !searchText.isEmpty {
+        Button("Clear search", systemImage: "xmark.circle.fill") {
+          searchText = ""
+        }
+        .labelStyle(.iconOnly)
+        .foregroundStyle(.secondary)
+        .buttonStyle(.plain)
+      }
     }
+    .frame(minHeight: 44)
+    .padding(.horizontal, 8)
+    .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 8))
+  }
+
+  @ViewBuilder private var tierPicker: some View {
+    Picker("Tier", selection: $selectedTier) {
+      Text("All tiers").tag(Int?.none)
+      ForEach(1...4, id: \.self) { tier in
+        Text("Tier \(tier)").tag(Int?.some(tier))
+      }
+    }
+    .pickerStyle(.menu)
+    .accessibilityIdentifier("compendium.filter-bar.tier")
+  }
+
+  @ViewBuilder private var typePicker: some View {
+    Picker("Type", selection: $selectedType) {
+      Text("All types").tag(AdversaryType?.none)
+      ForEach(AdversaryType.allCases, id: \.self) { type in
+        Text(type.rawValue).tag(AdversaryType?.some(type))
+      }
+    }
+    .pickerStyle(.menu)
+    .accessibilityIdentifier("compendium.filter-bar.type")
   }
 }
 

--- a/Encounter/Views/AdversaryFilterBar.swift
+++ b/Encounter/Views/AdversaryFilterBar.swift
@@ -1,0 +1,93 @@
+//
+//  AdversaryFilterBar.swift
+//  Encounter
+//
+//  Stateless filter bar for adversary lists. Binds search text, tier, and type;
+//  all active filters compose with AND. The static filter(_:searchText:tier:type:)
+//  method applies the same logic for use in parent views.
+//
+
+import DHModels
+import SwiftUI
+
+struct AdversaryFilterBar: View {
+  @Binding var searchText: String
+  @Binding var selectedTier: Int?
+  @Binding var selectedType: AdversaryType?
+
+  var body: some View {
+    HStack(spacing: 8) {
+      HStack(spacing: 4) {
+        Image(systemName: "magnifyingglass")
+          .foregroundStyle(.secondary)
+        TextField("Search", text: $searchText)
+          .textFieldStyle(.plain)
+          .accessibilityIdentifier("compendium.filter-bar.search")
+        if !searchText.isEmpty {
+          Button("Clear search", systemImage: "xmark.circle.fill") {
+            searchText = ""
+          }
+          .labelStyle(.iconOnly)
+          .foregroundStyle(.secondary)
+          .buttonStyle(.plain)
+        }
+      }
+      .padding(.horizontal, 8)
+      .padding(.vertical, 6)
+      .background(.fill.tertiary, in: RoundedRectangle(cornerRadius: 8))
+
+      Picker("Tier", selection: $selectedTier) {
+        Text("All").tag(Int?.none)
+        ForEach(1...5, id: \.self) { tier in
+          Text("Tier \(tier)").tag(Int?.some(tier))
+        }
+      }
+      .pickerStyle(.menu)
+      .accessibilityIdentifier("compendium.filter-bar.tier")
+
+      Picker("Type", selection: $selectedType) {
+        Text("All").tag(AdversaryType?.none)
+        ForEach(AdversaryType.allCases, id: \.self) { type in
+          Text(type.rawValue).tag(AdversaryType?.some(type))
+        }
+      }
+      .pickerStyle(.menu)
+      .accessibilityIdentifier("compendium.filter-bar.type")
+    }
+    .padding(.horizontal)
+    .padding(.vertical, 6)
+    .accessibilityElement(children: .contain)
+    .accessibilityIdentifier("compendium.filter-bar")
+  }
+
+  // MARK: - Filter logic
+
+  static func filter(
+    _ adversaries: [Adversary],
+    searchText: String,
+    tier: Int?,
+    type: AdversaryType?
+  ) -> [Adversary] {
+    adversaries.filter { adversary in
+      let matchesSearch = searchText.isEmpty
+        || adversary.name.localizedCaseInsensitiveContains(searchText)
+      let matchesTier = tier == nil || adversary.tier == tier
+      let matchesType = type == nil || adversary.role == type
+      return matchesSearch && matchesTier && matchesType
+    }
+  }
+}
+
+#Preview {
+  @Previewable @State var searchText = ""
+  @Previewable @State var selectedTier: Int? = nil
+  @Previewable @State var selectedType: AdversaryType? = nil
+  VStack {
+    AdversaryFilterBar(
+      searchText: $searchText,
+      selectedTier: $selectedTier,
+      selectedType: $selectedType
+    )
+    Spacer()
+  }
+}

--- a/EncounterTests/AdversaryFilterBarTests.swift
+++ b/EncounterTests/AdversaryFilterBarTests.swift
@@ -8,8 +8,7 @@ import Testing
 
 @testable import Encounter
 
-@MainActor
-@Suite("AdversaryFilterBar.filter")
+@Suite("[Adversary].filtered")
 struct AdversaryFilterBarTests {
 
   private let goblinMinion = Adversary(
@@ -35,56 +34,58 @@ struct AdversaryFilterBarTests {
   // MARK: - Search text
 
   @Test func emptySearchReturnsAll() {
-    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: nil)
+    let result = all.filtered(searchText: "", tier: nil, type: nil)
     #expect(result.count == 3)
   }
 
   @Test func searchTextFiltersName() {
-    let result = AdversaryFilterBar.filter(all, searchText: "Goblin", tier: nil, type: nil)
+    let result = all.filtered(searchText: "Goblin", tier: nil, type: nil)
     #expect(result.map(\.id) == ["goblin"])
   }
 
   @Test func searchTextIsCaseInsensitive() {
-    let result = AdversaryFilterBar.filter(all, searchText: "goblin", tier: nil, type: nil)
+    let result = all.filtered(searchText: "goblin", tier: nil, type: nil)
     #expect(result.map(\.id) == ["goblin"])
   }
 
   @Test func searchTextIsPartialMatch() {
-    let result = AdversaryFilterBar.filter(all, searchText: "shadow", tier: nil, type: nil)
+    let result = all.filtered(searchText: "shadow", tier: nil, type: nil)
     #expect(result.map(\.id) == ["shadow-skulk"])
   }
 
   // MARK: - Tier filter
 
   @Test func nilTierReturnsAll() {
-    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: nil)
-    #expect(result.count == 3)
+    // nil tier does not filter; type=.bruiser confirms orcBruiser (tier 2) is not excluded
+    let result = all.filtered(searchText: "", tier: nil, type: .bruiser)
+    #expect(result.map(\.id) == ["orc-bruiser"])
   }
 
   @Test func tierFilterIncludesOnlyMatchingTier() {
-    let result = AdversaryFilterBar.filter(all, searchText: "", tier: 1, type: nil)
+    let result = all.filtered(searchText: "", tier: 1, type: nil)
     #expect(result.map(\.id).sorted() == ["goblin", "shadow-skulk"])
   }
 
   @Test func tierFilterExcludesNonMatchingTier() {
-    let result = AdversaryFilterBar.filter(all, searchText: "", tier: 3, type: nil)
+    let result = all.filtered(searchText: "", tier: 3, type: nil)
     #expect(result.isEmpty)
   }
 
   // MARK: - Type filter
 
   @Test func nilTypeReturnsAll() {
-    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: nil)
-    #expect(result.count == 3)
+    // nil type does not filter; tier=1 confirms both tier-1 types are returned
+    let result = all.filtered(searchText: "", tier: 1, type: nil)
+    #expect(result.map(\.id).sorted() == ["goblin", "shadow-skulk"])
   }
 
   @Test func typeFilterIncludesOnlyMatchingType() {
-    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: .minion)
+    let result = all.filtered(searchText: "", tier: nil, type: .minion)
     #expect(result.map(\.id) == ["goblin"])
   }
 
   @Test func typeFilterExcludesNonMatchingType() {
-    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: .solo)
+    let result = all.filtered(searchText: "", tier: nil, type: .solo)
     #expect(result.isEmpty)
   }
 
@@ -92,23 +93,42 @@ struct AdversaryFilterBarTests {
 
   @Test func searchAndTierComposeWithAND() {
     // Both goblin and shadow-skulk are tier 1; only goblin matches "Goblin"
-    let result = AdversaryFilterBar.filter(all, searchText: "Goblin", tier: 1, type: nil)
+    let result = all.filtered(searchText: "Goblin", tier: 1, type: nil)
     #expect(result.map(\.id) == ["goblin"])
   }
 
   @Test func searchAndTypeComposeWithAND() {
-    // Both goblin and orc-bruiser could match "o"; only orc-bruiser is .bruiser
-    let result = AdversaryFilterBar.filter(all, searchText: "o", tier: nil, type: .bruiser)
+    let result = all.filtered(searchText: "o", tier: nil, type: .bruiser)
     #expect(result.map(\.id) == ["orc-bruiser"])
   }
 
   @Test func allThreeFiltersComposeWithAND() {
-    let result = AdversaryFilterBar.filter(all, searchText: "Goblin", tier: 1, type: .minion)
+    // "o" matches all three adversaries; tier 1 narrows to goblin + shadow-skulk;
+    // type .minion eliminates shadow-skulk — each filter contributes.
+    let result = all.filtered(searchText: "o", tier: 1, type: .minion)
     #expect(result.map(\.id) == ["goblin"])
   }
 
   @Test func composedFiltersYieldEmptyWhenNoMatch() {
-    let result = AdversaryFilterBar.filter(all, searchText: "Goblin", tier: 2, type: .minion)
+    let result = all.filtered(searchText: "Goblin", tier: 2, type: .minion)
     #expect(result.isEmpty)
+  }
+
+  // MARK: - Edge cases
+
+  @Test func emptyArrayReturnsEmpty() {
+    let result = [Adversary]().filtered(searchText: "Goblin", tier: 1, type: .minion)
+    #expect(result.isEmpty)
+  }
+
+  @Test func whitespaceSearchReturnsEmpty() {
+    // Whitespace is treated as a non-empty search string — no results
+    let result = all.filtered(searchText: "   ", tier: nil, type: nil)
+    #expect(result.isEmpty)
+  }
+
+  @Test func multiWordSearchMatchesFullName() {
+    let result = all.filtered(searchText: "Orc Bruiser", tier: nil, type: nil)
+    #expect(result.map(\.id) == ["orc-bruiser"])
   }
 }

--- a/EncounterTests/AdversaryFilterBarTests.swift
+++ b/EncounterTests/AdversaryFilterBarTests.swift
@@ -1,0 +1,114 @@
+//
+//  AdversaryFilterBarTests.swift
+//  EncounterTests
+//
+
+import DHModels
+import Testing
+
+@testable import Encounter
+
+@MainActor
+@Suite("AdversaryFilterBar.filter")
+struct AdversaryFilterBarTests {
+
+  private let goblinMinion = Adversary(
+    id: "goblin", name: "Goblin", tier: 1, role: .minion,
+    flavorText: "", difficulty: 8,
+    thresholdMajor: 4, thresholdSevere: 8, hp: 3, stress: 2,
+    attackModifier: "+1", attackName: "Club", attackRange: .melee, damage: "1d4 phy")
+
+  private let orcBruiser = Adversary(
+    id: "orc-bruiser", name: "Orc Bruiser", tier: 2, role: .bruiser,
+    flavorText: "", difficulty: 14,
+    thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+    attackModifier: "+5", attackName: "Greataxe", attackRange: .melee, damage: "2d8+4 phy")
+
+  private let shadowSkulk = Adversary(
+    id: "shadow-skulk", name: "Shadow Skulk", tier: 1, role: .skulk,
+    flavorText: "", difficulty: 10,
+    thresholdMajor: 5, thresholdSevere: 10, hp: 4, stress: 2,
+    attackModifier: "+3", attackName: "Shadow Strike", attackRange: .close, damage: "1d6+2 phy")
+
+  private var all: [Adversary] { [goblinMinion, orcBruiser, shadowSkulk] }
+
+  // MARK: - Search text
+
+  @Test func emptySearchReturnsAll() {
+    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: nil)
+    #expect(result.count == 3)
+  }
+
+  @Test func searchTextFiltersName() {
+    let result = AdversaryFilterBar.filter(all, searchText: "Goblin", tier: nil, type: nil)
+    #expect(result.map(\.id) == ["goblin"])
+  }
+
+  @Test func searchTextIsCaseInsensitive() {
+    let result = AdversaryFilterBar.filter(all, searchText: "goblin", tier: nil, type: nil)
+    #expect(result.map(\.id) == ["goblin"])
+  }
+
+  @Test func searchTextIsPartialMatch() {
+    let result = AdversaryFilterBar.filter(all, searchText: "shadow", tier: nil, type: nil)
+    #expect(result.map(\.id) == ["shadow-skulk"])
+  }
+
+  // MARK: - Tier filter
+
+  @Test func nilTierReturnsAll() {
+    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: nil)
+    #expect(result.count == 3)
+  }
+
+  @Test func tierFilterIncludesOnlyMatchingTier() {
+    let result = AdversaryFilterBar.filter(all, searchText: "", tier: 1, type: nil)
+    #expect(result.map(\.id).sorted() == ["goblin", "shadow-skulk"])
+  }
+
+  @Test func tierFilterExcludesNonMatchingTier() {
+    let result = AdversaryFilterBar.filter(all, searchText: "", tier: 3, type: nil)
+    #expect(result.isEmpty)
+  }
+
+  // MARK: - Type filter
+
+  @Test func nilTypeReturnsAll() {
+    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: nil)
+    #expect(result.count == 3)
+  }
+
+  @Test func typeFilterIncludesOnlyMatchingType() {
+    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: .minion)
+    #expect(result.map(\.id) == ["goblin"])
+  }
+
+  @Test func typeFilterExcludesNonMatchingType() {
+    let result = AdversaryFilterBar.filter(all, searchText: "", tier: nil, type: .solo)
+    #expect(result.isEmpty)
+  }
+
+  // MARK: - AND composition
+
+  @Test func searchAndTierComposeWithAND() {
+    // Both goblin and shadow-skulk are tier 1; only goblin matches "Goblin"
+    let result = AdversaryFilterBar.filter(all, searchText: "Goblin", tier: 1, type: nil)
+    #expect(result.map(\.id) == ["goblin"])
+  }
+
+  @Test func searchAndTypeComposeWithAND() {
+    // Both goblin and orc-bruiser could match "o"; only orc-bruiser is .bruiser
+    let result = AdversaryFilterBar.filter(all, searchText: "o", tier: nil, type: .bruiser)
+    #expect(result.map(\.id) == ["orc-bruiser"])
+  }
+
+  @Test func allThreeFiltersComposeWithAND() {
+    let result = AdversaryFilterBar.filter(all, searchText: "Goblin", tier: 1, type: .minion)
+    #expect(result.map(\.id) == ["goblin"])
+  }
+
+  @Test func composedFiltersYieldEmptyWhenNoMatch() {
+    let result = AdversaryFilterBar.filter(all, searchText: "Goblin", tier: 2, type: .minion)
+    #expect(result.isEmpty)
+  }
+}


### PR DESCRIPTION
## Summary

- Adds `AdversaryFilterBar` — a stateless filter bar that binds `searchText: String`, `selectedTier: Int?`, and `selectedType: AdversaryType?`
- All active filters compose with AND; empty search + nil tier + nil type = no filtering (show all)
- `AdversaryFilterBar.filter(_:searchText:tier:type:)` static method carries the predicate for parent views to call directly
- AX identifiers on container (`compendium.filter-bar`), search field, tier picker, and type menu; clear button labelled for VoiceOver

## Test plan

- [x] `emptySearchReturnsAll` — no filtering when all inputs are empty/nil
- [x] `searchTextFiltersName` — partial match on adversary name
- [x] `searchTextIsCaseInsensitive` — case-insensitive comparison
- [x] `searchTextIsPartialMatch` — substring match works
- [x] `nilTierReturnsAll` / `nilTypeReturnsAll` — nil passes all
- [x] `tierFilterIncludesOnlyMatchingTier` / `tierFilterExcludesNonMatchingTier`
- [x] `typeFilterIncludesOnlyMatchingType` / `typeFilterExcludesNonMatchingType`
- [x] `searchAndTierComposeWithAND` / `searchAndTypeComposeWithAND` / `allThreeFiltersComposeWithAND` / `composedFiltersYieldEmptyWhenNoMatch`

Closes #106