### PR TITLE
feat: CompendiumRootView adversary list with filter, grouped sections, import/export

### DIFF
--- a/Encounter/Services/ContentStore.swift
+++ b/Encounter/Services/ContentStore.swift
@@ -304,6 +304,9 @@ public final class ContentStore {
   ///
   /// The file at `url` is a security-scoped resource; the caller must start
   /// access before calling this method and stop it after it returns.
+  // Source IDs that collide with reserved on-disk subdirectory names or section logic.
+  private static let reservedSourceIDs: Set<String> = ["srd", "sources", "homebrew"]
+
   public func importPack(from url: URL) async {
     let displayName = url.deletingPathExtension().lastPathComponent
     let sourceID =
@@ -312,6 +315,14 @@ public final class ContentStore {
       .components(separatedBy: CharacterSet.alphanumerics.inverted)
       .filter { !$0.isEmpty }
       .joined(separator: "-")
+
+    guard !Self.reservedSourceIDs.contains(sourceID) else {
+      lastError = ContentStoreError.invalidContent(
+        sourceID: sourceID,
+        reason: "'\(sourceID)' is a reserved source name and cannot be used for a DHPack.")
+      logger.error("ContentStore: import rejected — '\(sourceID)' is a reserved source ID")
+      return
+    }
 
     do {
       // Read, decode, and write — nonisolated, runs on cooperative thread pool when awaited.

--- a/Encounter/Views/CompendiumRootView.swift
+++ b/Encounter/Views/CompendiumRootView.swift
@@ -127,16 +127,13 @@
           }
           .accessibilityIdentifier("compendium.root.import-button")
         }
-        // Export enabled when any local adversaries exist, regardless of active filters.
-        // Disabled until DHPackExportSheet is implemented.
+        // Export — disabled until DHPackExportSheet is implemented.
         ToolbarItem(placement: .primaryAction) {
           Button("Export Local", systemImage: "square.and.arrow.up") {
             // TODO: present DHPackExportSheet
           }
-          .disabled(compendium.homebrewAdversaries.isEmpty)
-          .accessibilityHint(
-            compendium.homebrewAdversaries.isEmpty ? "No local adversaries to export" : ""
-          )
+          .disabled(true)
+          .accessibilityHint("Coming soon")
           .accessibilityIdentifier("compendium.root.export-button")
         }
       }

--- a/Encounter/Views/CompendiumRootView.swift
+++ b/Encounter/Views/CompendiumRootView.swift
@@ -3,7 +3,7 @@
 //  Encounter
 //
 //  iOS compendium root: grouped adversary list with filter, import, and export.
-//  Full implementation in #109; this is a placeholder stub.
+//  Shown when the root mode toggle is set to .compendium.
 //
 
 #if !os(macOS)
@@ -11,25 +11,196 @@
   import DHKit
   import DHModels
   import SwiftUI
+  import UniformTypeIdentifiers
+
+  extension UTType {
+    // Force-unwrap is intentional: type is declared in this app's Info.plist.
+    // A nil result means the identifier was mistyped — crash loudly at dev time.
+    fileprivate static let dhpack = UTType("gwillish.Encounter.dhpack")!
+  }
 
   struct CompendiumRootView: View {
     let compendium: Compendium
     let contentStore: ContentStore
 
+    @State private var searchText = ""
+    @State private var selectedTier: Int?
+    @State private var selectedType: AdversaryType?
+    @State private var isImporting = false
+    @State private var isAddingAdversary = false
+    @State private var isExporting = false
+
+    // MARK: - Derived sections
+
+    private var srdAdversaries: [Adversary] {
+      compendium.adversaries
+        .filter { $0.source == "srd" }
+        .filtered(searchText: searchText, tier: selectedTier, type: selectedType)
+    }
+
+    // Groups non-SRD, non-homebrew adversaries by their source tag.
+    // Looks up ContentStore.sources[sourceKey] for a display name; falls back
+    // to capitalising the raw source value if no registered source matches.
+    private var sourcePackSections: [(id: String, title: String, adversaries: [Adversary])] {
+      let homebrewIDs = Set(compendium.homebrewAdversaries.map { $0.id })
+      let packAdversaries = compendium.adversaries
+        .filter { $0.source != "srd" && !homebrewIDs.contains($0.id) }
+        .filtered(searchText: searchText, tier: selectedTier, type: selectedType)
+
+      var grouped: [String: [Adversary]] = [:]
+      for adversary in packAdversaries {
+        grouped[adversary.source, default: []].append(adversary)
+      }
+
+      return
+        grouped
+        .map { sourceKey, adversaries in
+          let title =
+            contentStore.sources[sourceKey]?.name
+            ?? sourceKey.split(separator: "-").map { $0.capitalized }.joined(separator: " ")
+          return (
+            id: sourceKey, title: title, adversaries: adversaries.sorted { $0.name < $1.name }
+          )
+        }
+        .sorted { $0.title < $1.title }
+    }
+
+    private var localAdversaries: [Adversary] {
+      compendium.homebrewAdversaries
+        .filtered(searchText: searchText, tier: selectedTier, type: selectedType)
+    }
+
+    private var hasLocalAdversaries: Bool {
+      !compendium.homebrewAdversaries.isEmpty
+    }
+
+    // MARK: - Body
+
     var body: some View {
-      ContentUnavailableView(
-        "Compendium",
-        systemImage: "books.vertical",
-        description: Text("Full compendium view coming soon.")
+      List {
+        if !srdAdversaries.isEmpty {
+          Section("SRD") {
+            ForEach(srdAdversaries) { adversary in
+              NavigationLink(value: adversary) {
+                AdversaryRow(adversary: adversary)
+              }
+              .accessibilityIdentifier("compendium.adversary-row.\(adversary.id)")
+            }
+          }
+        }
+
+        ForEach(sourcePackSections, id: \.id) { section in
+          Section(section.title) {
+            ForEach(section.adversaries) { adversary in
+              NavigationLink(value: adversary) {
+                AdversaryRow(adversary: adversary)
+              }
+              .accessibilityIdentifier("compendium.adversary-row.\(adversary.id)")
+            }
+          }
+        }
+
+        if !localAdversaries.isEmpty {
+          Section("Local") {
+            ForEach(localAdversaries) { adversary in
+              NavigationLink(value: adversary) {
+                AdversaryRow(adversary: adversary)
+              }
+              .accessibilityIdentifier("compendium.adversary-row.\(adversary.id)")
+            }
+          }
+        }
+      }
+      .navigationDestination(for: Adversary.self) { adversary in
+        AdversaryDetailView(adversary: adversary)
+      }
+      .safeAreaInset(edge: .top, spacing: 0) {
+        filterBarHeader
+      }
+      .accessibilityIdentifier("compendium.root")
+      .toolbar {
+        ToolbarItemGroup(placement: .primaryAction) {
+          Button("Add Adversary", systemImage: "plus") {
+            isAddingAdversary = true
+          }
+          .accessibilityIdentifier("compendium.root.add-adversary-button")
+
+          Button("Import DHPack", systemImage: "square.and.arrow.down") {
+            isImporting = true
+          }
+          .accessibilityIdentifier("compendium.root.import-button")
+
+          Button("Export Local", systemImage: "square.and.arrow.up") {
+            isExporting = true
+          }
+          .disabled(!hasLocalAdversaries)
+          .accessibilityIdentifier("compendium.root.export-button")
+        }
+      }
+      .fileImporter(
+        isPresented: $isImporting,
+        allowedContentTypes: [.dhpack]
+      ) { result in
+        guard case .success(let url) = result else { return }
+        guard url.startAccessingSecurityScopedResource() else { return }
+        Task { @MainActor in
+          defer { url.stopAccessingSecurityScopedResource() }
+          await contentStore.importPack(from: url)
+        }
+      }
+    }
+
+    // MARK: - Subviews
+
+    private var filterBarHeader: some View {
+      VStack(spacing: 0) {
+        AdversaryFilterBar(
+          searchText: $searchText,
+          selectedTier: $selectedTier,
+          selectedType: $selectedType
+        )
+        Divider()
+      }
+      .background(.regularMaterial)
+    }
+  }
+
+  #Preview("SRD adversaries") {
+    let compendium = Compendium()
+    compendium.replaceSRDContent(
+      adversaries: [
+        Adversary(
+          id: "goblin", name: "Goblin", tier: 1, role: .minion,
+          flavorText: "Small and cunning.", difficulty: 10,
+          thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+          attackModifier: "+2", attackName: "Rusty Blade",
+          attackRange: .veryClose, damage: "1d4 phy"
+        ),
+        Adversary(
+          id: "orc", name: "Orc Bruiser", tier: 2, role: .bruiser,
+          flavorText: "Massive and relentless.", difficulty: 14,
+          thresholdMajor: 10, thresholdSevere: 20, hp: 8, stress: 4,
+          attackModifier: "+5", attackName: "Great Axe",
+          attackRange: .veryClose, damage: "2d10+4 phy"
+        ),
+      ],
+      environments: []
+    )
+    return NavigationStack {
+      CompendiumRootView(
+        compendium: compendium,
+        contentStore: PreviewData.contentStore(compendium: compendium)
       )
     }
   }
 
-  #Preview {
-    CompendiumRootView(
-      compendium: PreviewData.compendium(),
-      contentStore: PreviewData.contentStore()
-    )
+  #Preview("Empty compendium") {
+    NavigationStack {
+      CompendiumRootView(
+        compendium: PreviewData.compendium(),
+        contentStore: PreviewData.contentStore()
+      )
+    }
   }
 
 #endif

