### PR TITLE
feat: CompendiumSelectorSheet shared component

### DIFF
--- a/Encounter/Views/CompendiumSelectorSheet.swift
+++ b/Encounter/Views/CompendiumSelectorSheet.swift
@@ -1,0 +1,129 @@
+//
+//  CompendiumSelectorSheet.swift
+//  Encounter
+//
+//  Modal adversary selector presented from the encounter editor on iOS.
+//  Tapping a row calls onSelect and dismisses; Import DHPack and Done are
+//  always visible in the toolbar.
+//
+
+import DHKit
+import DHModels
+import SwiftUI
+import UniformTypeIdentifiers
+
+struct CompendiumSelectorSheet: View {
+  let compendium: Compendium
+  let contentStore: ContentStore
+  let onSelect: (Adversary) -> Void
+
+  @Environment(\.dismiss) private var dismiss
+  @State private var searchText = ""
+  @State private var selectedTier: Int?
+  @State private var selectedType: AdversaryType?
+  @State private var isImporting = false
+
+  private var filteredAdversaries: [Adversary] {
+    compendium.adversaries.filtered(
+      searchText: searchText,
+      tier: selectedTier,
+      type: selectedType
+    )
+  }
+
+  var body: some View {
+    NavigationStack {
+      VStack(spacing: 0) {
+        AdversaryFilterBar(
+          searchText: $searchText,
+          selectedTier: $selectedTier,
+          selectedType: $selectedType
+        )
+        Divider()
+        if filteredAdversaries.isEmpty {
+          ContentUnavailableView(
+            "No Adversaries",
+            systemImage: "magnifyingglass",
+            description: Text("Try a different search or filter.")
+          )
+          .frame(maxHeight: .infinity)
+        } else {
+          List(filteredAdversaries) { adversary in
+            Button {
+              onSelect(adversary)
+              dismiss()
+            } label: {
+              AdversaryRow(adversary: adversary)
+            }
+            .buttonStyle(.plain)
+            .accessibilityIdentifier("compendium.adversary-row")
+            .accessibilityValue(adversary.name)
+          }
+        }
+      }
+      .navigationTitle("Add Adversary")
+      #if os(iOS)
+        .navigationBarTitleDisplayMode(.inline)
+      #endif
+      .accessibilityIdentifier("compendium.selector-sheet")
+      .toolbar {
+        ToolbarItem(placement: .cancellationAction) {
+          Button("Done") { dismiss() }
+            .accessibilityIdentifier("compendium.selector-sheet.done-button")
+        }
+        ToolbarItem(placement: .primaryAction) {
+          Button {
+            isImporting = true
+          } label: {
+            Label("Import DHPack", systemImage: "square.and.arrow.down")
+          }
+          .accessibilityIdentifier("compendium.selector-sheet.import-button")
+        }
+      }
+      .fileImporter(
+        isPresented: $isImporting,
+        allowedContentTypes: [UTType("gwillish.Encounter.dhpack") ?? .json]
+      ) { result in
+        guard case .success(let url) = result else { return }
+        guard url.startAccessingSecurityScopedResource() else { return }
+        Task { @MainActor in
+          defer { url.stopAccessingSecurityScopedResource() }
+          await contentStore.importPack(from: url)
+        }
+      }
+    }
+  }
+}
+
+#Preview("With adversaries") {
+  let compendium = Compendium()
+  compendium.addAdversary(
+    Adversary(
+      id: "goblin", name: "Goblin", tier: 1, role: .minion,
+      flavorText: "Small and cunning.", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Rusty Blade",
+      attackRange: .veryClose, damage: "1d4 phy"
+    ))
+  compendium.addAdversary(
+    Adversary(
+      id: "orc", name: "Orc Bruiser", tier: 2, role: .bruiser,
+      flavorText: "Massive and relentless.", difficulty: 14,
+      thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+      attackModifier: "+5", attackName: "Great Axe",
+      attackRange: .veryClose, damage: "2d10+4 phy"
+    ))
+  return CompendiumSelectorSheet(
+    compendium: compendium,
+    contentStore: PreviewData.contentStore(compendium: compendium),
+    onSelect: { adversary in print("Selected: \(adversary.name)") }
+  )
+}
+
+#Preview("Empty compendium") {
+  CompendiumSelectorSheet(
+    compendium: PreviewData.compendium(),
+    contentStore: PreviewData.contentStore(),
+    onSelect: { _ in }
+  )
+}

--- a/Encounter/Views/CompendiumSelectorSheet.swift
+++ b/Encounter/Views/CompendiumSelectorSheet.swift
@@ -12,6 +12,12 @@ import DHModels
 import SwiftUI
 import UniformTypeIdentifiers
 
