### PR TITLE
EncounterEditorView: replace .fullScreenCover runner presentation with NavigationLink push

### DIFF
--- a/Encounter/ContentView.swift
+++ b/Encounter/ContentView.swift
@@ -67,7 +67,7 @@ struct ContentView: View {
           let id = encounterSelection,
           let definition = store.definitions.first(where: { $0.id == id })
         {
-          EncounterBuilderView(
+          EncounterEditorView(
             definition: definition, store: store, compendium: compendium,
             sessionRegistry: sessionRegistry, sessionStore: sessionStore,
             playerStore: playerStore

--- a/Encounter/Views/AdversaryDetailView.swift
+++ b/Encounter/Views/AdversaryDetailView.swift
@@ -3,7 +3,7 @@
 //  Encounter
 //
 //  Full stat card for a single adversary.
-//  When onSelect is provided (e.g. called from EncounterBuilderView),
+//  When onSelect is provided (e.g. called from EncounterEditorView),
 //  an "Add to Encounter" toolbar button is shown.
 //
 

--- a/Encounter/Views/AdversaryRosterRow.swift
+++ b/Encounter/Views/AdversaryRosterRow.swift
@@ -2,7 +2,7 @@
 //  AdversaryRosterRow.swift
 //  Encounter
 //
-//  Single row in the adversary roster inside EncounterBuilderView.
+//  Single row in the adversary roster inside EncounterEditorView.
 //  Looks up the adversary by ID for display; shows a fallback if unresolvable.
 //  When partyTier is provided, off-tier adversaries show a TierBadgeView.
 //

--- a/Encounter/Views/BuilderNotesSection.swift
+++ b/Encounter/Views/BuilderNotesSection.swift
@@ -2,7 +2,7 @@
 //  BuilderNotesSection.swift
 //  Encounter
 //
-//  Collapsible notes section inside EncounterBuilderView.
+//  Collapsible notes section inside EncounterEditorView.
 //  Collapsed by default; onChange fires save() on every keystroke.
 //
 

--- a/Encounter/Views/CompendiumBrowserView.swift
+++ b/Encounter/Views/CompendiumBrowserView.swift
@@ -5,7 +5,7 @@
 //  Root screen for browsing the adversary and environment compendium.
 //
 //  The optional onSelect / onSelectEnvironment closures establish the
-//  Step 3 seam: when non-nil (called from EncounterBuilderView),
+//  Step 3 seam: when non-nil (called from EncounterEditorView),
 //  detail views show an "Add to Encounter" button that calls the closure
 //  and dismisses the sheet.
 //

--- a/Encounter/Views/EncounterAndPartyRootView.swift
+++ b/Encounter/Views/EncounterAndPartyRootView.swift
@@ -220,7 +220,7 @@
         }
       }
       .navigationDestination(for: EncounterDefinition.self) { definition in
-        EncounterBuilderView(
+        EncounterEditorView(
           definition: definition,
           store: store,
           compendium: compendium,

--- a/Encounter/Views/EncounterEditorView.swift
+++ b/Encounter/Views/EncounterEditorView.swift
@@ -1,5 +1,5 @@
 //
-//  EncounterBuilderView.swift
+//  EncounterEditorView.swift
 //  Encounter
 //
 //  Full encounter preparation screen.
@@ -14,7 +14,7 @@ import DHKit
 import DHModels
 import SwiftUI
 
-struct EncounterBuilderView: View {
+struct EncounterEditorView: View {
   let definition: EncounterDefinition
   let store: EncounterStore
   let compendium: Compendium
@@ -161,8 +161,8 @@ struct EncounterBuilderView: View {
         )
       }
     #else
-      .fullScreenCover(item: $runSession) { session in
-        EncounterRunnerContainer(
+      .navigationDestination(item: $runSession) { session in
+        EncounterRunnerView(
           session: session, definition: draft,
           compendium: compendium, sessionRegistry: sessionRegistry, sessionStore: sessionStore
         )
@@ -279,7 +279,7 @@ struct EncounterBuilderView: View {
 }
 
 #Preview {
-  let store = EncounterStore(directory: URL.temporaryDirectory.appending(path: "preview-builder"))
+  let store = EncounterStore(directory: URL.temporaryDirectory.appending(path: "preview-editor"))
   let compendium = Compendium()
   compendium.addAdversary(
     Adversary(
@@ -301,7 +301,7 @@ struct EncounterBuilderView: View {
   let sessionRegistry = PreviewData.sessionRegistry()
   let sessionStore = PreviewData.sessionStore()
   return NavigationStack {
-    EncounterBuilderPreviewWrapper(
+    EncounterEditorPreviewWrapper(
       store: store, compendium: compendium,
       sessionRegistry: sessionRegistry, sessionStore: sessionStore,
       playerStore: playerStore
@@ -309,8 +309,8 @@ struct EncounterBuilderView: View {
   }
 }
 
-/// Preview wrapper that creates a definition in the store before showing the builder.
-private struct EncounterBuilderPreviewWrapper: View {
+/// Preview wrapper that creates a definition in the store before showing the editor.
+private struct EncounterEditorPreviewWrapper: View {
   let store: EncounterStore
   let compendium: Compendium
   let sessionRegistry: SessionRegistry
@@ -321,7 +321,7 @@ private struct EncounterBuilderPreviewWrapper: View {
   var body: some View {
     Group {
       if let definition {
-        EncounterBuilderView(
+        EncounterEditorView(
           definition: definition, store: store, compendium: compendium,
           sessionRegistry: sessionRegistry, sessionStore: sessionStore,
           playerStore: playerStore

--- a/Encounter/Views/EncounterLibraryView.swift
+++ b/Encounter/Views/EncounterLibraryView.swift
@@ -95,7 +95,7 @@ struct EncounterLibraryView: View {
     }
     #if !os(macOS)
       .navigationDestination(for: EncounterDefinition.self) { definition in
-        EncounterBuilderView(
+        EncounterEditorView(
           definition: definition, store: store, compendium: compendium,
           sessionRegistry: sessionRegistry, sessionStore: sessionStore,
           playerStore: playerStore

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -2,8 +2,8 @@
 //  EncounterRunnerView.swift
 //  Encounter
 //
-//  Live encounter running screen. Presented via fullScreenCover (iOS) /
-//  sheet (macOS) from EncounterBuilderView.
+//  Live encounter running screen. Pushed onto the NavigationStack (iOS) /
+//  presented as a sheet (macOS) from EncounterEditorView.
 //
 //  Layout:
 //   - Nav bar: encounter name + FearTrackerButton (trailing)

--- a/Encounter/Views/PlayerRosterRow.swift
+++ b/Encounter/Views/PlayerRosterRow.swift
@@ -2,7 +2,7 @@
 //  PlayerRosterRow.swift
 //  Encounter
 //
-//  Single row in the player roster inside EncounterBuilderView.
+//  Single row in the player roster inside EncounterEditorView.
 //  Shows name, HP, Stress, and Evasion.
 //
 

--- a/Encounter/Views/PlayerRosterSection.swift
+++ b/Encounter/Views/PlayerRosterSection.swift
@@ -2,7 +2,7 @@
 //  PlayerRosterSection.swift
 //  Encounter
 //
-//  Read-only section in EncounterBuilderView showing the active party
+//  Read-only section in EncounterEditorView showing the active party
 //  members that will be snapshotted when the encounter is started.
 //  Players are managed via PartyOverviewView (macOS) or EncounterAndPartyRootView (iOS).
 //


### PR DESCRIPTION
Per [redesign-plan.md M3a](../blob/main/docs/redesign-plan.md).

## Changes

- Rename `EncounterBuilderView` → `EncounterEditorView` (file + struct)
- **iOS**: replace `.fullScreenCover(item: $runSession) { EncounterRunnerContainer }` with `.navigationDestination(item: $runSession) { EncounterRunnerView }` — the runner is now a pushed destination on the existing `NavigationStack`, not a cover with its own inner stack
- **macOS**: unchanged — `.sheet(item: $runSession) { EncounterRunnerContainer }` stays
- Update callers in `ContentView`, `EncounterAndPartyRootView`, `EncounterLibraryView`
- Update stale header comment in `EncounterRunnerView`

## Test plan

- [ ] All 297 unit tests pass (`xcodebuild test -scheme Encounter -destination 'platform=macOS'`)
- [ ] iOS: tapping "Run Encounter" pushes the runner onto the stack with a back button
- [ ] iOS: tapping back (or "End Encounter") pops back to the editor
- [ ] macOS: "Run Encounter" still presents the runner as a sheet

Closes #112