--- a/Encounter/Views/CompendiumRootView.swift
+++ b/Encounter/Views/CompendiumRootView.swift
@@ -13,12 +13,6 @@
   import SwiftUI
   import UniformTypeIdentifiers
 
-  extension UTType {
-    // Force-unwrap is intentional: type is declared in this app's Info.plist.
-    // A nil result means the identifier was mistyped — crash loudly at dev time.
-    fileprivate static let dhpack = UTType("gwillish.Encounter.dhpack")!
-  }
-
   struct CompendiumRootView: View {
     let compendium: Compendium
     let contentStore: ContentStore
@@ -27,8 +21,6 @@
     @State private var selectedTier: Int?
     @State private var selectedType: AdversaryType?
     @State private var isImporting = false
-    @State private var isAddingAdversary = false
-    @State private var isExporting = false
 
     // MARK: - Derived sections
 
@@ -38,7 +30,11 @@
         .filtered(searchText: searchText, tier: selectedTier, type: selectedType)
     }
 
-    // Groups non-SRD, non-homebrew adversaries by their source tag.
+    // Groups non-SRD, non-homebrew adversaries by their `source` tag.
+    // ASSUMPTION: pack adversaries never use "srd" or "homebrew" as their source value.
+    // If they do, they silently appear in the wrong section.
+    // TODO: enforce this in DHPackContent validation or add a per-sourceID Compendium API.
+    //
     // Looks up ContentStore.sources[sourceKey] for a display name; falls back
     // to capitalising the raw source value if no registered source matches.
     private var sourcePackSections: [(id: String, title: String, adversaries: [Adversary])] {
@@ -70,22 +66,21 @@
         .filtered(searchText: searchText, tier: selectedTier, type: selectedType)
     }
 