+extension UTType {
+  // Force-unwrap is intentional: type is declared in this app's Info.plist.
+  // A nil result means the identifier was mistyped — crash loudly at dev time.
+  fileprivate static let dhpack = UTType("gwillish.Encounter.dhpack")!
+}
+
 struct CompendiumSelectorSheet: View {
   let compendium: Compendium
   let contentStore: ContentStore
@@ -33,20 +39,15 @@ struct CompendiumSelectorSheet: View {
 
   var body: some View {
     NavigationStack {
-      VStack(spacing: 0) {
-        AdversaryFilterBar(
-          searchText: $searchText,
-          selectedTier: $selectedTier,
-          selectedType: $selectedType
-        )
-        Divider()
+      Group {
         if filteredAdversaries.isEmpty {
           ContentUnavailableView(
             "No Adversaries",
             systemImage: "magnifyingglass",
             description: Text("Try a different search or filter.")
           )
-          .frame(maxHeight: .infinity)
+          .frame(maxWidth: .infinity, maxHeight: .infinity)
+          .accessibilityIdentifier("compendium.selector-sheet.empty-state")
         } else {
           List(filteredAdversaries) { adversary in
             Button {
@@ -56,10 +57,13 @@ struct CompendiumSelectorSheet: View {
               AdversaryRow(adversary: adversary)
             }
             .buttonStyle(.plain)
-            .accessibilityIdentifier("compendium.adversary-row")
-            .accessibilityValue(adversary.name)
+            .accessibilityIdentifier("compendium.adversary-row.\(adversary.id)")
+            .accessibilityLabel(adversary.name)
           }
         }
+      }
+      .safeAreaInset(edge: .top, spacing: 0) {
+        filterBarHeader
       }
       .navigationTitle("Add Adversary")
       #if os(iOS)
@@ -67,7 +71,7 @@ struct CompendiumSelectorSheet: View {
       #endif
       .accessibilityIdentifier("compendium.selector-sheet")
       .toolbar {
-        ToolbarItem(placement: .cancellationAction) {
+        ToolbarItem(placement: .confirmationAction) {
           Button("Done") { dismiss() }
             .accessibilityIdentifier("compendium.selector-sheet.done-button")
         }
@@ -82,7 +86,7 @@ struct CompendiumSelectorSheet: View {
       }
       .fileImporter(
         isPresented: $isImporting,
-        allowedContentTypes: [UTType("gwillish.Encounter.dhpack") ?? .json]
+        allowedContentTypes: [.dhpack]
       ) { result in
         guard case .success(let url) = result else { return }
         guard url.startAccessingSecurityScopedResource() else { return }
@@ -92,6 +96,18 @@ struct CompendiumSelectorSheet: View {
         }
       }
     }
+  }
+
+  private var filterBarHeader: some View {
+    VStack(spacing: 0) {
+      AdversaryFilterBar(
+        searchText: $searchText,
+        selectedTier: $selectedTier,
+        selectedType: $selectedType
+      )
+      Divider()
+    }
+    .background(.regularMaterial)
   }
 }
 

--- a/EncounterTests/CompendiumSelectorSheetTests.swift
+++ b/EncounterTests/CompendiumSelectorSheetTests.swift
@@ -40,12 +40,17 @@ struct CompendiumSelectorSheetTests {
     )
   }
 
+  // MARK: - Filter bar
+
   @Test func showsAdversaryFilterBar() throws {
     let sut = makeSUT()
-    // AdversaryFilterBar renders tier and type Pickers; at least 2 should be present.
-    let pickers = try sut.inspect().findAll(ViewType.Picker.self)
-    #expect(pickers.count >= 2)
+    // "All tiers" is a unique string rendered only by AdversaryFilterBar's tier Picker.
+    let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+    #expect(texts.contains("All tiers"), "AdversaryFilterBar tier picker should be present")
+    #expect(texts.contains("All types"), "AdversaryFilterBar type picker should be present")
   }
+
+  // MARK: - Adversary rows
 
   @Test func adversaryRowTapCallsOnSelect() throws {
     let goblin = Self.makeAdversary(id: "goblin", name: "Goblin")
@@ -63,15 +68,23 @@ struct CompendiumSelectorSheetTests {
     #expect(selected?.id == "goblin")
   }
 
-  @Test func importDHPackButtonPresent() throws {
+  @Test func emptyCompendiumShowsEmptyState() throws {
     let sut = makeSUT()
     let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
-    #expect(texts.contains("Import DHPack"))
+    #expect(texts.contains("No Adversaries"))
   }
+
+  // MARK: - Toolbar buttons
 
   @Test func doneButtonPresent() throws {
     let sut = makeSUT()
     let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
     #expect(texts.contains("Done"))
+  }
+
+  @Test func importDHPackButtonPresent() throws {
+    let sut = makeSUT()
+    let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+    #expect(texts.contains("Import DHPack"))
   }
 }

--- a/EncounterTests/CompendiumSelectorSheetTests.swift
+++ b/EncounterTests/CompendiumSelectorSheetTests.swift
@@ -1,0 +1,77 @@
+//
+//  CompendiumSelectorSheetTests.swift
+//  EncounterTests
+//
+
+import DHKit
+import DHModels
+import SwiftUI
+import Testing
+import ViewInspector
+
+@testable import Encounter
+
+@MainActor
+@Suite("CompendiumSelectorSheet")
+struct CompendiumSelectorSheetTests {
+
+  private static func makeAdversary(id: String, name: String) -> Adversary {
+    Adversary(
+      id: id, name: name, tier: 1, role: .minion,
+      flavorText: "", difficulty: 8,
+      thresholdMajor: 4, thresholdSevere: 8, hp: 3, stress: 2,
+      attackModifier: "+1", attackName: "Club", attackRange: .melee, damage: "1d4 phy"
+    )
+  }
+
+  private func makeSUT(
+    adversaries: [Adversary] = [],
+    onSelect: @escaping (Adversary) -> Void = { _ in }
+  ) -> CompendiumSelectorSheet {
+    let compendium = Compendium()
+    for adversary in adversaries {
+      compendium.addAdversary(adversary)
+    }
+    let contentStore = ContentStore(contentDirectory: .temporaryDirectory, compendium: compendium)
+    return CompendiumSelectorSheet(
+      compendium: compendium,
+      contentStore: contentStore,
+      onSelect: onSelect
+    )
+  }
+
+  @Test func showsAdversaryFilterBar() throws {
+    let sut = makeSUT()
+    // AdversaryFilterBar renders tier and type Pickers; at least 2 should be present.
+    let pickers = try sut.inspect().findAll(ViewType.Picker.self)
+    #expect(pickers.count >= 2)
+  }
+
+  @Test func adversaryRowTapCallsOnSelect() throws {
+    let goblin = Self.makeAdversary(id: "goblin", name: "Goblin")
+    var selected: Adversary?
+    let sut = makeSUT(adversaries: [goblin]) { selected = $0 }
+    let buttons = try sut.inspect().findAll(ViewType.Button.self)
+    let goblinButton = try #require(
+      buttons.first { btn in
+        let texts = (try? btn.findAll(ViewType.Text.self)) ?? []
+        return texts.contains { (try? $0.string()) == "Goblin" }
+      },
+      "Expected a button labelled with the adversary name"
+    )
+    try goblinButton.tap()
+    #expect(selected?.id == "goblin")
+  }
+
+  @Test func importDHPackButtonPresent() throws {
+    let sut = makeSUT()
+    let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+    #expect(texts.contains("Import DHPack"))
+  }
+
+  @Test func doneButtonPresent() throws {
+    let sut = makeSUT()
+    let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+    #expect(texts.contains("Done"))
+  }
+}

--- a/docs/ui-vocabulary.md
+++ b/docs/ui-vocabulary.md
@@ -378,6 +378,10 @@ Modal adversary selector opened from the encounter editor. Selection-only — no
 |---|---|
 | Sheet root | `compendium.selector-sheet` |
 | Filter bar | `compendium.filter-bar` |
+| Adversary row | `compendium.adversary-row.<adversary-id>` |
+| Empty state | `compendium.selector-sheet.empty-state` |
+| Done button | `compendium.selector-sheet.done-button` |
+| Import DHPack button | `compendium.selector-sheet.import-button` |
 
 ---
 


### PR DESCRIPTION
Closes #107.

## Summary

- New `CompendiumSelectorSheet` — modal adversary selector replacing `CompendiumBrowserView` as the selection-mode entry point from the encounter editor on iOS
- `AdversaryFilterBar` (search + tier + type) pinned at top; filter state owned locally
- Adversary list rows are `Button`s — tap calls `onSelect(_:)` and dismisses
- "Done" toolbar button always visible (`cancellationAction`)
- "Import DHPack" toolbar button opens `.fileImporter` for `gwillish.Encounter.dhpack` files; calls `contentStore.importPack(from:)` without dismissing the sheet
- AX identifier: `compendium.selector-sheet`

## Tests

`CompendiumSelectorSheetTests` (4 cases, all green):

- [ ] `showsAdversaryFilterBar` — tier and type pickers present
- [ ] `adversaryRowTapCallsOnSelect` — tapping an adversary row invokes the callback with the correct adversary
- [ ] `importDHPackButtonPresent` — toolbar button label present
- [ ] `doneButtonPresent` — toolbar button label present