### PR TITLE
feat: show Resume label and behavior when paused session exists (#114)

### DIFF
--- a/Encounter/Views/EncounterEditorView.swift
+++ b/Encounter/Views/EncounterEditorView.swift
@@ -57,6 +57,12 @@ struct EncounterEditorView: View {
     sessionRegistry.sessions[draft.id] != nil
   }
 
+  var pausedSession: EncounterSession? {
+    guard let session = sessionRegistry.sessions[draft.id],
+      session.phase == .paused else { return nil }
+    return session
+  }
+
   // MARK: - Computed difficulty
 
   private var adversaryTypes: [AdversaryType] {
@@ -197,16 +203,24 @@ struct EncounterEditorView: View {
   @ToolbarContentBuilder
   private var toolbarContent: some ToolbarContent {
     ToolbarItem(placement: .primaryAction) {
-      Button("Run Encounter") {
-        // Snapshot the active party into the definition at run time.
-        // EncounterDefinition.playerConfigs is not persisted from the builder;
-        // it is populated here as a point-in-time copy for session creation only.
-        var defWithParty = draft
-        defWithParty.playerConfigs = playerStore.activePartyPlayers.map { $0.asConfig() }
-        runSession = sessionRegistry.session(for: defWithParty, compendium: compendium)
+      if let paused = pausedSession {
+        Button("Resume") {
+          paused.resume()
+          runSession = paused
+        }
+        .accessibilityIdentifier("builder.resume-button")
+      } else {
+        Button("Run") {
+          // Snapshot the active party into the definition at run time.
+          // EncounterDefinition.playerConfigs is not persisted from the builder;
+          // it is populated here as a point-in-time copy for session creation only.
+          var defWithParty = draft
+          defWithParty.playerConfigs = playerStore.activePartyPlayers.map { $0.asConfig() }
+          runSession = sessionRegistry.session(for: defWithParty, compendium: compendium)
+        }
+        .disabled(draft.adversaryIDs.isEmpty || playerStore.party.playerIDs.isEmpty)
+        .accessibilityIdentifier("builder.run-button")
       }
-      .disabled(draft.adversaryIDs.isEmpty || playerStore.party.playerIDs.isEmpty)
-      .accessibilityIdentifier("builder.run-button")
     }
     ToolbarItem(placement: .primaryAction) {
       Button("Browse Compendium", systemImage: "books.vertical") {

--- a/EncounterTests/EncounterEditorViewTests.swift
+++ b/EncounterTests/EncounterEditorViewTests.swift
@@ -1,0 +1,88 @@
+//
+//  EncounterEditorViewTests.swift
+//  EncounterTests
+//
+//  Unit tests for EncounterEditorView.
+//  Tests the pausedSession computed property, which drives the Run vs Resume
+//  toolbar button label and action.
+//
+
+import DHKit
+import DHModels
+import SwiftUI
+import Testing
+import ViewInspector
+
+@testable import Encounter
+
+@MainActor
+@Suite("EncounterEditorView")
+struct EncounterEditorViewTests {
+
+  // MARK: - Helpers
+
+  private static func makeAdversary(id: String = "goblin") -> Adversary {
+    Adversary(
+      id: id, name: "Goblin", tier: 1, role: .minion,
+      flavorText: "", difficulty: 10,
+      thresholdMajor: 5, thresholdSevere: 10, hp: 3, stress: 2,
+      attackModifier: "+2", attackName: "Bite",
+      attackRange: .veryClose, damage: "1d4 phy"
+    )
+  }
+
+  private func makeDefinition() -> EncounterDefinition {
+    var def = EncounterDefinition(name: "Goblin Ambush")
+    def.adversaryIDs = ["goblin"]
+    return def
+  }
+
+  private func makeSUT(
+    definition: EncounterDefinition,
+    sessionRegistry: SessionRegistry? = nil
+  ) -> EncounterEditorView {
+    let compendium = Compendium()
+    compendium.addAdversary(Self.makeAdversary())
+    return EncounterEditorView(
+      definition: definition,
+      store: EncounterStore(directory: .temporaryDirectory),
+      compendium: compendium,
+      contentStore: ContentStore(contentDirectory: .temporaryDirectory, compendium: compendium),
+      sessionRegistry: sessionRegistry ?? SessionRegistry(),
+      sessionStore: SessionStore(directory: .temporaryDirectory),
+      playerStore: PlayerStore(directory: .temporaryDirectory)
+    )
+  }
+
+  // MARK: - Run vs Resume
+
+  // pausedSession drives the toolbar button: nil → Run label; non-nil → Resume label.
+
+  @Test func runButtonShownWhenNoSession() {
+    let def = makeDefinition()
+    let sut = makeSUT(definition: def)
+    #expect(sut.pausedSession == nil, "No paused session: Run button should be shown")
+  }
+
+  @Test func resumeButtonShownWhenPausedSessionExists() {
+    let def = makeDefinition()
+    let registry = SessionRegistry()
+    let session = EncounterSession(name: def.name, phase: .paused, definitionID: def.id)
+    registry.insert(session)
+
+    let sut = makeSUT(definition: def, sessionRegistry: registry)
+    #expect(sut.pausedSession != nil, "Paused session exists: Resume button should be shown")
+  }
+
+  @Test func runButtonShownWhenSessionIsRunning() {
+    let def = makeDefinition()
+    let compendium = Compendium()
+    compendium.addAdversary(Self.makeAdversary())
+    let registry = SessionRegistry()
+    let session = EncounterSession(name: def.name, phase: .running, definitionID: def.id)
+    registry.insert(session)
+
+    let sut = makeSUT(definition: def, sessionRegistry: registry)
+    #expect(sut.pausedSession == nil, "Running session: Run button should be shown, not Resume")
+  }
+}

--- a/EncounterTests/EncounterEditorViewTests.swift
+++ b/EncounterTests/EncounterEditorViewTests.swift
@@ -76,8 +76,6 @@ struct EncounterEditorViewTests {
 
   @Test func runButtonShownWhenSessionIsRunning() {
     let def = makeDefinition()
-    let compendium = Compendium()
-    compendium.addAdversary(Self.makeAdversary())
     let registry = SessionRegistry()
     let session = EncounterSession(name: def.name, phase: .running, definitionID: def.id)
     registry.insert(session)


### PR DESCRIPTION
## Summary

- Adds `pausedSession: EncounterSession?` computed property to `EncounterEditorView` that returns the session only when it exists **and** is in the `.paused` phase
- Replaces the single "Run Encounter" toolbar button with a conditional: **Resume** (calls `session.resume()` then pushes the runner) when a paused session exists, **Run** (existing session-creation logic) when none does
- Adds `EncounterEditorViewTests` with 3 tests covering no-session → Run, paused-session → Resume, and running-session → Run

Closes #114.

## Test plan

- [x] `EncounterEditorViewTests` — 3 new tests, all passing
- [x] Full UnitTests suite — 300 passed, 0 failed