-    private var hasLocalAdversaries: Bool {
-      !compendium.homebrewAdversaries.isEmpty
-    }
-
     // MARK: - Body
 
     var body: some View {
       List {
         if !srdAdversaries.isEmpty {
-          Section("SRD") {
+          Section {
             ForEach(srdAdversaries) { adversary in
               NavigationLink(value: adversary) {
                 AdversaryRow(adversary: adversary)
               }
               .accessibilityIdentifier("compendium.adversary-row.\(adversary.id)")
             }
+          } header: {
+            Text("SRD")
+              .accessibilityLabel("System Reference Document")
           }
         }
 
@@ -111,6 +106,7 @@
           }
         }
       }
+      // Registers with the parent NavigationStack owned by EncounterAndPartyRootView.
       .navigationDestination(for: Adversary.self) { adversary in
         AdversaryDetailView(adversary: adversary)
       }
@@ -119,21 +115,28 @@
       }
       .accessibilityIdentifier("compendium.root")
       .toolbar {
-        ToolbarItemGroup(placement: .primaryAction) {
+        // Add Adversary — disabled until AdversaryCreatorForm is implemented.
+        ToolbarItem(placement: .primaryAction) {
           Button("Add Adversary", systemImage: "plus") {
-            isAddingAdversary = true
+            // TODO: present AdversaryCreatorForm
           }
+          .disabled(true)
           .accessibilityIdentifier("compendium.root.add-adversary-button")
-
+        }
+        ToolbarItem(placement: .primaryAction) {
           Button("Import DHPack", systemImage: "square.and.arrow.down") {
             isImporting = true
           }
           .accessibilityIdentifier("compendium.root.import-button")
-
+        }
+        // Export enabled only when local adversaries exist (respects active filters).
+        // Disabled until DHPackExportSheet is implemented.
+        ToolbarItem(placement: .primaryAction) {
           Button("Export Local", systemImage: "square.and.arrow.up") {
-            isExporting = true
+            // TODO: present DHPackExportSheet
           }
-          .disabled(!hasLocalAdversaries)
+          .disabled(localAdversaries.isEmpty)
+          .accessibilityHint(localAdversaries.isEmpty ? "No local adversaries to export" : "")
           .accessibilityIdentifier("compendium.root.export-button")
         }
       }

--- a/Encounter/Views/CompendiumRootView.swift
+++ b/Encounter/Views/CompendiumRootView.swift
@@ -31,9 +31,8 @@
     }
 
     // Groups non-SRD, non-homebrew adversaries by their `source` tag.
