### PR TITLE
fix: address review feedback on #148

### DIFF
--- a/Encounter/Views/Adversary+Filtering.swift
+++ b/Encounter/Views/Adversary+Filtering.swift
@@ -6,7 +6,8 @@ extension [Adversary] {
   // Parent views own the filter state and call this to derive the displayed list.
   nonisolated func filtered(searchText: String, tier: Int?, type: AdversaryType?) -> [Adversary] {
     filter { adversary in
-      let matchesSearch = searchText.isEmpty
+      let matchesSearch =
+        searchText.isEmpty
         || adversary.name.localizedStandardContains(searchText)
       let matchesTier = tier == nil || adversary.tier == tier
       let matchesType = type == nil || adversary.role == type

--- a/Encounter/Views/EncounterAndPartyRootView.swift
+++ b/Encounter/Views/EncounterAndPartyRootView.swift
@@ -29,6 +29,7 @@
     @State private var isConfirmingDeleteEncounter = false
     @State private var deleteEncounterTarget: EncounterDefinition?
     @State private var actionError: String?
+    @State private var isShowingActionError = false
     @State private var isAddingPlayer = false
     @State private var editPlayerTarget: Player?
     @State private var deletePlayerTarget: Player?
@@ -132,6 +133,11 @@
           Task { await playerStore.updatePlayer(updated) }
         }
       }
+      .alert("Action Failed", isPresented: $isShowingActionError) {
+        Button("OK", role: .cancel) { actionError = nil }
+      } message: {
+        Text(actionError ?? "")
+      }
     }
 
     // MARK: - Toolbar
@@ -180,7 +186,7 @@
                   isPaused: pausedDefinitionIDs.contains(definition.id)
                 )
               }
-              .accessibilityIdentifier("root.encounter-row")
+              .accessibilityIdentifier("root.encounter-row.\(definition.id)")
               .swipeActions(edge: .trailing, allowsFullSwipe: false) {
                 Button(role: .destructive) {
                   beginDeleteEncounter(definition)
@@ -242,7 +248,7 @@
         }
       }
       .opacity(hidden ? 0.5 : 1.0)
-      .accessibilityIdentifier("root.party-row")
+      .accessibilityIdentifier("root.party-row.\(player.id)")
       .accessibilityLabel(hidden ? "\(player.name), hidden" : player.name)
       .swipeActions(edge: .trailing, allowsFullSwipe: false) {
         Button(role: .destructive) {
@@ -295,6 +301,7 @@
           try await store.create(name: finalName)
         } catch {
           actionError = error.localizedDescription
+          isShowingActionError = true
         }
       }
     }
@@ -308,14 +315,14 @@
     private func commitRenameEncounter() {
       guard var target = renameTarget else { return }
       let trimmed = renameText.trimmingCharacters(in: .whitespaces)
-      guard !trimmed.isEmpty else { return }
-      target.name = trimmed
+      target.name = trimmed.isEmpty ? target.name : trimmed
       renameTarget = nil
       Task {
         do {
           try await store.save(target)
         } catch {
           actionError = error.localizedDescription
+          isShowingActionError = true
         }
       }
     }
@@ -333,6 +340,7 @@
           try await store.delete(id: target.id)
         } catch {
           actionError = error.localizedDescription
+          isShowingActionError = true
         }
       }
     }

--- a/docs/ui-vocabulary.md
+++ b/docs/ui-vocabulary.md
@@ -173,8 +173,12 @@ Single root screen for the iOS encounters workflow.
 | Element | Identifier |
 |---|---|
 | Root mode toggle | `root.mode-toggle` |
-| Encounter row | `root.encounter-row` |
-| Party row | `root.party-row` |
+| New Encounter button | `library.create-button` |
+| New name field (alert) | `library.new-name-field` |
+| Rename field (alert) | `library.rename-field` |
+| Add Player button | `party.add-button` |
+| Encounter row | `root.encounter-row.<encounter-id>` |
+| Party row | `root.party-row.<player-id>` |
 | In-progress badge | `library.row.in-progress-badge` |
 | Resume button (row) | `library.row.resume-button` |
 | Hide player button | `party.hide-button` |


### PR DESCRIPTION
Follow-up to #148. Fixes that were prepared during code review but not committed before the branch was pushed and merged.

## Changes

- **`actionError` wired up** — adds `isShowingActionError` state and an "Action Failed" alert; errors from `store.create`, `store.save`, and `store.delete` now surface to the user instead of disappearing silently
- **Unique AX row identifiers** — `root.encounter-row` and `root.party-row` now include the entity UUID suffix (`root.encounter-row.<encounter-id>`, `root.party-row.<player-id>`), consistent with the `compendium.adversary-row.<id>` pattern from #107
- **Rename empty-input fallback** — empty input now keeps the existing name instead of silently no-oping while the alert dismisses
- **Vocabulary doc** — `EncounterAndPartyRootView` identifier table updated with `library.create-button`, `library.new-name-field`, `library.rename-field`, `party.add-button`; row identifier entries corrected to show the `<id>` suffix format
- **swift-format** — reflow `Adversary+Filtering.swift` (line-wrap only)

## Test plan

- [x] `xcodebuild test -scheme Encounter -destination 'platform=macOS'` — all tests pass