### PR TITLE
fix: extract endSession() and await delete before dismiss in EncounterRunnerView

### DIFF
--- a/Encounter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/Encounter.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -7,7 +7,7 @@
       "location" : "https://github.com/gwillish/DHModels",
       "state" : {
         "branch" : "main",
-        "revision" : "5be6afb5d732bf87aa787775afe966116373c8e1"
+        "revision" : "0b7d284ec1096dda4f3d9a012c053a0039179709"
       }
     },
     {
@@ -33,8 +33,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/apple/swift-log",
       "state" : {
-        "revision" : "bbd81b6725ae874c69e9b8c8804d462356b55523",
-        "version" : "1.10.1"
+        "revision" : "5073617dac96330a486245e4c0179cb0a6fd2256",
+        "version" : "1.12.0"
       }
     },
     {

--- a/Encounter/Views/EncounterRunnerView.swift
+++ b/Encounter/Views/EncounterRunnerView.swift
@@ -70,12 +70,7 @@ struct EncounterRunnerView: View {
       }
       ToolbarItem(placement: .secondaryAction) {
         Button("End Encounter", role: .destructive) {
-          let sessionID = session.id
-          // Clear registry first so the editor never shows a stale Resume prompt;
-          // the file delete completes asynchronously.
-          sessionRegistry.clearSession(for: definition.id)
-          Task { await sessionStore.delete(sessionID: sessionID) }
-          dismiss()
+          endSession()
         }
         .accessibilityIdentifier("runner.end-button")
       }
@@ -92,14 +87,24 @@ struct EncounterRunnerView: View {
       titleVisibility: .visible
     ) {
       Button("Reset Session", role: .destructive) {
-        let sessionID = session.id
-        sessionRegistry.clearSession(for: definition.id)
-        Task { await sessionStore.delete(sessionID: sessionID) }
-        dismiss()
+        endSession()
       }
       .accessibilityIdentifier("runner.reset-confirm-button")
     } message: {
       Text("The current session will be cleared. The encounter definition is not changed.")
+    }
+  }
+
+  // MARK: - Actions
+
+  private func endSession() {
+    let sessionID = session.id
+    // Clear registry first so the editor never shows a stale Resume prompt;
+    // the file delete completes asynchronously.
+    sessionRegistry.clearSession(for: definition.id)
+    Task {
+      await sessionStore.delete(sessionID: sessionID)
+      dismiss()
     }
   }
 }

--- a/EncounterTests/EncounterRunnerViewTests.swift
+++ b/EncounterTests/EncounterRunnerViewTests.swift
@@ -97,30 +97,4 @@ struct EncounterRunnerViewTests {
     #expect(registry.sessions.isEmpty)
   }
 
-  // MARK: - Reset Session action
-
-  @Test func resetSessionClearsSessionFromRegistry() {
-    let (def, session) = makeDefinitionAndSession()
-    let registry = SessionRegistry()
-    registry.insert(session)
-    #expect(registry.sessions[def.id] != nil)
-
-    registry.clearSession(for: def.id)
-
-    #expect(registry.sessions[def.id] == nil)
-  }
-
-  @Test func resetSessionDeletesPersistedSession() async {
-    let dir = Self.tempDir()
-    defer { try? FileManager.default.removeItem(at: dir) }
-    let store = SessionStore(directory: dir)
-    let (_, session) = makeDefinitionAndSession()
-
-    await store.save(session)
-    await store.delete(sessionID: session.id)
-
-    let registry = SessionRegistry()
-    await store.load(into: registry)
-    #expect(registry.sessions.isEmpty)
-  }
 }


### PR DESCRIPTION
## Summary

- **Bug fix**: `End Encounter` and `Reset Session` were fire-and-forgetting the session file delete before calling `dismiss()`. If the system suspended the app in the gap between dismiss and delete completion, the persisted session file could survive and produce a stale Resume prompt on next launch. Both buttons now await the delete before dismissing, matching the pattern `Pause` already used.
- **Extraction**: `endSession()` private helper replaces the identical inline logic that `End Encounter` and the `Reset Session` confirmation dialog were each duplicating.
- **Test cleanup**: Removed the `Reset Session` test section from `EncounterRunnerViewTests` — it was a verbatim copy of the `End Encounter` tests covering the same underlying model operations (`clearSession` + `delete`). The confirmation-dialog UI flow belongs in `EncounterUITests`.

## Test plan

- [ ] All unit tests pass (`xcodebuild test -scheme Encounter -destination 'platform=macOS'`)
- [ ] Tap **Pause** → pop to editor → in-progress badge visible → tap editor row again → **Resume** appears
- [ ] Tap **End Encounter** → popped to root → encounter row shows no in-progress badge; verify no stale session on re-launch
- [ ] Tap **Reset Session** → confirm → same post-condition as End Encounter