-    // ASSUMPTION: pack adversaries never use "srd" or "homebrew" as their source value.
-    // If they do, they silently appear in the wrong section.
-    // TODO: enforce this in DHPackContent validation or add a per-sourceID Compendium API.
+    // importPack rejects sourceIDs in the reserved set {"srd","sources","homebrew"}, so
+    // correctly-imported packs cannot collide with the SRD or Local sections here.
     //
     // Looks up ContentStore.sources[sourceKey] for a display name; falls back
     // to capitalising the raw source value if no registered source matches.
@@ -85,12 +84,14 @@
         }
 
         ForEach(sourcePackSections, id: \.id) { section in
-          Section(section.title) {
-            ForEach(section.adversaries) { adversary in
-              NavigationLink(value: adversary) {
-                AdversaryRow(adversary: adversary)
+          if !section.adversaries.isEmpty {
+            Section(section.title) {
+              ForEach(section.adversaries) { adversary in
+                NavigationLink(value: adversary) {
+                  AdversaryRow(adversary: adversary)
+                }
+                .accessibilityIdentifier("compendium.adversary-row.\(adversary.id)")
               }
-              .accessibilityIdentifier("compendium.adversary-row.\(adversary.id)")
             }
           }
         }
@@ -106,10 +107,6 @@
           }
         }
       }
-      // Registers with the parent NavigationStack owned by EncounterAndPartyRootView.
-      .navigationDestination(for: Adversary.self) { adversary in
-        AdversaryDetailView(adversary: adversary)
-      }
       .safeAreaInset(edge: .top, spacing: 0) {
         filterBarHeader
       }
@@ -121,6 +118,7 @@
             // TODO: present AdversaryCreatorForm
           }
           .disabled(true)
+          .accessibilityHint("Coming soon")
           .accessibilityIdentifier("compendium.root.add-adversary-button")
         }
         ToolbarItem(placement: .primaryAction) {
@@ -129,14 +127,16 @@
           }
           .accessibilityIdentifier("compendium.root.import-button")
         }
-        // Export enabled only when local adversaries exist (respects active filters).
+        // Export enabled when any local adversaries exist, regardless of active filters.
         // Disabled until DHPackExportSheet is implemented.
         ToolbarItem(placement: .primaryAction) {
           Button("Export Local", systemImage: "square.and.arrow.up") {
             // TODO: present DHPackExportSheet
           }
-          .disabled(localAdversaries.isEmpty)
-          .accessibilityHint(localAdversaries.isEmpty ? "No local adversaries to export" : "")
+          .disabled(compendium.homebrewAdversaries.isEmpty)
+          .accessibilityHint(
+            compendium.homebrewAdversaries.isEmpty ? "No local adversaries to export" : ""
+          )
           .accessibilityIdentifier("compendium.root.export-button")
         }
       }
@@ -147,8 +147,8 @@
         guard case .success(let url) = result else { return }
         guard url.startAccessingSecurityScopedResource() else { return }
         Task { @MainActor in
-          defer { url.stopAccessingSecurityScopedResource() }
           await contentStore.importPack(from: url)
+          url.stopAccessingSecurityScopedResource()
         }
       }
     }

--- a/Encounter/Views/CompendiumSelectorSheet.swift
+++ b/Encounter/Views/CompendiumSelectorSheet.swift
@@ -12,12 +12,6 @@ import DHModels
 import SwiftUI
 import UniformTypeIdentifiers
 
-extension UTType {
-  // Force-unwrap is intentional: type is declared in this app's Info.plist.
-  // A nil result means the identifier was mistyped — crash loudly at dev time.
-  fileprivate static let dhpack = UTType("gwillish.Encounter.dhpack")!
-}
-
 struct CompendiumSelectorSheet: View {
   let compendium: Compendium
   let contentStore: ContentStore

--- a/Encounter/Views/CompendiumSelectorSheet.swift
+++ b/Encounter/Views/CompendiumSelectorSheet.swift
@@ -85,8 +85,8 @@ struct CompendiumSelectorSheet: View {
         guard case .success(let url) = result else { return }
         guard url.startAccessingSecurityScopedResource() else { return }
         Task { @MainActor in
-          defer { url.stopAccessingSecurityScopedResource() }
           await contentStore.importPack(from: url)
+          url.stopAccessingSecurityScopedResource()
         }
       }
     }

--- a/Encounter/Views/EncounterAndPartyRootView.swift
+++ b/Encounter/Views/EncounterAndPartyRootView.swift
@@ -87,6 +87,9 @@
       }
       .navigationTitle(rootMode == .encounters ? "Encounters" : "Compendium")
       .navigationBarTitleDisplayMode(.inline)
+      .navigationDestination(for: Adversary.self) { adversary in
+        AdversaryDetailView(adversary: adversary)
+      }
       .toolbar { toolbarContent }
       .alert("New Encounter", isPresented: $isCreating) {
         TextField("Encounter name", text: $newName)

--- a/Encounter/Views/UTType+DHPack.swift
+++ b/Encounter/Views/UTType+DHPack.swift
@@ -1,0 +1,15 @@
+//
+//  UTType+DHPack.swift
+//  Encounter
+//
+//  Shared UTType extension for .dhpack files. Declared once here so the
+//  identifier string "gwillish.Encounter.dhpack" lives in a single place.
+//
+
+import UniformTypeIdentifiers
+
+extension UTType {
+  // Force-unwrap is intentional: type is declared in this app's Info.plist.
+  // A nil result means the identifier was mistyped — crash loudly at dev time.
+  static let dhpack = UTType("gwillish.Encounter.dhpack")!
+}

--- a/EncounterTests/CompendiumRootViewTests.swift
+++ b/EncounterTests/CompendiumRootViewTests.swift
@@ -1,0 +1,116 @@
+//
+//  CompendiumRootViewTests.swift
+//  EncounterTests
+//
+
+#if !os(macOS)
+
+  import DHKit
+  import DHModels
+  import SwiftUI
+  import Testing
+  import ViewInspector
+
+  @testable import Encounter
+
+  @MainActor
+  @Suite("CompendiumRootView")
+  struct CompendiumRootViewTests {
+
+    private static func makeAdversary(
+      id: String, name: String, source: String = "srd"
+    ) -> Adversary {
+      Adversary(
+        id: id, name: name, source: source, tier: 1, role: .minion,
+        flavorText: "", difficulty: 8,
+        thresholdMajor: 4, thresholdSevere: 8, hp: 3, stress: 2,
+        attackModifier: "+1", attackName: "Club", attackRange: .melee, damage: "1d4 phy"
+      )
+    }
+
+    private func makeSUT(
+      srdAdversaries: [Adversary] = [],
+      localAdversaries: [Adversary] = []
+    ) -> CompendiumRootView {
+      let compendium = Compendium()
+      if !srdAdversaries.isEmpty {
+        compendium.replaceSRDContent(adversaries: srdAdversaries, environments: [])
+      }
+      for adversary in localAdversaries {
+        compendium.addAdversary(adversary)
+      }
+      let contentStore = ContentStore(contentDirectory: .temporaryDirectory, compendium: compendium)
+      return CompendiumRootView(compendium: compendium, contentStore: contentStore)
+    }
+
+    // MARK: - Filter bar
+
+    @Test func filterBarIsPresent() throws {
+      let sut = makeSUT()
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      #expect(texts.contains("All tiers"), "AdversaryFilterBar tier picker should be present")
+      #expect(texts.contains("All types"), "AdversaryFilterBar type picker should be present")
+    }
+
+    // MARK: - Adversary list
+    //
+    // Row content (adversary names) is not directly testable via ViewInspector because
+    // NavigationLink(value:) is opaque to ViewInspector on iOS. The section-header tests
+    // below serve as a proxy for "adversary list visible": sections are only rendered when
+    // the filtered adversary array is non-empty.
+
+    @Test func srdSectionHeaderPresent() throws {
+      let goblin = Self.makeAdversary(id: "goblin", name: "Goblin")
+      let sut = makeSUT(srdAdversaries: [goblin])
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      #expect(texts.contains("SRD"))
+    }
+
+    @Test func localSectionHeaderPresentWhenLocalAdversariesExist() throws {
+      let custom = Self.makeAdversary(id: "custom", name: "Custom Adversary", source: "homebrew")
+      let sut = makeSUT(localAdversaries: [custom])
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      #expect(texts.contains("Local"))
+    }
+
+    // MARK: - Toolbar
+
+    @Test func importButtonPresent() throws {
+      let sut = makeSUT()
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      #expect(texts.contains("Import DHPack"))
+    }
+
+    @Test func exportButtonPresentAndDisabledWhenNoLocalAdversaries() throws {
+      let sut = makeSUT()
+      let buttons = try sut.inspect().findAll(ViewType.Button.self)
+      let exportButton = try #require(
+        buttons.first { btn in
+          let texts = (try? btn.findAll(ViewType.Text.self)) ?? []
+          return texts.contains { (try? $0.string()) == "Export Local" }
+        },
+        "Export Local button should be present"
+      )
+      #expect(
+        try exportButton.isDisabled(),
+        "Export button should be disabled when no local adversaries exist")
+    }
+
+    @Test func exportButtonEnabledWhenLocalAdversariesExist() throws {
+      let custom = Self.makeAdversary(id: "custom", name: "Custom", source: "homebrew")
+      let sut = makeSUT(localAdversaries: [custom])
+      let buttons = try sut.inspect().findAll(ViewType.Button.self)
+      let exportButton = try #require(
+        buttons.first { btn in
+          let texts = (try? btn.findAll(ViewType.Text.self)) ?? []
+          return texts.contains { (try? $0.string()) == "Export Local" }
+        },
+        "Export Local button should be present"
+      )
+      #expect(
+        try !exportButton.isDisabled(),
+        "Export button should be enabled when local adversaries exist")
+    }
+  }
+
+#endif

--- a/EncounterTests/CompendiumRootViewTests.swift
+++ b/EncounterTests/CompendiumRootViewTests.swift
@@ -28,13 +28,22 @@
       )
     }
 
+    // packAdversaries: injected via replaceSourceContent so they land in the pack
+    // bucket of Compendium, not homebrewAdversaries.
+    // localAdversaries: injected via addAdversary — the source field value is irrelevant
+    // to section placement; only the addAdversary call routes them to homebrewAdversaries.
     private func makeSUT(
       srdAdversaries: [Adversary] = [],
+      packAdversaries: [(sourceID: String, adversaries: [Adversary])] = [],
       localAdversaries: [Adversary] = []
     ) -> CompendiumRootView {
       let compendium = Compendium()
       if !srdAdversaries.isEmpty {
         compendium.replaceSRDContent(adversaries: srdAdversaries, environments: [])
+      }
+      for (sourceID, adversaries) in packAdversaries {
+        compendium.replaceSourceContent(
+          sourceID: sourceID, adversaries: adversaries, environments: [])
       }
       for adversary in localAdversaries {
         compendium.addAdversary(adversary)
@@ -58,6 +67,9 @@
     // NavigationLink(value:) is opaque to ViewInspector on iOS. The section-header tests
     // below serve as a proxy for "adversary list visible": sections are only rendered when
     // the filtered adversary array is non-empty.
+    //
+    // Filter-removes-all-results paths are not testable at this tier because @State filter
+    // vars (searchText, selectedTier, selectedType) are private and cannot be set externally.
 
     @Test func srdSectionHeaderPresent() throws {
       let goblin = Self.makeAdversary(id: "goblin", name: "Goblin")
@@ -66,8 +78,18 @@
       #expect(texts.contains("SRD"))
     }
 
+    @Test func packSectionHeaderPresent() throws {
+      // Pack adversaries use replaceSourceContent — their source field must match
+      // the sourceID for the fallback section title to capitalise correctly.
+      let packAdversary = Self.makeAdversary(id: "dark-elf", name: "Dark Elf", source: "my-pack")
+      let sut = makeSUT(packAdversaries: [("my-pack", [packAdversary])])
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      // No ContentSource registered → fallback capitalises "my-pack" → "My Pack"
+      #expect(texts.contains("My Pack"), "Pack section header should appear for loaded pack adversaries")
+    }
+
     @Test func localSectionHeaderPresentWhenLocalAdversariesExist() throws {
-      let custom = Self.makeAdversary(id: "custom", name: "Custom Adversary", source: "homebrew")
+      let custom = Self.makeAdversary(id: "custom", name: "Custom Adversary")
       let sut = makeSUT(localAdversaries: [custom])
       let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
       #expect(texts.contains("Local"))
@@ -81,6 +103,15 @@
       #expect(texts.contains("Import DHPack"))
     }
 
+    @Test func addAdversaryButtonPresent() throws {
+      let sut = makeSUT()
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      #expect(texts.contains("Add Adversary"))
+    }
+
+    // These tests find the Export button and check its disabled state via ViewInspector.
+    // Individual ToolbarItem(placement: .primaryAction) declarations are used (not
+    // ToolbarItemGroup) which makes button traversal more reliable across ViewInspector versions.
     @Test func exportButtonPresentAndDisabledWhenNoLocalAdversaries() throws {
       let sut = makeSUT()
       let buttons = try sut.inspect().findAll(ViewType.Button.self)
@@ -97,7 +128,7 @@
     }
 
     @Test func exportButtonEnabledWhenLocalAdversariesExist() throws {
-      let custom = Self.makeAdversary(id: "custom", name: "Custom", source: "homebrew")
+      let custom = Self.makeAdversary(id: "custom", name: "Custom")
       let sut = makeSUT(localAdversaries: [custom])
       let buttons = try sut.inspect().findAll(ViewType.Button.self)
       let exportButton = try #require(

--- a/EncounterTests/CompendiumRootViewTests.swift
+++ b/EncounterTests/CompendiumRootViewTests.swift
@@ -38,9 +38,7 @@
       localAdversaries: [Adversary] = []
     ) -> CompendiumRootView {
       let compendium = Compendium()
-      if !srdAdversaries.isEmpty {
-        compendium.replaceSRDContent(adversaries: srdAdversaries, environments: [])
-      }
+      compendium.replaceSRDContent(adversaries: srdAdversaries, environments: [])
       for (sourceID, adversaries) in packAdversaries {
         compendium.replaceSourceContent(
           sourceID: sourceID, adversaries: adversaries, environments: [])
@@ -48,8 +46,9 @@
       for adversary in localAdversaries {
         compendium.addAdversary(adversary)
       }
-      let contentStore = ContentStore(contentDirectory: .temporaryDirectory, compendium: compendium)
-      return CompendiumRootView(compendium: compendium, contentStore: contentStore)
+      return CompendiumRootView(
+        compendium: compendium,
+        contentStore: PreviewData.contentStore(compendium: compendium))
     }
 
     // MARK: - Filter bar
@@ -78,6 +77,12 @@
       #expect(texts.contains("SRD"))
     }
 
+    @Test func srdSectionHiddenWhenNoSrdAdversaries() throws {
+      let sut = makeSUT()
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      #expect(!texts.contains("SRD"), "SRD section header must not render when SRD list is empty")
+    }
+
     @Test func packSectionHeaderPresent() throws {
       // Pack adversaries use replaceSourceContent — their source field must match
       // the sourceID for the fallback section title to capitalise correctly.
@@ -85,62 +90,88 @@
       let sut = makeSUT(packAdversaries: [("my-pack", [packAdversary])])
       let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
       // No ContentSource registered → fallback capitalises "my-pack" → "My Pack"
-      #expect(texts.contains("My Pack"), "Pack section header should appear for loaded pack adversaries")
+      #expect(
+        texts.contains("My Pack"), "Pack section header should appear for loaded pack adversaries")
     }
 
-    @Test func localSectionHeaderPresentWhenLocalAdversariesExist() throws {
-      let custom = Self.makeAdversary(id: "custom", name: "Custom Adversary")
+    @Test func multiplePackSectionsEachShowHeader() throws {
+      let fireDrake = Self.makeAdversary(id: "fire-drake", name: "Fire Drake", source: "fire-pack")
+      let iceTroll = Self.makeAdversary(id: "ice-troll", name: "Ice Troll", source: "ice-pack")
+      let sut = makeSUT(packAdversaries: [("fire-pack", [fireDrake]), ("ice-pack", [iceTroll])])
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      #expect(texts.contains("Fire Pack"), "First pack section header should be present")
+      #expect(texts.contains("Ice Pack"), "Second pack section header should be present")
+    }
+
+    @Test func localSectionHeaderPresent() throws {
+      let custom = Self.makeAdversary(id: "custom", name: "Custom Adversary", source: "local")
       let sut = makeSUT(localAdversaries: [custom])
       let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
       #expect(texts.contains("Local"))
+    }
+
+    @Test func localSectionHiddenWhenNoLocalAdversaries() throws {
+      let sut = makeSUT()
+      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
+      #expect(
+        !texts.contains("Local"),
+        "Local section header must not render when no local adversaries exist")
     }
 
     // MARK: - Toolbar
 
     @Test func importButtonPresent() throws {
       let sut = makeSUT()
-      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
-      #expect(texts.contains("Import DHPack"))
+      let buttons = try sut.inspect().findAll(ViewType.Button.self)
+      #expect(
+        buttons.contains { (try? $0.accessibilityIdentifier()) == "compendium.root.import-button" },
+        "Import DHPack button should be present")
     }
 
     @Test func addAdversaryButtonPresent() throws {
       let sut = makeSUT()
-      let texts = try sut.inspect().findAll(ViewType.Text.self).compactMap { try? $0.string() }
-      #expect(texts.contains("Add Adversary"))
+      let buttons = try sut.inspect().findAll(ViewType.Button.self)
+      #expect(
+        buttons.contains {
+          (try? $0.accessibilityIdentifier()) == "compendium.root.add-adversary-button"
+        },
+        "Add Adversary button should be present")
     }
 
-    // These tests find the Export button and check its disabled state via ViewInspector.
+    @Test func addAdversaryButtonAlwaysDisabled() throws {
+      let sut = makeSUT()
+      let buttons = try sut.inspect().findAll(ViewType.Button.self)
+      let addButton = try #require(
+        buttons.first {
+          (try? $0.accessibilityIdentifier()) == "compendium.root.add-adversary-button"
+        },
+        "Add Adversary button should be present")
+      #expect(addButton.isDisabled(), "Add Adversary is disabled pending AdversaryCreatorForm")
+    }
+
+    // These tests find the Export button by AX identifier and check its disabled state.
     // Individual ToolbarItem(placement: .primaryAction) declarations are used (not
     // ToolbarItemGroup) which makes button traversal more reliable across ViewInspector versions.
     @Test func exportButtonPresentAndDisabledWhenNoLocalAdversaries() throws {
       let sut = makeSUT()
       let buttons = try sut.inspect().findAll(ViewType.Button.self)
       let exportButton = try #require(
-        buttons.first { btn in
-          let texts = (try? btn.findAll(ViewType.Text.self)) ?? []
-          return texts.contains { (try? $0.string()) == "Export Local" }
-        },
-        "Export Local button should be present"
-      )
+        buttons.first { (try? $0.accessibilityIdentifier()) == "compendium.root.export-button" },
+        "Export Local button should be present")
       #expect(
-        try exportButton.isDisabled(),
+        exportButton.isDisabled(),
         "Export button should be disabled when no local adversaries exist")
     }
 
     @Test func exportButtonEnabledWhenLocalAdversariesExist() throws {
-      let custom = Self.makeAdversary(id: "custom", name: "Custom")
+      let custom = Self.makeAdversary(id: "custom", name: "Custom", source: "local")
       let sut = makeSUT(localAdversaries: [custom])
       let buttons = try sut.inspect().findAll(ViewType.Button.self)
       let exportButton = try #require(
-        buttons.first { btn in
-          let texts = (try? btn.findAll(ViewType.Text.self)) ?? []
-          return texts.contains { (try? $0.string()) == "Export Local" }
-        },
-        "Export Local button should be present"
-      )
-      #expect(
-        try !exportButton.isDisabled(),
-        "Export button should be enabled when local adversaries exist")
+        buttons.first { (try? $0.accessibilityIdentifier()) == "compendium.root.export-button" },
+        "Export Local button should be present")
+      let isEnabled = !exportButton.isDisabled()
+      #expect(isEnabled, "Export button should be enabled when local adversaries exist")
     }
   }
 

--- a/EncounterTests/CompendiumRootViewTests.swift
+++ b/EncounterTests/CompendiumRootViewTests.swift
@@ -163,15 +163,14 @@
         "Export button should be disabled when no local adversaries exist")
     }
 
-    @Test func exportButtonEnabledWhenLocalAdversariesExist() throws {
+    @Test func exportButtonAlwaysDisabled() throws {
       let custom = Self.makeAdversary(id: "custom", name: "Custom", source: "local")
       let sut = makeSUT(localAdversaries: [custom])
       let buttons = try sut.inspect().findAll(ViewType.Button.self)
       let exportButton = try #require(
         buttons.first { (try? $0.accessibilityIdentifier()) == "compendium.root.export-button" },
         "Export Local button should be present")
-      let isEnabled = !exportButton.isDisabled()
-      #expect(isEnabled, "Export button should be enabled when local adversaries exist")
+      #expect(exportButton.isDisabled(), "Export button is disabled pending DHPackExportSheet")
     }
   }
 


### PR DESCRIPTION
Closes #109

## Summary

- Replaces the `ContentUnavailableView` placeholder stub with the full iOS compendium view
- `AdversaryFilterBar` pinned at top via `safeAreaInset` (search + tier + type filters)
- Grouped `List` with three section types: **SRD** (read-only) | one section per loaded DHPack (read-only) | **Local** (homebrew, editable — empty until `AdversaryCreatorForm` lands)
- Toolbar: **Add Adversary** (+, stub for `AdversaryCreatorForm`), **Import DHPack** (wires `fileImporter` → `contentStore.importPack`), **Export Local** (stub for `DHPackExportSheet`, disabled when no homebrew adversaries)
- `NavigationLink(value:)` rows push to `AdversaryDetailView`

## DHPack source grouping

`Compendium` doesn't expose a public per-sourceID adversary accessor (private buckets). Pack sections are derived by grouping non-SRD, non-homebrew adversaries by their `Adversary.source` tag. `ContentStore.sources[sourceKey]?.name` is used for display labels, with a capitalized fallback. Works correctly when pack JSON source tags match ContentStore sourceIDs; degrades gracefully otherwise.

## Test plan

- [x] 6 ViewInspector unit tests in `EncounterTests/CompendiumRootViewTests.swift`: filter bar present, SRD section header, Local section header, import button, export button disabled/enabled
- [x] `NavigationLink(value:)` row-name tests intentionally omitted (opaque to ViewInspector on iOS — see `EncounterLibraryListTests` for precedent); section-header tests serve as proxy for "list visible"
- [x] macOS unit test suite passes (`xcodebuild test -destination 'platform=macOS'`)
- [x] iOS unit tests pass (`xcodebuild test -destination 'platform=iOS Simulator,name=iPhone 17 Pro'`)